### PR TITLE
fix: disable rollbar when token is not present

### DIFF
--- a/src/monitoring/rollbar.js
+++ b/src/monitoring/rollbar.js
@@ -5,6 +5,7 @@ import { TERRASO_ENV, ROLLBAR_TOKEN } from 'config';
 const rollbarConfig = {
   accessToken: ROLLBAR_TOKEN,
   environment: TERRASO_ENV,
+  enabled: !!ROLLBAR_TOKEN,
 };
 
 export const logLevel = 'warn';


### PR DESCRIPTION
## Description
Disable rollbar when token is not present.

### Related Issues
Fixes #318.