### PR TITLE
fix: map zoom out control

### DIFF
--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -5,7 +5,12 @@ import 'gis/components/Map.css';
 
 const Map = props => {
   return (
-    <MapContainer zoomDelta={0.5} wheelPxPerZoomLevel={100} {...props}>
+    <MapContainer
+      zoomDelta={0.5}
+      zoomSnap={0.5}
+      wheelPxPerZoomLevel={200}
+      {...props}
+    >
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
This change fixes the zoom out control. Although the root cause is not
exactly known, the assumption was the `zoomDelta` option being
fractional without changing the `zoomSnap` option. So, the `zoomSnap`
was set to also be fractional. It worked.
