### PR TITLE
fix: correctly set width and height for logos

### DIFF
--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -38,7 +38,12 @@ const AccountForm = () => {
     >
       <Stack sx={{ maxWidth: 'sm' }} alignItems="center">
         <Typography variant="h1">{t('account.welcome_to')}</Typography>
-        <img src={logo} width="125" height="35" alt={t('common.terraso_projectName')} />
+        <img
+          src={logo}
+          width="125"
+          height="35"
+          alt={t('common.terraso_projectName')}
+        />
 
         <Stack spacing={3} sx={{ margin: '3em 0 8em' }}>
           {urls.google && (

--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -38,7 +38,7 @@ const AccountForm = () => {
     >
       <Stack sx={{ maxWidth: 'sm' }} alignItems="center">
         <Typography variant="h1">{t('account.welcome_to')}</Typography>
-        <img src={logo} height="35px" alt={t('common.terraso_projectName')} />
+        <img src={logo} width="125" height="35" alt={t('common.terraso_projectName')} />
 
         <Stack spacing={3} sx={{ margin: '3em 0 8em' }}>
           {urls.google && (

--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -34,7 +34,7 @@ const AppBarComponent = () => {
         <Button color="inherit" component={Link} to="/">
           <img
             src={isSmall ? logoSquare : logo}
-            width={isSmall ? "35": "125"}
+            width={isSmall ? 35 : 125}
             height="35"
             alt={t('common.terraso_projectName')}
           />

--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -34,7 +34,8 @@ const AppBarComponent = () => {
         <Button color="inherit" component={Link} to="/">
           <img
             src={isSmall ? logoSquare : logo}
-            height="35px"
+            width={isSmall ? "35": "125"}
+            height="35"
             alt={t('common.terraso_projectName')}
           />
         </Button>

--- a/src/common/components/UnexpectedError.js
+++ b/src/common/components/UnexpectedError.js
@@ -20,7 +20,12 @@ const UnexpectedError = () => {
         sx={theme => ({ maxWidth: 'md', padding: theme.spacing(3) })}
         alignItems="center"
       >
-        <img src={logo} width="125" height="35" alt={t('common.terraso_projectName')} />
+        <img
+          src={logo}
+          width="125"
+          height="35"
+          alt={t('common.terraso_projectName')}
+        />
 
         <Alert severity="error" sx={{ margin: '3em 0 8em' }}>
           {t('common.unexpected_error')}

--- a/src/common/components/UnexpectedError.js
+++ b/src/common/components/UnexpectedError.js
@@ -20,7 +20,7 @@ const UnexpectedError = () => {
         sx={theme => ({ maxWidth: 'md', padding: theme.spacing(3) })}
         alignItems="center"
       >
-        <img src={logo} height="35px" alt={t('common.terraso_projectName')} />
+        <img src={logo} width="125" height="35" alt={t('common.terraso_projectName')} />
 
         <Alert severity="error" sx={{ margin: '3em 0 8em' }}>
           {t('common.unexpected_error')}


### PR DESCRIPTION
## Description
Correctly set width and height for Terraso logos. The height was set as `35px` instead of `35` and the width was not set.

### Checklist
- [X] Verified on mobile
- [X] Verified on desktop
