### PR TITLE
feat: add Landscape area polygon to the map 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
+        "@turf/bbox": "^6.5.0",
         "history": "^5.1.0",
         "i18next": "^21.5.2",
         "i18next-browser-languagedetector": "^6.1.2",
@@ -4251,6 +4252,37 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/aria-query": {
@@ -29789,6 +29821,28 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
     },
     "@types/aria-query": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "@turf/bbox": "^6.5.0",
     "history": "^5.1.0",
     "i18next": "^21.5.2",
     "i18next-browser-languagedetector": "^6.1.2",

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -5,7 +5,7 @@ import 'gis/components/Map.css';
 
 const Map = props => {
   return (
-    <MapContainer scrollWheelZoom={false} {...props}>
+    <MapContainer zoomDelta={0.5} wheelPxPerZoomLevel={100} {...props}>
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MapContainer, TileLayer } from 'react-leaflet';
+import { GeoJSON, MapContainer, TileLayer } from 'react-leaflet';
 
 import 'gis/components/Map.css';
 
@@ -10,6 +10,7 @@ const Map = props => {
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
+      <GeoJSON data={props.geojson} />
       {props.children}
     </MapContainer>
   );

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -14,6 +14,7 @@ import {
   Box,
 } from '@mui/material';
 import PublicIcon from '@mui/icons-material/Public';
+import bbox from '@turf/bbox';
 
 import { fetchLandscapeView } from 'landscape/landscapeSlice';
 import { withProps } from 'react-hoc';
@@ -68,16 +69,24 @@ const LandscapeCard = ({ landscape }) => {
   );
 };
 
-const LandscapeMap = ({ position }) => {
+const LandscapeMap = ({ landscape }) => {
   const { t } = useTranslation();
-  const bounds = position && [
-    [position.boundingbox[0], position.boundingbox[2]],
-    [position.boundingbox[1], position.boundingbox[3]],
+  const { areaPolygon, position } = landscape;
+
+  const areaBoundingBox = areaPolygon && bbox(areaPolygon);
+  const positionBoundingBox = position && position.boundingbox;
+
+  const boundingBox = areaBoundingBox || positionBoundingBox;
+  const bounds = boundingBox && [
+    [boundingBox[1], boundingBox[0]],
+    [boundingBox[3], boundingBox[2]],
   ];
+
   return (
     <Box component="section" aria-label={t('landscape.view_map_title')}>
       <Map
         bounds={bounds}
+        geojson={areaPolygon}
         style={{
           width: '100%',
           height: '400px',
@@ -128,7 +137,7 @@ const LandscapeView = () => {
       </Typography>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
-          <LandscapeMap position={landscape.position} />
+          <LandscapeMap landscape={landscape} />
         </Grid>
         <Grid item xs={12} md={6}>
           <LandscapeCard landscape={landscape} />

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -14,7 +14,6 @@ import {
   Box,
 } from '@mui/material';
 import PublicIcon from '@mui/icons-material/Public';
-import bbox from '@turf/bbox';
 
 import { fetchLandscapeView } from 'landscape/landscapeSlice';
 import { withProps } from 'react-hoc';
@@ -28,6 +27,8 @@ import PageHeader from 'common/components/PageHeader';
 import PageContainer from 'common/components/PageContainer';
 import theme from 'theme';
 import { useDocumentTitle } from 'common/document';
+
+import { getLandscapeBoundingBox } from 'landscape/landscapeUtils';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   label: 'landscape.view_leave_label',
@@ -71,22 +72,12 @@ const LandscapeCard = ({ landscape }) => {
 
 const LandscapeMap = ({ landscape }) => {
   const { t } = useTranslation();
-  const { areaPolygon, position } = landscape;
-
-  const areaBoundingBox = areaPolygon && bbox(areaPolygon);
-  const positionBoundingBox = position && position.boundingbox;
-
-  const boundingBox = areaBoundingBox || positionBoundingBox;
-  const bounds = boundingBox && [
-    [boundingBox[1], boundingBox[0]],
-    [boundingBox[3], boundingBox[2]],
-  ];
 
   return (
     <Box component="section" aria-label={t('landscape.view_map_title')}>
       <Map
-        bounds={bounds}
-        geojson={areaPolygon}
+        bounds={getLandscapeBoundingBox(landscape)}
+        geojson={landscape.areaPolygon}
         style={{
           width: '100%',
           height: '400px',

--- a/src/landscape/landscapeFragments.js
+++ b/src/landscape/landscapeFragments.js
@@ -8,6 +8,7 @@ export const landscapeFields = `
     location
     description
     website
+    areaPolygon
   }
 `;
 

--- a/src/landscape/landscapeService.js
+++ b/src/landscape/landscapeService.js
@@ -65,6 +65,12 @@ export const fetchLandscapeToView = (slug, currentUser) => {
           position: placeInfo,
         }))
       )
+      .then(landscape => ({
+        ...landscape,
+        areaPolygon: landscape.areaPolygon
+          ? JSON.parse(landscape.areaPolygon)
+          : null,
+      }))
   );
 };
 

--- a/src/landscape/landscapeUtils.js
+++ b/src/landscape/landscapeUtils.js
@@ -1,0 +1,17 @@
+import bbox from '@turf/bbox';
+
+export const getLandscapeBoundingBox = landscape => {
+  const { areaPolygon, position } = landscape;
+
+  const areaBoundingBox = areaPolygon && bbox(areaPolygon);
+  const positionBoundingBox = position && position.boundingbox;
+
+  const boundingBox = areaBoundingBox || positionBoundingBox;
+
+  return (
+    boundingBox && [
+      [boundingBox[1], boundingBox[0]],
+      [boundingBox[3], boundingBox[2]],
+    ]
+  );
+};

--- a/src/landscape/landscapeUtils.test.js
+++ b/src/landscape/landscapeUtils.test.js
@@ -1,0 +1,45 @@
+import { getLandscapeBoundingBox } from 'landscape/landscapeUtils';
+
+test('Landscape Utils: get bounding box by area geojson', () => {
+  const landscape = {
+    areaPolygon: {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [-100, 39],
+      },
+    },
+    position: {},
+  };
+  const boundingBox = getLandscapeBoundingBox(landscape);
+
+  expect(boundingBox).toStrictEqual([
+    [39, -100],
+    [39, -100],
+  ]);
+});
+
+test('Landscape Utils: get bounding box by position', () => {
+  const landscape = {
+    areaPolygon: null,
+    position: {
+      boundingbox: [1, 2, 3, 4],
+    },
+  };
+  const boundingBox = getLandscapeBoundingBox(landscape);
+
+  expect(boundingBox).toStrictEqual([
+    [2, 1],
+    [4, 3],
+  ]);
+});
+
+test('Landscape Utils: get bounding box without area nor position', () => {
+  const landscape = {
+    areaPolygon: null,
+    position: null,
+  };
+  const boundingBox = getLandscapeBoundingBox(landscape);
+
+  expect(boundingBox).toBeFalsy();
+});


### PR DESCRIPTION
This change updates the Map component to support it receiving a GeoJSON
objects. This GeoJSON is used to add a new map polygon layer.

The new `geojson` property is already being used to the Landscape's
`areaPolygon` attribute. When a `areaPolygon` is used, the bounding box
of this polygon is used. Otherwise, the Landscape's position bounding
box continue being used.

Even before this change, the `LandscapeView` had a limitation to don't
properly handle the situation where a Landscape has no location. This
limitation isn't addressed in this change.

Fix: #192 

![image](https://user-images.githubusercontent.com/348237/153925023-39cb9587-0f24-477b-ad29-9dab25b1d189.png)
