### PR TITLE
fix: don't use on FS API boundary upload

### DIFF
--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -46,7 +46,6 @@ const openGeoJsonFile = file =>
         throw new Error('Invalid GeoJSON format');
       }
     } catch (error) {
-      console.error('error', error);
       return Promise.reject(error);
     }
   });

--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -43,9 +43,10 @@ const openGeoJsonFile = file =>
       if (isValidGeoJson(json)) {
         return Promise.resolve(json);
       } else {
-        throw new Error('Invalid GEO Json format');
+        throw new Error('Invalid GeoJSON format');
       }
     } catch (error) {
+      console.error('error', error);
       return Promise.reject(error);
     }
   });

--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -94,6 +94,7 @@ const DropZone = props => {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: '.json,.geojson',
+    useFsAccessApi: false,
     multiple: false,
     maxSize: GEOJSON_MAX_SIZE,
   });


### PR DESCRIPTION
## Description
Works around Dropzone bug [#1164](https://github.com/react-dropzone/react-dropzone/issues/1164) / [#1141](https://github.com/react-dropzone/react-dropzone/issues/1141)

### Verification steps
1. Go to boundary upload page
2. Click on "Select File"
3. Confirm only `.json` and `.geojson` files appear in open dialog