### PR TITLE
fix: Remove discovery card if no landscapes

### DIFF
--- a/src/dashboard/components/Dashboard.test.js
+++ b/src/dashboard/components/Dashboard.test.js
@@ -106,8 +106,17 @@ test('Dashboard: Display landscapes discovery', async () => {
     }
   }))
   await setup()
-  expect(screen.getByText(/Discover Landscapes in Terraso/i)).toBeInTheDocument()
-  expect(screen.getByText(/Landscape Discovery 2/i)).toBeInTheDocument()
+  expect(screen.queryByText(/Discover Landscapes in Terraso/i)).toBeInTheDocument()
+  expect(screen.queryByText(/Landscape Discovery 2/i)).toBeInTheDocument()
+})
+test('Dashboard: Display landscapes empty', async () => {
+  terrasoApi.request.mockReturnValue(Promise.resolve({
+    landscapesDiscovery: {
+      edges: []
+    }
+  }))
+  await setup()
+  expect(screen.queryByText(/Discover Landscapes in Terraso/i)).not.toBeInTheDocument()
 })
 test('Dashboard: Display groups', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({

--- a/src/dashboard/components/Dashboard.test.js
+++ b/src/dashboard/components/Dashboard.test.js
@@ -109,7 +109,7 @@ test('Dashboard: Display landscapes discovery', async () => {
   expect(screen.queryByText(/Discover Landscapes in Terraso/i)).toBeInTheDocument()
   expect(screen.queryByText(/Landscape Discovery 2/i)).toBeInTheDocument()
 })
-test('Dashboard: Display landscapes empty', async () => {
+test('Dashboard: Display landscapes discovery empty', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({
     landscapesDiscovery: {
       edges: []

--- a/src/landscape/components/LandscapesDashboardDiscoveryCard.js
+++ b/src/landscape/components/LandscapesDashboardDiscoveryCard.js
@@ -1,11 +1,12 @@
 import React from 'react'
+import _ from 'lodash'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import { Link, List, ListItem, Typography } from '@mui/material'
 
 import DashboardCard from 'dashboard/components/DashboardCard'
-import theme from 'theme'
 import LoaderCard from 'common/components/LoaderCard'
+import theme from 'theme'
 
 const LandscapesDashboardDiscoveryCard = props => {
   const { t } = useTranslation()
@@ -15,6 +16,10 @@ const LandscapesDashboardDiscoveryCard = props => {
     return (
       <LoaderCard />
     )
+  }
+
+  if (_.isEmpty(landscapes)) {
+    return null
   }
 
   return (


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Remove Landascapes discovery card if there are no landascapes

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [ ] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes #119 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Screenshot:

![download (16)](https://user-images.githubusercontent.com/1316782/147978893-2c31c1c9-2605-4579-8d1c-bb81a3f6d121.png)

