### PR TITLE
chore: rename Dashboard references to Home

### DIFF
--- a/locales/po/en-US.po
+++ b/locales/po/en-US.po
@@ -8,17 +8,17 @@ msgstr ""
 "POT-Creation-Date: 2021-12-03T01:12:54.292Z\n"
 "PO-Revision-Date: 2021-12-03T01:12:54.292Z\n"
 
-msgid "dashboard##title"
-msgstr "Dashboard"
+msgid "home##title"
+msgstr "Home"
 
-msgid "dashboard##error"
+msgid "home##error"
 msgstr "Error loading data. {{error}}"
 
 msgid "user##login"
 msgstr "Log in"
 
 msgctxt "title"
-msgid "dashboard##page"
+msgid "home##page"
 msgstr "Your Stuff"
 
 msgctxt "title"

--- a/src/group/components/GroupDefaultHomeCard.js
+++ b/src/group/components/GroupDefaultHomeCard.js
@@ -9,7 +9,7 @@ import {
 } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import { Link } from 'react-router-dom'
 import theme from 'theme'
 
@@ -20,23 +20,23 @@ const Actions = () => {
     <CardActions>
       <Button
         component={Link}
-        to="/landscapes"
+        to="/groups"
         sx={{ width: '100%' }}
       >
-        {t('landscape.default_connect_button').toUpperCase()}
+        {t('group.default_connect_button').toUpperCase()}
       </Button>
     </CardActions>
   )
 }
 
