### PR TITLE
fix: use 127.0.0.1 instead of localhost for default URL

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-export const TERRASO_API_URL = process.env.REACT_APP_TERRASO_API_URL || 'http://localhost:8000'
+export const TERRASO_API_URL = process.env.REACT_APP_TERRASO_API_URL || 'http://127.0.0.1:8000'
 
 export const GRAPH_QL_ENDPOINT = 'graphql/'
 


### PR DESCRIPTION
## Description
Use `127.0.0.1` instead of `localhost` for default URL. Allows Google authentication in local development environment.