### PR TITLE
fix: add icon beside tool links

### DIFF
--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -5,6 +5,7 @@ import {
   Stack,
   Typography
 } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import { useTranslation } from 'react-i18next'
 import theme from 'theme'
 
@@ -54,6 +55,7 @@ const Tool = ({ tool }) => {
             <p>
               <Link href={tool.url}>
                 {t('tool.go_to', { tool: tool.title })}
+                <LaunchIcon sx={{ paddingLeft: '5px', height: '1.2rem', width: '1.2rem', verticalAlign: 'bottom' }} />
               </Link>
             </p>
           </section>


### PR DESCRIPTION
## Description
Adds icon beside tool links. Uses standard Martial UI LaunchIcon instead of what is in Figma.

![image](https://user-images.githubusercontent.com/86784/146802840-320d0f37-6fbf-4424-aebc-4262b00cb6f4.png)

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #89.