### PR TITLE
fix: set pagination size to 15

### DIFF
--- a/src/common/components/Table.js
+++ b/src/common/components/Table.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { DataGrid } from '@mui/x-data-grid'
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 15
 
 const Table = props => {
   const [sortModel, setSortModel] = useState(props.initialSort)

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -85,7 +85,7 @@ test('GroupList: Display list', async () => {
   // Group info
   expect(screen.getByRole('heading', { name: 'Groups' })).toBeInTheDocument()
   const rows = screen.getAllByRole('row')
-  expect(rows.length).toBe(11) // 10 displayed + header
+  expect(rows.length).toBe(16) // 15 displayed + header
   expect(within(rows[2]).getByRole('cell', { name: 'Group name 1' })).toHaveAttribute('data-field', 'name')
   expect(within(rows[2]).getByRole('cell', { name: 'https://www.group.org' })).toHaveAttribute('data-field', 'website')
   expect(within(rows[2]).getByRole('cell', { name: 'email@email.com' })).toHaveAttribute('data-field', 'email')
@@ -148,7 +148,7 @@ test('GroupList: List sort', async () => {
   // Group info
   expect(screen.getByRole('heading', { name: 'Groups' })).toBeInTheDocument()
   const rows = screen.getAllByRole('row')
-  expect(rows.length).toBe(11) // 10 displayed + header
+  expect(rows.length).toBe(16) // 11 displayed + header
 
   // Sorting
   expect(within(rows[1]).getByRole('cell', { name: 'Group name 0' })).toHaveAttribute('data-field', 'name')

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -94,7 +94,7 @@ test('LandscapeList: Display list', async () => {
   // Landscape info
   expect(screen.getByRole('heading', { name: 'Landscapes' })).toBeInTheDocument()
   const rows = screen.getAllByRole('row')
-  expect(rows.length).toBe(11) // 10 displayed + header
+  expect(rows.length).toBe(16) // 15 displayed + header
   expect(within(rows[2]).getByRole('cell', { name: 'Landscape Name 1' })).toHaveAttribute('data-field', 'name')
   expect(within(rows[2]).getByRole('cell', { name: '23' })).toHaveAttribute('data-field', 'members')
   expect(within(rows[2]).getByRole('cell', { name: 'Connect' })).toHaveAttribute('data-field', 'actions')
@@ -164,7 +164,7 @@ test('LandscapeList: List sort', async () => {
   // Landscape info
   expect(screen.getByRole('heading', { name: 'Landscapes' })).toBeInTheDocument()
   const rows = screen.getAllByRole('row')
-  expect(rows.length).toBe(11) // 10 displayed + header
+  expect(rows.length).toBe(16) // 15 displayed + header
 
   // Sorting
   expect(within(rows[1]).getByRole('cell', { name: 'Landscape Name 0' })).toHaveAttribute('data-field', 'name')


### PR DESCRIPTION
## Description
Show 15 items per page instead of 10.

### Related Issues
Fixes #135.
