### PR TITLE
fix: Better error messages for duplicate group errors

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -83,7 +83,8 @@
         "members_document_title": "Members: {{name}}",
         "list_column_actions_description": "Actions",
         "members_list_column_actions_description": "Actions",
-        "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). There should at least be one manager."
+        "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). There should at least be one manager.",
+        "unique": "The group “{{inputData.input.name}}” already exists."
     },
     "tool": {
         "requirements": "System requirements",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -84,7 +84,7 @@
         "list_column_actions_description": "Acciones",
         "members_list_column_actions_description": "Acciones",
         "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). Debe existir al menos un administrador.",
-        "unique": "El grupo  “{{inputData.input.name}}” ya existe."
+        "unique": "El grupo “{{inputData.input.name}}” ya existe."
     },
     "tool": {
         "avilability": "Disponibilidad",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -83,7 +83,8 @@
         "members_document_title": "Miembros: {{name}}",
         "list_column_actions_description": "Acciones",
         "members_list_column_actions_description": "Acciones",
-        "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). Debe existir al menos un administrador."
+        "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). Debe existir al menos un administrador.",
+        "unique": "[TODO]The group “{{inputData.input.name}}” already exists."
     },
     "tool": {
         "avilability": "Disponibilidad",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -84,7 +84,7 @@
         "list_column_actions_description": "Acciones",
         "members_list_column_actions_description": "Acciones",
         "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). Debe existir al menos un administrador.",
-        "unique": "[TODO]The group “{{inputData.input.name}}” already exists."
+        "unique": "El grupo  “{{inputData.input.name}}” ya existe."
     },
     "tool": {
         "avilability": "Disponibilidad",


### PR DESCRIPTION
## Description
Pass input data to error handler. Use custom message for groups that don't have a unique name.

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [x] Strings are localized

### Related Issues
Fixes #291.