### PR TITLE
fix: only show active links in footer.

### DIFF
--- a/src/common/components/Footer.js
+++ b/src/common/components/Footer.js
@@ -95,7 +95,7 @@ const Footer = () => {
         component={LinksContainer}
       >
         {footerLinks.map((link, index) => (
-          <FooterLink key={index} index={index} link={link} />
+          link.url !== '#' && <FooterLink key={index} index={index} link={link} />
         ))}
       </Grid>
       <Grid item xs={12} md="auto"

--- a/src/common/components/Footer.js
+++ b/src/common/components/Footer.js
@@ -24,7 +24,7 @@ const footerLinks = [
 const FooterLink = ({ index, link }) => {
   const { t } = useTranslation()
   const isBig = useMediaQuery(theme.breakpoints.up('sm'))
-  const showBorder = isBig && index < footerLinks.length - 1
+  const showBorder = isBig && index < footerLinks.length - 2
 
   const borderStyle = {
     borderRight: `1px solid ${palette.white}`,


### PR DESCRIPTION
## Description
In footer, omit links that go to `#`.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #131.