### PR TITLE
fix: Only save preference if user is logged in

### DIFF
--- a/src/localization/components/LocalePicker.js
+++ b/src/localization/components/LocalePicker.js
@@ -28,6 +28,7 @@ const LocalePicker = () => {
   const language = useSelector(
     _.get('account.currentUser.data.preferences.language')
   );
+  const userEmail = useSelector(_.get('account.currentUser.data.email'));
 
   const isSmall = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -41,7 +42,9 @@ const LocalePicker = () => {
   const handleChange = event => {
     const locale = _.get('target.value', event);
     i18n.changeLanguage(locale);
-    dispatch(savePreference({ key: 'language', value: locale }));
+    if (userEmail) {
+      dispatch(savePreference({ key: 'language', value: locale }));
+    }
   };
 
   const getLocaleLabel = locale =>

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -62,7 +62,24 @@ test('LocalePicker: Change locale', async () => {
       value: 'es-ES',
     },
   });
-  });
+});
+test('LocalePicker: Dont save if no user', async () => {
+  useMediaQuery.mockReturnValue(false);
+  await render(
+    <LocalePicker />
+  );
+
+  expect(screen.queryByText('English')).toBeInTheDocument();
+  await act(async () =>
+    fireEvent.mouseDown(screen.getByRole('button', { name: /English/i }))
+  );
+  const listbox = within(screen.getByRole('listbox'));
+  await act(async () =>
+    fireEvent.click(listbox.getByRole('option', { name: /Español/i }))
+  );
+  expect(screen.getByRole('button', { name: /Español/i })).toBeInTheDocument();
+  expect(terrasoApi.request).toHaveBeenCalledTimes(0);
+});
 test('LocalePicker: Change locale (small screen)', async () => {
   terrasoApi.request.mockResolvedValue(
     _.set(


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added check to save language preference if there is a logged in user.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added
- [x] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop
- [x] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))