### PR TITLE
fix: make footer stick to bottom of viewport

### DIFF
--- a/src/common/components/Footer.js
+++ b/src/common/components/Footer.js
@@ -21,7 +21,7 @@ const Footer = () => {
   ]
 
   return (
-    <footer>
+    <footer style={{ position: 'fixed', bottom: 0, width: '100%' }}>
       <Stack direction={isSmall ? 'column' : 'row'} justifyContent="space-between" spacing={2} sx={{ color: theme.palette.white, background: theme.palette.secondary.main }}>
         <ul style={{ listStyle: 'none' }}>
           {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ ReactDOM.render(
       <Container>
         <Navigation />
       </Container>
-      <Box sx={{ bgcolor: 'white' }}>
+      <Box sx={{ bgcolor: 'white', marginBottom: '100px' }}>
         <Container>
           <Routes />
         </Container>


### PR DESCRIPTION
## Description
Makes the footer stick to the bottom of the viewport.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #65.
