### PR TITLE
fix: add hover to navbar

### DIFF
--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -36,6 +36,9 @@ const LinkTab = props => (
       '&.Mui-selected': {
         color: 'black',
         fontWeight: theme.typography.fontWeightMedium
+      },
+      '&:hover': {
+        background: theme.palette.gray.mid
       }
     }}
     {...props}


### PR DESCRIPTION
## Description
Add a hover color to top navbar.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #134.