### PR TITLE
fix: Tools page not using list content

### DIFF
--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -22,24 +22,10 @@ const Tool = ({ tool }) => {
         >
           <section>
             <Typography variant="h2">{t('tool.is_for')}</Typography>
-
-            <ul>
-              {t(`tools.${tool}.description`, { returnObjects: true }).map(
-                (description, index) => (
-                  <li key={index}>{description}</li>
-                )
-              )}
-            </ul>
+            <Typography>{t(`tools.${tool}.description`)}</Typography>
 
             <Typography variant="h2">{t('tool.requirements')}</Typography>
-
-            <ul>
-              {t(`tools.${tool}.requirements`, { returnObjects: true }).map(
-                (req, index) => (
-                  <li key={index}>{req}</li>
-                )
-              )}
-            </ul>
+            <Typography>{t(`tools.${tool}.requirements`)}</Typography>
 
             <Typography variant="h2">{t('tool.avilability')}</Typography>
             <p>{t(`tools.${tool}.availability`)}</p>


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Tools page content changed, now it is not using list content

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes #187 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Screenshot:

![download (39)](https://user-images.githubusercontent.com/1316782/151825430-e7f3238c-0613-4c36-8fbc-7423679645dd.png)

