### PR TITLE
fix: show email address as plain text, not form field

### DIFF
--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -25,7 +25,7 @@ const FIELDS = [{
 {
   name: 'email',
   label: 'account.form_email_label',
-  props: { disabled: true }
+  props: { guideText: true }
 }]
 
 const AccountProfile = ({ tool }) => {

--- a/src/forms/components/FormField.js
+++ b/src/forms/components/FormField.js
@@ -11,7 +11,7 @@ import {
 
 import theme from 'theme'
 
-const FormField = ({ control, required, disabled, id, name, label, info, inputProps }) => {
+const FormField = ({ control, required, disabled, id, name, label, info, inputProps, guideText }) => {
   const { t } = useTranslation()
   return (
     <Controller
@@ -22,7 +22,7 @@ const FormField = ({ control, required, disabled, id, name, label, info, inputPr
           <InputLabel disabled={disabled} error={!!fieldState.error} htmlFor={id}>
             {t(label)} {required && `(${t('form.required_label')})` }
           </InputLabel>
-          <OutlinedInput
+          {guideText ? field.value : <OutlinedInput
             id={id}
             disabled={disabled}
             error={!!fieldState.error}
@@ -31,6 +31,7 @@ const FormField = ({ control, required, disabled, id, name, label, info, inputPr
             {...inputProps}
             {...field}
           />
+          }
           {info && (
             <FormHelperText id={`${id}-helper-text`}>{t(info)}</FormHelperText>
           )}


### PR DESCRIPTION
## Description
Show the email address as plain text, not a disabled form field. Fields should not be disabled unless there is some way of enabling them. 

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #127.

### Verification steps
Go to http://127.0.0.1:3000/account/profile