### PR TITLE
fix: tools page: remove placeholder text and buttons

### DIFF
--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -8,9 +8,11 @@ import {
 import LaunchIcon from '@mui/icons-material/Launch'
 import { useTranslation } from 'react-i18next'
 import theme from 'theme'
+import useMediaQuery from '@mui/material/useMediaQuery'
 
 const Tool = ({ tool }) => {
   const { t } = useTranslation()
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
     <React.Fragment>
@@ -18,7 +20,7 @@ const Tool = ({ tool }) => {
         <Typography variant="h1" >
           {tool.title}
         </Typography>
-        <Stack direction="row" justifyContent="space-between" spacing={2}>
+        <Stack direction={isSmall ? 'column' : 'row'} justifyContent="space-between" spacing={2}>
 
           <section>
             <Typography variant="h2" >

--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import useMediaQuery from '@mui/material/useMediaQuery'
 import {
-  Button,
   Card,
   Link,
   Stack,
@@ -13,7 +11,6 @@ import theme from 'theme'
 
 const Tool = ({ tool }) => {
   const { t } = useTranslation()
-  const isSmall = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
     <React.Fragment>
@@ -21,19 +18,6 @@ const Tool = ({ tool }) => {
         <Typography variant="h1" >
           {tool.title}
         </Typography>
-        <Stack direction={isSmall ? 'column' : 'row'} spacing={2}
-          sx= {{
-            marginTop: theme.spacing(3),
-            marginBottom: theme.spacing(4)
-          }}
-        >
-          <Button variant="contained">
-            {t('tool.actions_bookmark')}
-          </Button>
-          <Button variant="outlined">
-            {t('tool.actions_recommend')}
-          </Button>
-        </Stack>
         <Stack direction="row" justifyContent="space-between" spacing={2}>
 
           <section>

--- a/src/tool/components/ToolList.js
+++ b/src/tool/components/ToolList.js
@@ -13,7 +13,7 @@ const ToolList = ({ tools }) => {
 
   const toolsData = [
     {
-      title: 'KoBo toolbox',
+      title: 'KoBoToolbox',
       url: 'https://www.kobotoolbox.org/',
       img: {
         height: 222,

--- a/src/tool/components/ToolList.js
+++ b/src/tool/components/ToolList.js
@@ -1,13 +1,9 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
   Box,
   Typography
 } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 
 import theme from 'theme'
 import Tool from 'tool/components/Tool'
@@ -57,47 +53,6 @@ const ToolList = ({ tools }) => {
         {toolsData.map(tool => (
           <Tool key="{tool}" tool={tool} />
         ))}
-      </Box>
-
-      <Box sx={{
-        paddingTop: theme.spacing(3),
-        paddingBottom: theme.spacing(2)
-      }}>
-        <Typography variant="h1" >
-          {t('tool.faq_title')}
-        </Typography>
-
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1a-content"
-            id="panel1a-header"
-          >
-            <Typography>What does adding the tool to the landscape’s toolset mean?</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-              malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </AccordionDetails>
-        </Accordion>
-        <Accordion>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2a-content"
-            id="panel2a-header"
-          >
-            <Typography>Who can add the tool to the Landscape or the group?</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-              malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </AccordionDetails>
-        </Accordion>
-
       </Box>
     </React.Fragment>
   )


### PR DESCRIPTION
## Description
Remove placeholder text and buttons.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #139, Fixes #141.