### PR TITLE
feat: only show language picker if multiple languages are present

### DIFF
--- a/src/localization/components/LocalePicker.js
+++ b/src/localization/components/LocalePicker.js
@@ -36,6 +36,11 @@ const LocalePicker = () => {
       ? `localization.locale_${locale}_small`
       : `localization.locale_${locale}`;
 
+  // Only show language picker if at least two languages are available.
+  if (Object.keys(LOCALES).length <= 1) {
+    return null;
+  }
+
   return (
     <Select
       size="small"


### PR DESCRIPTION
## Description
Only show language picker if at least two languages are present.

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #130.