-const LandscapeDefaultDashboardCard = () => {
+const GroupDefaultHomeCard = () => {
   const { t } = useTranslation()
 
   return (
-    <DashboardCard sx={{ flexDirection: 'column' }}>
+    <HomeCard sx={{ flexDirection: 'column' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', padding: theme.spacing(2) }}>
         <Typography variant="h5">
-          {t('landscape.dashboard_default_title')}
+          {t('group.home_default_title')}
         </Typography>
         <Alert
           severity="info"
@@ -46,14 +46,14 @@ const LandscapeDefaultDashboardCard = () => {
           }}
         >
           <Typography variant="body1">
-            {t('landscape.default_content')}
+            {t('group.default_content')}
           </Typography>
         </Alert>
       </Box>
       <Divider />
       <Actions />
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default LandscapeDefaultDashboardCard
+export default GroupDefaultHomeCard

--- a/src/group/components/GroupsHomeCard.js
+++ b/src/group/components/GroupsHomeCard.js
@@ -13,7 +13,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import theme from 'theme'
 
 const GroupItem = ({ group }) => {
@@ -34,12 +34,12 @@ const GroupItem = ({ group }) => {
   )
 }
 
-const GroupsDashboardCard = ({ groups }) => {
+const GroupsHomeCard = ({ groups }) => {
   const { t } = useTranslation()
   return (
-    <DashboardCard sx={{ flexDirection: 'column' }}>
+    <HomeCard sx={{ flexDirection: 'column' }}>
       <Typography variant="h5" sx={{ padding: theme.spacing(2) }}>
-        {t('group.dashboard_title')}
+        {t('group.home_title')}
       </Typography>
       <List>
         {groups
@@ -63,11 +63,11 @@ const GroupsDashboardCard = ({ groups }) => {
           to="/groups"
           sx={{ width: '100%' }}
         >
-          {t('group.dashboard_connect_label').toUpperCase()}
+          {t('group.home_connect_label').toUpperCase()}
         </Button>
       </CardActions>
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default GroupsDashboardCard
+export default GroupsHomeCard

--- a/src/home/components/Home.js
+++ b/src/home/components/Home.js
@@ -11,13 +11,13 @@ import {
 } from '@mui/material'
 
 import LoaderCard from 'common/components/LoaderCard'
-import { fetchDashboardData } from 'dashboard/dashboardSlice'
-import LandscapesCard from 'landscape/components/LandscapesDashboardCard'
-import LandscapeDefaultCard from 'landscape/components/LandscapeDefaultDashboardCard'
-import GroupsCard from 'group/components/GroupsDashboardCard'
-import GroupDefaultCard from 'group/components/GroupDefaultDashboardCard'
-import ToolDashboardCard from 'tool/components/ToolDasboardCard'
-import LandscapesDashboardDiscoveryCard from 'landscape/components/LandscapesDashboardDiscoveryCard'
+import { fetchHomeData } from 'home/homeSlice'
+import LandscapesCard from 'landscape/components/LandscapesHomeCard'
+import LandscapeDefaultCard from 'landscape/components/LandscapeDefaultHomeCard'
+import GroupsCard from 'group/components/GroupsHomeCard'
+import GroupDefaultCard from 'group/components/GroupDefaultHomeCard'
+import ToolHomeCard from 'tool/components/ToolHomeCard'
+import LandscapesHomeDiscoveryCard from 'landscape/components/LandscapesHomeDiscoveryCard'
 import theme from 'theme'
 
 const Landscapes = ({ landscapes, fetching }) => {
@@ -56,22 +56,22 @@ const Groups = ({ groups, fetching }) => {
   )
 }
 
-const Dashboard = () => {
+const Home = () => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
 
   const { data: user } = useSelector(state => state.account.currentUser)
-  const dashboard = useSelector(state => state.userDashboard)
-  const { groups, landscapes, landscapesDiscovery, error, fetching } = dashboard
+  const home = useSelector(state => state.userHome)
+  const { groups, landscapes, landscapesDiscovery, error, fetching } = home
 
   useEffect(() => {
-    dispatch(fetchDashboardData(user.email))
+    dispatch(fetchHomeData(user.email))
   }, [dispatch, user])
 
   if (error) {
     return (
       <Alert severity="error">
-        {t('dashboard.error', { error: t(error) })}
+        {t('home.error', { error: t(error) })}
       </Alert>
     )
   }
@@ -89,19 +89,19 @@ const Dashboard = () => {
           marginTop: theme.spacing(2)
         }}
       >
-        {t('dashboard.page_title', { name: user.firstName })}
+        {t('home.page_title', { name: user.firstName })}
       </Typography>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Stack spacing={1}>
             <Landscapes landscapes={landscapes} fetching={fetching} />
-            <ToolDashboardCard />
+            <ToolHomeCard />
           </Stack>
         </Grid>
         <Grid item xs={12} md={6}>
           <Stack spacing={1}>
             <Groups groups={groups} fetching={fetching} />
-            <LandscapesDashboardDiscoveryCard
+            <LandscapesHomeDiscoveryCard
               fetching={fetching}
               landscapes={landscapesDiscovery}
             />
@@ -112,4 +112,4 @@ const Dashboard = () => {
   )
 }
 
-export default Dashboard
+export default Home

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -2,19 +2,19 @@ import React from 'react'
 import { act } from 'react-dom/test-utils'
 
 import { render, screen } from 'tests/utils'
-import Dashboard from 'dashboard/components/Dashboard'
-import { fetchDashboardData } from 'dashboard/dashboardService'
+import Home from 'home/components/Home'
+import { fetchHomeData } from 'home/homeService'
 import * as terrasoApi from 'terrasoBackend/api'
 
 jest.mock('terrasoBackend/api')
 
-jest.mock('dashboard/dashboardService', () => ({
-  ...jest.requireActual('dashboard/dashboardService'),
-  fetchDashboardData: jest.fn()
+jest.mock('home/homeService', () => ({
+  ...jest.requireActual('home/homeService'),
+  fetchHomeData: jest.fn()
 }))
 
 const setup = async () => {
-  await act(async () => render(<Dashboard />, {
+  await act(async () => render(<Home />, {
     account: {
       hasToken: true,
       currentUser: {
@@ -29,15 +29,15 @@ const setup = async () => {
 }
 
 beforeEach(() => {
-  fetchDashboardData.mockImplementation(jest.requireActual('dashboard/dashboardService').fetchDashboardData)
+  fetchHomeData.mockImplementation(jest.requireActual('home/homeService').fetchHomeData)
 })
 
-test('Dashboard: Display error', async () => {
+test('Home: Display error', async () => {
   terrasoApi.request.mockRejectedValue('Load error')
   await setup()
   expect(screen.getByText(/Error loading data. Load error/i)).toBeInTheDocument()
 })
-test('Dashboard: Display loader', async () => {
+test('Home: Display loader', async () => {
   terrasoApi.request.mockReturnValue(new Promise(() => {}))
   await setup()
   const loaders = screen.getAllByRole('loader', { name: '', hidden: true })
@@ -46,7 +46,7 @@ test('Dashboard: Display loader', async () => {
     expect(role).toBeInTheDocument()
   )
 })
-test('Dashboard: Display landscapes', async () => {
+test('Home: Display landscapes', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({
     groups: {
       edges: []
@@ -85,7 +85,7 @@ test('Dashboard: Display landscapes', async () => {
   expect(screen.getByText(/Landscape 2/i)).toBeInTheDocument()
   expect(screen.getByText(/Manager/i)).toBeInTheDocument()
 })
-test('Dashboard: Display landscapes discovery', async () => {
+test('Home: Display landscapes discovery', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({
     landscapesDiscovery: {
       edges: [{
@@ -109,7 +109,7 @@ test('Dashboard: Display landscapes discovery', async () => {
   expect(screen.queryByText(/Discover Landscapes in Terraso/i)).toBeInTheDocument()
   expect(screen.queryByText(/Landscape Discovery 2/i)).toBeInTheDocument()
 })
-test('Dashboard: Display landscapes discovery empty', async () => {
+test('Home: Display landscapes discovery empty', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({
     landscapesDiscovery: {
       edges: []
@@ -118,7 +118,7 @@ test('Dashboard: Display landscapes discovery empty', async () => {
   await setup()
   expect(screen.queryByText(/Discover Landscapes in Terraso/i)).not.toBeInTheDocument()
 })
-test('Dashboard: Display groups', async () => {
+test('Home: Display groups', async () => {
   terrasoApi.request.mockReturnValue(Promise.resolve({
     userIndependentGroups: {
       edges: [{
@@ -147,8 +147,8 @@ test('Dashboard: Display groups', async () => {
   expect(screen.getByText('Group 2')).toBeInTheDocument()
   expect(screen.getByText('Manager')).toBeInTheDocument()
 })
-test('Dashboard: Display defaults', async () => {
-  fetchDashboardData.mockReturnValue(Promise.resolve({
+test('Home: Display defaults', async () => {
+  fetchHomeData.mockReturnValue(Promise.resolve({
     groups: [],
     landscapes: [],
     landscapesDiscovery: []

--- a/src/home/components/HomeCard.js
+++ b/src/home/components/HomeCard.js
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash'
 import { Card } from '@mui/material'
 
-const DashboardCard = props => (
+const HomeCard = props => (
   <Card
     {...props}
     sx={{
@@ -14,4 +14,4 @@ const DashboardCard = props => (
   </Card>
 )
 
-export default DashboardCard
+export default HomeCard

--- a/src/home/homeService.js
+++ b/src/home/homeService.js
@@ -4,9 +4,9 @@ import * as terrasoApi from 'terrasoBackend/api'
 import { groupFields } from 'group/groupFragments'
 import { landscapeFields } from 'landscape/landscapeFragments'
 
-export const fetchDashboardData = email => {
+export const fetchHomeData = email => {
   const query = `
-    query dashboard($email: String!) {
+    query home($email: String!) {
       landscapeGroups: groups(
         members_Email: $email,
         associatedLandscapes_IsDefaultLandscapeGroup: true

--- a/src/home/homeSlice.js
+++ b/src/home/homeSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 
 import { createAsyncThunk } from 'state/utils'
-import * as dashboardService from 'dashboard/dashboardService'
+import * as homeService from 'home/homeService'
 
 const initialState = {
   groups: [],
@@ -10,15 +10,15 @@ const initialState = {
   error: null
 }
 
-export const fetchDashboardData = createAsyncThunk('dashboard/fetchData', dashboardService.fetchDashboardData)
+export const fetchHomeData = createAsyncThunk('home/fetchData', homeService.fetchHomeData)
 
-export const dashboardSlice = createSlice({
-  name: 'dashboard',
+export const homeSlice = createSlice({
+  name: 'home',
   initialState,
   reducers: {},
   extraReducers: {
-    [fetchDashboardData.pending]: () => initialState,
-    [fetchDashboardData.fulfilled]: (state, action) => ({
+    [fetchHomeData.pending]: () => initialState,
+    [fetchHomeData.fulfilled]: (state, action) => ({
       ...state,
       fetching: false,
       error: null,
@@ -26,7 +26,7 @@ export const dashboardSlice = createSlice({
       landscapes: action.payload.landscapes,
       landscapesDiscovery: action.payload.landscapesDiscovery
     }),
-    [fetchDashboardData.rejected]: (state, action) => ({
+    [fetchHomeData.rejected]: (state, action) => ({
       ...state,
       fetching: false,
       error: action.payload
@@ -34,4 +34,4 @@ export const dashboardSlice = createSlice({
   }
 })
 
-export default dashboardSlice.reducer
+export default homeSlice.reducer

--- a/src/landscape/components/LandscapeDefaultHomeCard.js
+++ b/src/landscape/components/LandscapeDefaultHomeCard.js
@@ -9,7 +9,7 @@ import {
 } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import { Link } from 'react-router-dom'
 import theme from 'theme'
 
@@ -20,23 +20,23 @@ const Actions = () => {
     <CardActions>
       <Button
         component={Link}
-        to="/groups"
+        to="/landscapes"
         sx={{ width: '100%' }}
       >
-        {t('group.default_connect_button').toUpperCase()}
+        {t('landscape.default_connect_button').toUpperCase()}
       </Button>
     </CardActions>
   )
 }
 
-const GroupDefaultDashboardCard = () => {
+const LandscapeDefaultHomeCard = () => {
   const { t } = useTranslation()
 
   return (
-    <DashboardCard sx={{ flexDirection: 'column' }}>
+    <HomeCard sx={{ flexDirection: 'column' }}>
       <Box sx={{ display: 'flex', flexDirection: 'column', padding: theme.spacing(2) }}>
         <Typography variant="h5">
-          {t('group.dashboard_default_title')}
+          {t('landscape.home_default_title')}
         </Typography>
         <Alert
           severity="info"
@@ -46,14 +46,14 @@ const GroupDefaultDashboardCard = () => {
           }}
         >
           <Typography variant="body1">
-            {t('group.default_content')}
+            {t('landscape.default_content')}
           </Typography>
         </Alert>
       </Box>
       <Divider />
       <Actions />
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default GroupDefaultDashboardCard
+export default LandscapeDefaultHomeCard

--- a/src/landscape/components/LandscapesHomeCard.js
+++ b/src/landscape/components/LandscapesHomeCard.js
@@ -14,7 +14,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import theme from 'theme'
 
 const getAcronym = name => name
@@ -44,12 +44,12 @@ const LandscapeItem = ({ landscape }) => {
   )
 }
 
-const LandscapesDashboardCard = ({ landscapes }) => {
+const LandscapesHomeCard = ({ landscapes }) => {
   const { t } = useTranslation()
   return (
-    <DashboardCard sx={{ flexDirection: 'column' }}>
+    <HomeCard sx={{ flexDirection: 'column' }}>
       <Typography variant="h5" sx={{ padding: theme.spacing(2) }}>
-        {t('landscape.dashboard_title')}
+        {t('landscape.home_title')}
       </Typography>
       <List>
         {landscapes
@@ -73,11 +73,11 @@ const LandscapesDashboardCard = ({ landscapes }) => {
           to="/landscapes"
           sx={{ width: '100%' }}
         >
-          {t('landscape.dashboard_connect_label').toUpperCase()}
+          {t('landscape.home_connect_label').toUpperCase()}
         </Button>
       </CardActions>
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default LandscapesDashboardCard
+export default LandscapesHomeCard

--- a/src/landscape/components/LandscapesHomeDiscoveryCard.js
+++ b/src/landscape/components/LandscapesHomeDiscoveryCard.js
@@ -4,11 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import { Link, List, ListItem, Typography } from '@mui/material'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import LoaderCard from 'common/components/LoaderCard'
 import theme from 'theme'
 
-const LandscapesDashboardDiscoveryCard = props => {
+const LandscapesHomeDiscoveryCard = props => {
   const { t } = useTranslation()
   const { landscapes, fetching } = props
 
@@ -23,14 +23,14 @@ const LandscapesDashboardDiscoveryCard = props => {
   }
 
   return (
-    <DashboardCard
+    <HomeCard
       sx={{
         flexDirection: 'column',
         padding: theme.spacing(2)
       }}
     >
       <Typography variant="h5">
-        {t('landscape.dashboard_discovery_title')}
+        {t('landscape.home_discovery_title')}
       </Typography>
       <List>
         {landscapes.slice(0, 5).map(landscape => (
@@ -48,8 +48,8 @@ const LandscapesDashboardDiscoveryCard = props => {
           </ListItem>
         ))}
       </List>
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default LandscapesDashboardDiscoveryCard
+export default LandscapesHomeDiscoveryCard

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -1,6 +1,6 @@
 {
-    "dashboard": {
-        "title": "Dashboard",
+    "home": {
+        "title": "Home",
         "error": "Error loading data. {{error}}",
         "page_title": "{{name}}’s Home in Terraso"
     },
@@ -13,9 +13,9 @@
     "group": {
         "role_member": "Member",
         "role_manager": "Manager",
-        "dashboard_title": "Groups",
-        "dashboard_default_title": "Group",
-        "dashboard_connect_label": "Join another group",
+        "home_title": "Groups",
+        "home_default_title": "Group",
+        "home_connect_label": "Join another group",
         "default_content": "Terraso groups connect people with common interests and needs. Explore the groups and join your organizations. Groups exist for people within and across landscapes.",
         "edit_profile_button": "Edit Group Profile",
         "default_connect_button": "Connect",
@@ -60,9 +60,9 @@
         "list_new_button": "Create Group"
     },
     "landscape": {
-        "dashboard_title": "Landscapes",
-        "dashboard_default_title": "Landscape",
-        "dashboard_connect_label": "Connect to another Landscape",
+        "home_title": "Landscapes",
+        "home_default_title": "Landscape",
+        "home_connect_label": "Connect to another Landscape",
         "default_content": "Explore the landscapes in Terraso and become a member of your landscape. This will help you connect with others on Terraso and lets you share information with other landscape members.",
         "edit_profile_button": "Edit Landscape Profile",
         "default_connect_button": "Explore and Connect to Landscape",
@@ -96,7 +96,7 @@
         "list_column_members": "Members",
         "list_column_actions": "Actions",
         "list_empty": "No Landscapes",
-        "dashboard_discovery_title": "Discover Landscapes in Terraso"
+        "home_discovery_title": "Discover Landscapes in Terraso"
     },
     "tool": {
       "faq_title": "Tools FAQ",
@@ -107,11 +107,11 @@
       "requirements": "System requirements",
       "actions_bookmark": "Bookmark",
       "actions_recommend": "Recommend this to my team",
-      "dashboard_card_title": "Access Data Collection Tool in Terraso",
-      "dashboard_card_description": "Take advantage of integrated tools in Terraso. KoBoToolbox is a free open-source data collection tool.",
-      "dashboard_card_img_alt": "KoBoToolbox image",
-      "dashboard_card_kobo_title": "KoBoToolbox",
-      "dashboard_card_kobo_link": "Learn more about KoBoToolbox features"
+      "home_card_title": "Access Data Collection Tool in Terraso",
+      "home_card_description": "Take advantage of integrated tools in Terraso. KoBoToolbox is a free open-source data collection tool.",
+      "home_card_img_alt": "KoBoToolbox image",
+      "home_card_kobo_title": "KoBoToolbox",
+      "home_card_kobo_link": "Learn more about KoBoToolbox features"
     },
     "localization": {
         "locale_en-US": "English",

--- a/src/navigation/Routes.js
+++ b/src/navigation/Routes.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 
-import Dashboard from 'dashboard/components/Dashboard'
+import Home from 'home/components/Home'
 import GroupList from 'group/components/GroupList'
 import GroupForm from 'group/components/GroupForm'
 import GroupView from 'group/components/GroupView'
@@ -18,7 +18,7 @@ const path = (path, Component, auth = true) => ({
 })
 
 const paths = [
-  path('/', Dashboard),
+  path('/', Home),
   path('/groups', GroupList),
   path('/groups/new', GroupForm),
   path('/groups/:slug/edit', GroupForm),

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 
 import accountReducer from 'account/accountSlice'
-import userDashboardReducer from 'dashboard/dashboardSlice'
+import userHomeReducer from 'home/homeSlice'
 import groupReducer from 'group/groupSlice'
 import landscapeReducer from 'landscape/landscapeSlice'
 import notificationsReducer from 'notifications/notificationsSlice'
@@ -9,7 +9,7 @@ import notificationsReducer from 'notifications/notificationsSlice'
 const createStore = intialState => configureStore({
   reducer: {
     account: accountReducer,
-    userDashboard: userDashboardReducer,
+    userHome: userHomeReducer,
     group: groupReducer,
     landscape: landscapeReducer,
     notifications: notificationsReducer

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -3,20 +3,20 @@ import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 import { Link, Stack, Typography } from '@mui/material'
 
-import DashboardCard from 'dashboard/components/DashboardCard'
+import HomeCard from 'home/components/HomeCard'
 import theme from 'theme'
 
-const ToolDashboardCard = () => {
+const ToolHomeCard = () => {
   const { t } = useTranslation()
   return (
-    <DashboardCard
+    <HomeCard
       sx={{
         flexDirection: 'column',
         padding: theme.spacing(2)
       }}
     >
       <Typography variant="h5">
-        {t('tool.dashboard_card_title')}
+        {t('tool.home_card_title')}
       </Typography>
       <Typography
         variant="body1"
@@ -25,28 +25,28 @@ const ToolDashboardCard = () => {
           marginBottom: theme.spacing(2)
         }}
       >
-        {t('tool.dashboard_card_description')}
+        {t('tool.home_card_description')}
       </Typography>
       <Stack direction="row" spacing={3}>
         <img
           src="/tools/kobo-small.png"
-          alt={t('tool.dashboard_card_img_alt')}
+          alt={t('tool.home_card_img_alt')}
           height={64}
         />
         <Stack spacing={1}>
           <Typography>
-            {t('tool.dashboard_card_kobo_title')}
+            {t('tool.home_card_kobo_title')}
           </Typography>
           <Link
             component={RouterLink}
             to="/tools"
           >
-            {t('tool.dashboard_card_kobo_link')}
+            {t('tool.home_card_kobo_link')}
           </Link>
         </Stack>
       </Stack>
-    </DashboardCard>
+    </HomeCard>
   )
 }
 
-export default ToolDashboardCard
+export default ToolHomeCard


### PR DESCRIPTION
This change is necessary to reflect the business decision to refer to
the home page as Home instead of Dashboard since the structure of the
home isn't a Dashboard.

It fixes:
- #31 
