### PR TITLE
fix: Use Save Changes for button name

### DIFF
--- a/src/landscape/components/LandscapeBoundaries.test.js
+++ b/src/landscape/components/LandscapeBoundaries.test.js
@@ -277,11 +277,11 @@ test('LandscapeBoundaries: Save', async () => {
   fireEvent.drop(dropzone, data);
   await waitFor(() =>
     expect(
-      screen.getByRole('button', { name: 'Update Geographic Info' })
+      screen.getByRole('button', { name: 'Save Changes' })
     ).not.toHaveAttribute('disabled')
   );
   const saveButton = screen.getByRole('button', {
-    name: 'Update Geographic Info',
+    name: 'Save Changes',
   });
   expect(saveButton).toBeInTheDocument();
   expect(saveButton).not.toHaveAttribute('disabled');

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -214,7 +214,7 @@
         "boundaries_select_file": "Select File",
         "boundaries_size": "Maximum file size: {{size}}MB",
         "boundaries_format": "Accepted file formats: *.json, *.geojson",
-        "boundaries_save": "Update Geographic Info",
+        "boundaries_save": "Save Changes",
         "boundaries_cancel": "Cancel",
         "boundaries_drop_message": "Drop file to upload",
         "boundaries_file_empty": "The file was empty.",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -214,7 +214,7 @@
         "boundaries_select_file": "Selecciona Archivo",
         "boundaries_size": "Tamaño máximo de archivo: {{size}}MB",
         "boundaries_format": "Formatos de archivo aceptados: *.json, *.geojson",
-        "boundaries_save": "Actualizar información geográfica",
+        "boundaries_save": "Guardar cambios",
         "boundaries_cancel": "Cancelar",
         "boundaries_drop_message": "Soltar el archivo para subirlo",
         "boundaries_file_empty": "El archivo está vacío.",


### PR DESCRIPTION
## Description
Improve consistency and ease of comprehension when updating boundaries.

### Checklist
- [X] English strings reviewed and copyedited
- [X] Strings are localized
- [X] Verified on mobile
- [X] Verified on desktop
