### PR TITLE
fix: simplify top-level markup by using <main> and promoting <nav>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ ReactDOM.render(
         <Navigation />
       </Container>
       <Box
+        component="main"
         sx={{
           bgcolor: 'white',
           marginBottom: { xs: '29vh', sm: '15vh', md: '10vh' },

--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,7 @@ ReactDOM.render(
   <AppWrappers store={createStore()} theme={theme} permissionsRules={rules}>
     <Box sx={{ flexGrow: 1, bgcolor: 'gray.lite2' }}>
       <AppBar />
-      <Container>
-        <Navigation />
-      </Container>
+      <Navigation />
       <Box
         component="main"
         sx={{

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -79,6 +79,10 @@ const Navigation = () => {
         '& .MuiTabs-indicator': {
           backgroundColor: 'black',
         },
+        maxWidth: 'lg',
+        margin: '0 auto',
+        padding: '0 24px',
+        boxSizing: 'border-box',
       }}
     >
       {Object.keys(PAGES).map((path, index) => (


### PR DESCRIPTION
## Description
Simplify top-level markup by using `<main>` and promoting `<nav>` so it's no longer inside a container.

### Checklist
- [X] Verified on mobile
- [X] Verified on desktop
