### PR TITLE
fix: reduce width of snackbar alert

### DIFF
--- a/src/notifications/NotificationsWrapper.js
+++ b/src/notifications/NotificationsWrapper.js
@@ -46,7 +46,7 @@ const NotificationsWrapper = props => {
         <Alert
           onClose={() => onClose(key)}
           severity={notification.severity}
-          sx={{ width: '100%' }}
+          sx={{ width: '90%' }}
         >
           {t(notification.content, notification.params)}
         </Alert>


### PR DESCRIPTION
## Description
Prevents snackbar from being truncated on right side of mobile device screens.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #303.