### PR TITLE
fix: Fixed website label for landscapes

### DIFF
--- a/src/landscape/components/LandscapeList.js
+++ b/src/landscape/components/LandscapeList.js
@@ -51,7 +51,7 @@ const LandscapeTable = ({ landscapes }) => {
     minWidth: 200
   }, {
     field: 'website',
-    headerName: t('landscape.list_column_contact'),
+    headerName: t('landscape.list_column_website'),
     sortable: false,
     flex: 1.5,
     minWidth: 200,
@@ -128,7 +128,7 @@ const LandscapeCards = ({ landscapes }) => {
               {landscape.website && (
                 <Grid item xs={12}>
                   <Typography variant="caption">
-                    {t('landscape.list_column_contact')}
+                    {t('landscape.list_column_website')}
                   </Typography>
                   <Link component={Box} href={landscape.website} underline="none">
                     {landscape.website}
@@ -171,10 +171,6 @@ const LandscapeList = () => {
         <CircularProgress color="inherit" />
       </Backdrop>
     )
-  }
-
-  if (!landscapes) {
-    return null
   }
 
   return (

--- a/src/landscape/landscapeSlice.js
+++ b/src/landscape/landscapeSlice.js
@@ -8,8 +8,7 @@ import * as groupUtils from 'group/groupUtils'
 const initialState = {
   list: {
     fetching: true,
-    landscapes: [],
-    message: null
+    landscapes: []
   },
   view: {
     fetching: true,
@@ -67,19 +66,14 @@ const landscapeSlice = createSlice({
     [fetchLandscapes.rejected]: (state, action) => ({
       ...state,
       list: {
-        ...state.list,
         fetching: false,
-        message: {
-          severity: 'error',
-          content: action.payload
-        }
+        landscapes: []
       }
     }),
     [fetchLandscapes.fulfilled]: (state, action) => ({
       ...state,
       list: {
         fetching: false,
-        message: null,
         landscapes: action.payload
       }
     }),

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -91,7 +91,7 @@
         "list_leave_button": "Member",
         "list_column_name": "Landscape Name",
         "list_column_location": "Location",
-        "list_column_contact": "Contact Info",
+        "list_column_website": "Website",
         "list_column_members": "Members",
         "list_column_actions": "Actions",
         "list_empty": "No Landscapes",


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Fixed website label in Landscapes directory
- Removed null check for landscapes, it is not needed

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [x] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes #104 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Screenshot:

![Screen Shot 2021-12-21 at 11 50 49 AM](https://user-images.githubusercontent.com/1316782/146968001-8ec9cd36-f988-441a-990e-5498797d3303.png)
![Screen Shot 2021-12-21 at 11 50 43 AM](https://user-images.githubusercontent.com/1316782/146968006-26e5da97-804c-41cb-aefc-42bf85aa16b3.png)

