### PR TITLE
fix: send us a message link now loads contact form

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -218,6 +218,7 @@
         "boundaries_file_invalid_geojson": "The file was JSON, but not a valid GeoJSON file.",
         "view_map_boundaries_help": "Something wrong with the map?",
         "view_map_boundaries_help_details": "Contact your landscape’s manager or <1>send us a message <1 /></1>.",
+        "view_map_boundaries_help_url": "/contact",
         "view_map_boundaries_update": "Update Map"
     },
     "common": {

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -218,6 +218,7 @@
         "boundaries_file_invalid_geojson": "El archivo es JSON, pero no es un archivo GeoJSON válido.",
         "view_map_boundaries_help": "¿Algo mal con el mapa?",
         "view_map_boundaries_help_details": "Comunícate con el administrador de su paisaje o <1>envíanos un mensaje <1 /></1>.",
+        "view_map_boundaries_help_url": "/contact",
         "view_map_boundaries_update": "Actualizar información geográfica"
     },
     "common": {


### PR DESCRIPTION
## Description
The `send us a message` link now loads the contact form. Added missing URL to strings.

### Checklist
- [X] Corresponding issue has been opened
- [X] Strings are localized
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #290.