### PR TITLE
fix: GroupForm URL field validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
     "serve": "^13.0.2"
   },
   "jest": {
+    "collectCoverageFrom" : [
+      "src/**/*.js",
+      "!src/terrasoBackend/*.js"
+    ],
     "coverageThreshold": {
       "global": {
         "branches": 80,

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -14,13 +14,21 @@ import { fetchGroupForm, saveGroup, setFormNewValues, resetFormSuccess } from 'g
 import Form from 'forms/components/Form'
 import PageLoader from 'common/components/PageLoader'
 
+const transformURL = (url) => {
+  if (url === '' || url.startsWith('http:') || url.startsWith('https:')) {
+    return url
+  }
+
+  return `https://${url}`
+}
+
 const VALIDATION_SCHEMA = yup.object({
   name: yup.string().required(),
   description: yup.string()
     .maxCustom(600)
     .required(),
   email: yup.string().email(),
-  website: yup.string().url()
+  website: yup.string().ensure().transform(transformURL).url()
 }).required()
 
 const FIELDS = [{

--- a/src/group/components/GroupForm.test.js
+++ b/src/group/components/GroupForm.test.js
@@ -172,6 +172,43 @@ test('GroupForm: Input validation', async () => {
   expect(screen.getByText(/email must be a valid email/i)).toBeInTheDocument()
   expect(screen.getByText(/website must be a valid URL/i)).toBeInTheDocument()
 })
+
+test('GroupForm: website accepts address without protocol', async () => {
+  terrasoApi.request
+    .mockResolvedValueOnce({
+      groups: {
+        edges: [{
+          node: {
+            id: '1',
+            name: 'Group name',
+            description: 'Group description',
+            email: 'group@group.org',
+            website: 'https://www.group.org'
+          }
+        }]
+      }
+    })
+    .mockResolvedValueOnce({
+      updateGroup: {
+        group: {
+          id: '1',
+          name: 'Group name',
+          description: 'Group description',
+          email: 'group@group.org',
+          website: 'https://www.group.org'
+        }
+      }
+    })
+  const { inputs } = await setup()
+
+  fireEvent.change(inputs.website, { target: { value: 'example.org' } })
+
+  await act(async () => fireEvent.click(screen.getByText(/Submit Group Info/i)))
+  const saveCall = terrasoApi.request.mock.calls[1]
+
+  expect(saveCall[1].input.website).toEqual('https://example.org')
+})
+
 test('GroupForm: Save form', async () => {
   terrasoApi.request
     .mockResolvedValueOnce({


### PR DESCRIPTION
This change updates the URL field validation on `GroupForm` to allow users
inform URLs without the protocol (HTTPS). To make it work, it was added
a transform function to add the protocol value if needed before calling
the field validation and sending the data to the API.

This fix:
- #115 
