### PR TITLE
chore: sort imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "arrowParens": "avoid",
   "singleQuote": true,
-  "semi": true
+  "semi": true,
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,19 @@
 {
-  "arrowParens": "avoid",
-  "singleQuote": true,
-  "semi": true,
-  "importOrder": ["^tests/utils$", "^react.*$", "^@mui/(.*)$", "^lodash/(.*)$", "<THIRD_PARTY_MODULES>", "^[./]"],
-  "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+	"arrowParens": "avoid",
+	"singleQuote": true,
+	"semi": true,
+	"importOrder": [
+		"^tests/utils$",
+		"^react.*$",
+		"<THIRD_PARTY_MODULES>",
+		"^@mui/(.*)$",
+		"^assets/(.*)$",
+		"^(common|forms|layout|localization|monitoring|navigation|notifications|permissions|state)/(.*)$",
+		"^(account|contact|gis|group|home|landscape|terrasoBackend|tool|user)/(.*)$",
+		"^(config|custom-hooks|react-hoc)$",
+		"^[./]",
+		"^theme$"
+	],
+	"importOrderSeparation": true,
+	"importOrderSortSpecifiers": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,14 +4,14 @@
 	"semi": true,
 	"importOrder": [
 		"^tests/utils$",
-		"^react.*$",
+		"^react$",
 		"<THIRD_PARTY_MODULES>",
 		"^@mui/(.*)$",
-		"^assets/(.*)$",
 		"^(common|forms|layout|localization|monitoring|navigation|notifications|permissions|state)/(.*)$",
 		"^(account|contact|gis|group|home|landscape|terrasoBackend|tool|user)/(.*)$",
 		"^(config|custom-hooks|react-hoc)$",
 		"^[./]",
+		"^assets/(.*)$",
 		"^theme$"
 	],
 	"importOrderSeparation": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,7 @@
   "arrowParens": "avoid",
   "singleQuote": true,
   "semi": true,
+  "importOrder": ["^tests/utils$", "^react.*$", "^@mui/(.*)$", "^lodash/(.*)$", "<THIRD_PARTY_MODULES>", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.17.0",
+        "@ianvs/prettier-plugin-sort-imports": "^3.3.1",
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "eslint-config-prettier": "^8.5.0",
@@ -2338,6 +2339,24 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.1.tgz",
+      "integrity": "sha512-AXdV6NJPQUu6ME2qLdm1/eu08ipVCiwfJ3p8denC4SXnbjq8OOe1+lz4Y/WF5kYsR4Cm4kV76qZPj9aTTgzrKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.17.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/parser": "^7.17.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -11217,6 +11236,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -22105,6 +22130,21 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ianvs/prettier-plugin-sort-imports": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.1.tgz",
+      "integrity": "sha512-AXdV6NJPQUu6ME2qLdm1/eu08ipVCiwfJ3p8denC4SXnbjq8OOe1+lz4Y/WF5kYsR4Cm4kV76qZPj9aTTgzrKw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.17.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/parser": "^7.17.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -28661,6 +28701,12 @@
           }
         }
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=",
+      "dev": true
     },
     "jest": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   ],
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
+    "@ianvs/prettier-plugin-sort-imports": "^3.3.1",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "eslint-config-prettier": "^8.5.0",

--- a/src/account/accountService.js
+++ b/src/account/accountService.js
@@ -1,13 +1,13 @@
 import _ from 'lodash/fp';
 
 import { getUserEmail } from 'account/auth';
+import { TERRASO_API_URL } from 'config';
+import * as terrasoApi from 'terrasoBackend/api';
 import {
   userFields,
   userPreferences,
   userPreferencesFields,
 } from 'user/userFragments';
-import * as terrasoApi from 'terrasoBackend/api';
-import { TERRASO_API_URL } from 'config';
 
 const parsePreferences = user =>
   _.flow(

--- a/src/account/accountService.js
+++ b/src/account/accountService.js
@@ -1,13 +1,14 @@
 import _ from 'lodash/fp';
 
 import { getUserEmail } from 'account/auth';
-import { TERRASO_API_URL } from 'config';
 import * as terrasoApi from 'terrasoBackend/api';
 import {
   userFields,
   userPreferences,
   userPreferencesFields,
 } from 'user/userFragments';
+
+import { TERRASO_API_URL } from 'config';
 
 const parsePreferences = user =>
   _.flow(

--- a/src/account/accountSlice.js
+++ b/src/account/accountSlice.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
-import { createSlice } from '@reduxjs/toolkit';
 
-import { createAsyncThunk } from 'state/utils';
-import { getToken, removeToken } from 'account/auth';
+import { createSlice } from '@reduxjs/toolkit';
 import * as accountService from 'account/accountService';
+import { getToken, removeToken } from 'account/auth';
 import logger from 'monitoring/logger';
+import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   currentUser: {

--- a/src/account/accountSlice.js
+++ b/src/account/accountSlice.js
@@ -1,10 +1,11 @@
+import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
 
-import { createSlice } from '@reduxjs/toolkit';
-import * as accountService from 'account/accountService';
-import { getToken, removeToken } from 'account/auth';
 import logger from 'monitoring/logger';
 import { createAsyncThunk } from 'state/utils';
+
+import * as accountService from 'account/accountService';
+import { getToken, removeToken } from 'account/auth';
 
 const initialState = {
   currentUser: {

--- a/src/account/auth.js
+++ b/src/account/auth.js
@@ -1,8 +1,7 @@
+import { UNAUTHENTICATED } from 'account/authConstants';
+import { COOKIES_DOMAIN, TERRASO_API_URL } from 'config';
 import Cookies from 'js-cookie';
 import jwt from 'jwt-decode';
-
-import { COOKIES_DOMAIN, TERRASO_API_URL } from 'config';
-import { UNAUTHENTICATED } from 'account/authConstants';
 
 const COOKIES_PARAMS = { path: '/', domain: COOKIES_DOMAIN };
 

--- a/src/account/auth.js
+++ b/src/account/auth.js
@@ -1,7 +1,9 @@
-import { UNAUTHENTICATED } from 'account/authConstants';
-import { COOKIES_DOMAIN, TERRASO_API_URL } from 'config';
 import Cookies from 'js-cookie';
 import jwt from 'jwt-decode';
+
+import { UNAUTHENTICATED } from 'account/authConstants';
+
+import { COOKIES_DOMAIN, TERRASO_API_URL } from 'config';
 
 const COOKIES_PARAMS = { path: '/', domain: COOKIES_DOMAIN };
 

--- a/src/account/components/AccountAvatar.js
+++ b/src/account/components/AccountAvatar.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Avatar, Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Avatar, Typography } from '@mui/material';
 
 const AccountAvatar = props => {
   const { user } = props;

--- a/src/account/components/AccountAvatar.js
+++ b/src/account/components/AccountAvatar.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import _ from 'lodash/fp';
+
 import { Avatar, Typography } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 const AccountAvatar = props => {
   const { user } = props;

--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -7,12 +7,14 @@ import AppleIcon from '@mui/icons-material/Apple';
 import GoogleIcon from '@mui/icons-material/Google';
 import { Button, Stack } from '@mui/material';
 
-import { fetchAuthURLs } from 'account/accountSlice';
 import logo from 'assets/logo.svg';
+
 import { useDocumentTitle } from 'common/document';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import LocalePicker from 'localization/components/LocalePicker';
+
+import { fetchAuthURLs } from 'account/accountSlice';
 
 const appendReferrer = (url, referrer) =>
   referrer ? `${url}&state=${referrer}` : url;

--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
@@ -7,14 +8,14 @@ import AppleIcon from '@mui/icons-material/Apple';
 import GoogleIcon from '@mui/icons-material/Google';
 import { Button, Stack } from '@mui/material';
 
-import logo from 'assets/logo.svg';
-
 import { useDocumentTitle } from 'common/document';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import LocalePicker from 'localization/components/LocalePicker';
 
 import { fetchAuthURLs } from 'account/accountSlice';
+
+import logo from 'assets/logo.svg';
 
 const appendReferrer = (url, referrer) =>
   referrer ? `${url}&state=${referrer}` : url;

--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -1,18 +1,18 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
-import { Button, Stack } from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
+
 import AppleIcon from '@mui/icons-material/Apple';
 import GoogleIcon from '@mui/icons-material/Google';
+import { Button, Stack } from '@mui/material';
 
 import { fetchAuthURLs } from 'account/accountSlice';
-import { useDocumentTitle } from 'common/document';
-import PageLoader from 'layout/PageLoader';
-import PageHeader from 'layout/PageHeader';
-import LocalePicker from 'localization/components/LocalePicker';
-
 import logo from 'assets/logo.svg';
+import { useDocumentTitle } from 'common/document';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+import LocalePicker from 'localization/components/LocalePicker';
 
 const appendReferrer = (url, referrer) =>
   referrer ? `${url}&state=${referrer}` : url;

--- a/src/account/components/AccountLogin.test.js
+++ b/src/account/components/AccountLogin.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import * as accountService from 'account/accountService';

--- a/src/account/components/AccountLogin.test.js
+++ b/src/account/components/AccountLogin.test.js
@@ -1,9 +1,10 @@
-import React from 'react';
-import { useSearchParams } from 'react-router-dom';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
+
 import * as accountService from 'account/accountService';
 import AccountLogin from 'account/components/AccountLogin';
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 jest.mock('account/accountService');
 

--- a/src/account/components/AccountLogin.test.js
+++ b/src/account/components/AccountLogin.test.js
@@ -1,9 +1,10 @@
 import { render, screen } from 'tests/utils';
 
-import * as accountService from 'account/accountService';
-import AccountLogin from 'account/components/AccountLogin';
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
+
+import * as accountService from 'account/accountService';
+import AccountLogin from 'account/components/AccountLogin';
 
 jest.mock('account/accountService');
 

--- a/src/account/components/AccountLogin.test.js
+++ b/src/account/components/AccountLogin.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { useSearchParams } from 'react-router-dom';
 
 import * as accountService from 'account/accountService';

--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -4,16 +4,17 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import * as yup from 'yup';
 
-import { saveUser } from 'account/accountSlice';
-import { savePreference } from 'account/accountSlice';
 import { useDocumentTitle } from 'common/document';
 import Form from 'forms/components/Form';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import LocalePickerSelect from 'localization/components/LocalePickerSelect';
-import * as yup from 'yup';
+
+import { saveUser } from 'account/accountSlice';
+import { savePreference } from 'account/accountSlice';
 
 import AccountAvatar from './AccountAvatar';
 

--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -1,19 +1,21 @@
 import React from 'react';
-import _ from 'lodash/fp';
-import * as yup from 'yup';
-import { useSelector, useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import _ from 'lodash/fp';
 
 import { saveUser } from 'account/accountSlice';
 import { savePreference } from 'account/accountSlice';
 import { useDocumentTitle } from 'common/document';
 import Form from 'forms/components/Form';
-import AccountAvatar from './AccountAvatar';
-import PageLoader from 'layout/PageLoader';
-import PageHeader from 'layout/PageHeader';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
 import LocalePickerSelect from 'localization/components/LocalePickerSelect';
+import * as yup from 'yup';
+
+import AccountAvatar from './AccountAvatar';
 
 const VALIDATION_SCHEMA = yup
   .object({

--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -1,9 +1,9 @@
 import React from 'react';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 import * as yup from 'yup';
 
 import { useDocumentTitle } from 'common/document';

--- a/src/account/components/AccountProfile.test.js
+++ b/src/account/components/AccountProfile.test.js
@@ -1,10 +1,12 @@
-import AccountProfile from 'account/components/AccountProfile';
-import _ from 'lodash/fp';
+import { fireEvent, render, screen, within } from 'tests/utils';
+
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import * as terrasoApi from 'terrasoBackend/api';
 
-import { fireEvent, render, screen, within } from 'tests/utils';
+import _ from 'lodash/fp';
+
+import AccountProfile from 'account/components/AccountProfile';
+import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');
 

--- a/src/account/components/AccountProfile.test.js
+++ b/src/account/components/AccountProfile.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import AccountProfile from 'account/components/AccountProfile';
 import * as terrasoApi from 'terrasoBackend/api';

--- a/src/account/components/AccountProfile.test.js
+++ b/src/account/components/AccountProfile.test.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-
-import { render, screen, fireEvent, within } from 'tests/utils';
 import AccountProfile from 'account/components/AccountProfile';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
 import * as terrasoApi from 'terrasoBackend/api';
+
+import { fireEvent, render, screen, within } from 'tests/utils';
 
 jest.mock('terrasoBackend/api');
 

--- a/src/account/components/RequireAuth.js
+++ b/src/account/components/RequireAuth.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { Navigate, useLocation } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { useDispatch, useSelector } from 'react-redux';
+import { Navigate, useLocation } from 'react-router-dom';
 
 import PageLoader from 'layout/PageLoader';
 

--- a/src/account/components/RequireAuth.js
+++ b/src/account/components/RequireAuth.js
@@ -4,8 +4,9 @@ import { Navigate, useLocation } from 'react-router-dom';
 
 import _ from 'lodash/fp';
 
-import { fetchUser } from 'account/accountSlice';
 import PageLoader from 'layout/PageLoader';
+
+import { fetchUser } from 'account/accountSlice';
 
 const RequireAuth = ({ children }) => {
   const dispatch = useDispatch();

--- a/src/account/components/RequireAuth.js
+++ b/src/account/components/RequireAuth.js
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
+import { useDispatch, useSelector } from 'react-redux';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
+
+import _ from 'lodash/fp';
 
 import { fetchUser } from 'account/accountSlice';
 import PageLoader from 'layout/PageLoader';

--- a/src/account/components/RequireAuth.test.js
+++ b/src/account/components/RequireAuth.test.js
@@ -1,9 +1,9 @@
 import { render, screen } from 'tests/utils';
 
 import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { useLocation, useParams } from 'react-router-dom';
 
 import { getUserEmail } from 'account/auth';
 import RequireAuth from 'account/components/RequireAuth';

--- a/src/account/components/RequireAuth.test.js
+++ b/src/account/components/RequireAuth.test.js
@@ -1,11 +1,13 @@
 import { render, screen } from 'tests/utils';
 
+import React from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+
+import _ from 'lodash/fp';
+
 import { getUserEmail } from 'account/auth';
 import RequireAuth from 'account/components/RequireAuth';
 import GroupView from 'group/components/GroupView';
-import _ from 'lodash/fp';
-import React from 'react';
-import { useLocation, useParams } from 'react-router-dom';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/account/components/RequireAuth.test.js
+++ b/src/account/components/RequireAuth.test.js
@@ -1,12 +1,13 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { useLocation, useParams } from 'react-router-dom';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
-import GroupView from 'group/components/GroupView';
-import * as terrasoApi from 'terrasoBackend/api';
-import RequireAuth from 'account/components/RequireAuth';
+
 import { getUserEmail } from 'account/auth';
+import RequireAuth from 'account/components/RequireAuth';
+import GroupView from 'group/components/GroupView';
+import _ from 'lodash/fp';
+import React from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');
 

--- a/src/account/components/RequireAuth.test.js
+++ b/src/account/components/RequireAuth.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import { getUserEmail } from 'account/auth';

--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -7,12 +7,15 @@ import { useLocation } from 'react-router-dom';
 import { AppBar, Box, Button, Toolbar } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import { signOut } from 'account/accountSlice';
-import AccountAvatar from 'account/components/AccountAvatar';
 import logoSquare from 'assets/logo-square.svg';
 import logo from 'assets/logo.svg';
+
 import ConditionalLink from 'common/components/ConditionalLink';
 import LocalePicker from 'localization/components/LocalePicker';
+
+import { signOut } from 'account/accountSlice';
+import AccountAvatar from 'account/components/AccountAvatar';
+
 import theme from 'theme';
 
 const AppBarComponent = () => {

--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -1,19 +1,19 @@
 import React from 'react';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { AppBar, Toolbar, Button, Box } from '@mui/material';
-import { Link } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 
-import LocalePicker from 'localization/components/LocalePicker';
-import { signOut } from 'account/accountSlice';
-import theme from 'theme';
+import { AppBar, Box, Button, Toolbar } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
-import logo from 'assets/logo.svg';
-import logoSquare from 'assets/logo-square.svg';
+import { signOut } from 'account/accountSlice';
 import AccountAvatar from 'account/components/AccountAvatar';
+import logoSquare from 'assets/logo-square.svg';
+import logo from 'assets/logo.svg';
 import ConditionalLink from 'common/components/ConditionalLink';
+import LocalePicker from 'localization/components/LocalePicker';
+import theme from 'theme';
 
 const AppBarComponent = () => {
   const dispatch = useDispatch();

--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -7,14 +8,14 @@ import { useLocation } from 'react-router-dom';
 import { AppBar, Box, Button, Toolbar } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import logoSquare from 'assets/logo-square.svg';
-import logo from 'assets/logo.svg';
-
 import ConditionalLink from 'common/components/ConditionalLink';
 import LocalePicker from 'localization/components/LocalePicker';
 
 import { signOut } from 'account/accountSlice';
 import AccountAvatar from 'account/components/AccountAvatar';
+
+import logoSquare from 'assets/logo-square.svg';
+import logo from 'assets/logo.svg';
 
 import theme from 'theme';
 

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -3,10 +3,11 @@ import { fireEvent, render, screen } from 'tests/utils';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
+import Cookies from 'js-cookie';
+
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import AppBar from 'common/components/AppBar';
-import Cookies from 'js-cookie';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('js-cookie');

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import Cookies from 'js-cookie';
+import { act } from 'react-dom/test-utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -1,10 +1,11 @@
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+import AppBar from 'common/components/AppBar';
+import Cookies from 'js-cookie';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import Cookies from 'js-cookie';
-
-import { render, screen, fireEvent } from 'tests/utils';
-import AppBar from 'common/components/AppBar';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('js-cookie');

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-import AppBar from 'common/components/AppBar';
-import Cookies from 'js-cookie';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import AppBar from 'common/components/AppBar';
+import Cookies from 'js-cookie';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('js-cookie');

--- a/src/common/components/AppWrappers.js
+++ b/src/common/components/AppWrappers.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
+import { PermissionsProvider } from 'permissions';
+
 import { ThemeProvider } from '@mui/material';
 
 import ErrorMonitoringProvider from 'monitoring/error';
 import NotificationsWrapper from 'notifications/NotificationsWrapper';
-import { PermissionsProvider } from 'permissions';
 
 // Localization
 import 'localization/i18n';

--- a/src/common/components/AppWrappers.js
+++ b/src/common/components/AppWrappers.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
 
 import { PermissionsProvider } from 'permissions';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 
 import { ThemeProvider } from '@mui/material';
 

--- a/src/common/components/AppWrappers.js
+++ b/src/common/components/AppWrappers.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import { ThemeProvider } from '@mui/material';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
+import { ThemeProvider } from '@mui/material';
+
+import ErrorMonitoringProvider from 'monitoring/error';
 import NotificationsWrapper from 'notifications/NotificationsWrapper';
 import { PermissionsProvider } from 'permissions';
-import ErrorMonitoringProvider from 'monitoring/error';
 
 // Localization
 import 'localization/i18n';
-
 // Form validations
 import 'forms/yup';
-
 // Analytics
 import 'monitoring/analytics';
 

--- a/src/common/components/ConfirmButton.js
+++ b/src/common/components/ConfirmButton.js
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+
 import { LoadingButton } from '@mui/lab';
 
 import ConfirmationDialog from 'common/components/ConfirmationDialog';

--- a/src/common/components/ConfirmationDialog.js
+++ b/src/common/components/ConfirmationDialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { LoadingButton } from '@mui/lab';

--- a/src/common/components/ConfirmationDialog.js
+++ b/src/common/components/ConfirmationDialog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
+
+import { LoadingButton } from '@mui/lab';
 import {
   Button,
   Dialog,
@@ -9,9 +10,9 @@ import {
   DialogContentText,
   DialogTitle,
 } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import theme from 'theme';
-import { LoadingButton } from '@mui/lab';
 
 const ConfirmationDialog = props => {
   const { t } = useTranslation();

--- a/src/common/components/InlineHelp.js
+++ b/src/common/components/InlineHelp.js
@@ -1,11 +1,12 @@
 import React from 'react';
+
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Typography,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 const Item = props => {
   const { id, item } = props;

--- a/src/common/components/LoaderCard.js
+++ b/src/common/components/LoaderCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { Box, Card, Skeleton } from '@mui/material';

--- a/src/common/components/LoaderCard.js
+++ b/src/common/components/LoaderCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, Skeleton, Card } from '@mui/material';
+
+import { Box, Card, Skeleton } from '@mui/material';
 
 import theme from 'theme';
 

--- a/src/common/components/Table.js
+++ b/src/common/components/Table.js
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import _ from 'lodash/fp';
+import React, { useEffect, useState } from 'react';
+
 import { DataGrid } from '@mui/x-data-grid';
+
+import _ from 'lodash/fp';
 
 const PAGE_SIZE = 15;
 const SORT_DIRECTION_BY_WORD = {

--- a/src/common/components/Table.js
+++ b/src/common/components/Table.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { DataGrid } from '@mui/x-data-grid';
-
 import _ from 'lodash/fp';
+
+import { DataGrid } from '@mui/x-data-grid';
 
 const PAGE_SIZE = 15;
 const SORT_DIRECTION_BY_WORD = {

--- a/src/common/components/TableResponsive.js
+++ b/src/common/components/TableResponsive.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import _ from 'lodash/fp';
+
 import { Card, Grid, List, ListItem, Stack, Typography } from '@mui/material';
 
-import ResponsiveSwitch from 'layout/ResponsiveSwitch';
+import _ from 'lodash/fp';
+
 import BaseTable from 'common/components/Table';
+import ResponsiveSwitch from 'layout/ResponsiveSwitch';
 
 const Table = props => {
   const { columns, rows, tableProps } = props;

--- a/src/common/components/TableResponsive.js
+++ b/src/common/components/TableResponsive.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Card, Grid, List, ListItem, Stack, Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Card, Grid, List, ListItem, Stack, Typography } from '@mui/material';
 
 import BaseTable from 'common/components/Table';
 import ResponsiveSwitch from 'layout/ResponsiveSwitch';

--- a/src/common/components/UnexpectedError.js
+++ b/src/common/components/UnexpectedError.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { Alert, Paper, Stack } from '@mui/material';
 
 import logo from 'assets/logo.svg';

--- a/src/common/components/UnexpectedError.js
+++ b/src/common/components/UnexpectedError.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { Alert, Paper, Stack } from '@mui/material';

--- a/src/common/document.js
+++ b/src/common/document.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+
+import _ from 'lodash/fp';
 
 export const useDocumentTitle = (title, fetching, omitSuffix = false) => {
   const { t } = useTranslation();

--- a/src/common/document.js
+++ b/src/common/document.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 export const useDocumentTitle = (title, fetching, omitSuffix = false) => {
   const { t } = useTranslation();

--- a/src/contact/ContactForm.js
+++ b/src/contact/ContactForm.js
@@ -4,11 +4,12 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
 
-import { HUBSPOT_FORMS } from 'config';
-import { useScript } from 'custom-hooks';
 import PageContainer from 'layout/PageContainer';
 import PageLoader from 'layout/PageLoader';
 import { addMessage } from 'notifications/notificationsSlice';
+
+import { HUBSPOT_FORMS } from 'config';
+import { useScript } from 'custom-hooks';
 
 const ContactForm = () => {
   const dispatch = useDispatch();

--- a/src/contact/ContactForm.js
+++ b/src/contact/ContactForm.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
 import PageContainer from 'layout/PageContainer';
 import PageLoader from 'layout/PageLoader';

--- a/src/contact/ContactForm.js
+++ b/src/contact/ContactForm.js
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import _ from 'lodash/fp';
-import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { addMessage } from 'notifications/notificationsSlice';
+import _ from 'lodash/fp';
+
+import { HUBSPOT_FORMS } from 'config';
 import { useScript } from 'custom-hooks';
 import PageContainer from 'layout/PageContainer';
 import PageLoader from 'layout/PageLoader';
-import { HUBSPOT_FORMS } from 'config';
+import { addMessage } from 'notifications/notificationsSlice';
 
 const ContactForm = () => {
   const dispatch = useDispatch();

--- a/src/contact/ContactForm.test.js
+++ b/src/contact/ContactForm.test.js
@@ -1,9 +1,9 @@
 import { render, screen } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import ContactForm from 'contact/ContactForm';
 

--- a/src/contact/ContactForm.test.js
+++ b/src/contact/ContactForm.test.js
@@ -1,10 +1,12 @@
 import { render, screen } from 'tests/utils';
 
-import ContactForm from 'contact/ContactForm';
-import { useScript } from 'custom-hooks';
-import _ from 'lodash/fp';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+
+import _ from 'lodash/fp';
+
+import ContactForm from 'contact/ContactForm';
+import { useScript } from 'custom-hooks';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('js-cookie');

--- a/src/contact/ContactForm.test.js
+++ b/src/contact/ContactForm.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import ContactForm from 'contact/ContactForm';

--- a/src/contact/ContactForm.test.js
+++ b/src/contact/ContactForm.test.js
@@ -1,10 +1,11 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
-import { useScript } from 'custom-hooks';
+
 import ContactForm from 'contact/ContactForm';
+import { useScript } from 'custom-hooks';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('js-cookie');

--- a/src/contact/ContactForm.test.js
+++ b/src/contact/ContactForm.test.js
@@ -6,6 +6,7 @@ import { act } from 'react-dom/test-utils';
 import _ from 'lodash/fp';
 
 import ContactForm from 'contact/ContactForm';
+
 import { useScript } from 'custom-hooks';
 
 jest.mock('@mui/material/useMediaQuery');

--- a/src/forms/components/Form.js
+++ b/src/forms/components/Form.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 import _ from 'lodash/fp';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
 import { Button, Grid } from '@mui/material';
 

--- a/src/forms/components/Form.js
+++ b/src/forms/components/Form.js
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Button, Grid } from '@mui/material';
-import { yupResolver } from '@hookform/resolvers/yup';
 
+import { Button, Grid } from '@mui/material';
+
+import _ from 'lodash/fp';
+
+import { yupResolver } from '@hookform/resolvers/yup';
 import FormField from 'forms/components/FormField';
 import theme from 'theme';
 

--- a/src/forms/components/Form.js
+++ b/src/forms/components/Form.js
@@ -2,12 +2,13 @@ import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { Button, Grid } from '@mui/material';
-
+import { yupResolver } from '@hookform/resolvers/yup';
 import _ from 'lodash/fp';
 
-import { yupResolver } from '@hookform/resolvers/yup';
+import { Button, Grid } from '@mui/material';
+
 import FormField from 'forms/components/FormField';
+
 import theme from 'theme';
 
 const getInitialEmptyValues = _.flow(

--- a/src/forms/components/FormField.js
+++ b/src/forms/components/FormField.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import _ from 'lodash/fp';
+
 import { FormControlUnstyled } from '@mui/base';
 import {
   FormHelperText,
@@ -10,8 +12,6 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-
-import _ from 'lodash/fp';
 
 import theme from 'theme';
 

--- a/src/forms/components/FormField.js
+++ b/src/forms/components/FormField.js
@@ -1,15 +1,17 @@
 import React from 'react';
-import _ from 'lodash/fp';
-import { useTranslation } from 'react-i18next';
 import { Controller } from 'react-hook-form';
-import {
-  OutlinedInput,
-  InputLabel,
-  FormHelperText,
-  Typography,
-  Stack,
-} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
 import { FormControlUnstyled } from '@mui/base';
+import {
+  FormHelperText,
+  InputLabel,
+  OutlinedInput,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import _ from 'lodash/fp';
 
 import theme from 'theme';
 

--- a/src/forms/components/FormField.js
+++ b/src/forms/components/FormField.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Controller } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
 import { FormControlUnstyled } from '@mui/base';
 import {

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { GeoJSON, MapContainer, TileLayer, useMap } from 'react-leaflet';
+
 import { v4 as uuidv4 } from 'uuid';
 
 import 'gis/components/Map.css';

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import { GeoJSON, MapContainer, TileLayer, useMap } from 'react-leaflet';
 
+import { GeoJSON, MapContainer, TileLayer, useMap } from 'react-leaflet';
 import { v4 as uuidv4 } from 'uuid';
 
 import 'gis/components/Map.css';

--- a/src/group/components/GroupDefaultHomeCard.js
+++ b/src/group/components/GroupDefaultHomeCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 

--- a/src/group/components/GroupDefaultHomeCard.js
+++ b/src/group/components/GroupDefaultHomeCard.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import {
-  Box,
-  CardActions,
-  Typography,
-  Button,
-  Alert,
-  Divider,
-} from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import {
+  Alert,
+  Box,
+  Button,
+  CardActions,
+  Divider,
+  Typography,
+} from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';
-import { Link } from 'react-router-dom';
 import theme from 'theme';
 
 const Actions = () => {

--- a/src/group/components/GroupDefaultHomeCard.js
+++ b/src/group/components/GroupDefaultHomeCard.js
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';
+
 import theme from 'theme';
 
 const Actions = () => {

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -1,23 +1,25 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
-import { useParams, useNavigate } from 'react-router-dom';
-import * as yup from 'yup';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+
 import { Typography } from '@mui/material';
 
-import {
-  fetchGroupForm,
-  saveGroup,
-  setFormNewValues,
-  resetFormSuccess,
-} from 'group/groupSlice';
+import _ from 'lodash/fp';
+
 import { useDocumentTitle } from 'common/document';
 import Form from 'forms/components/Form';
-import PageLoader from 'layout/PageLoader';
-import PageHeader from 'layout/PageHeader';
+import {
+  fetchGroupForm,
+  resetFormSuccess,
+  saveGroup,
+  setFormNewValues,
+} from 'group/groupSlice';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
 import theme from 'theme';
+import * as yup from 'yup';
 
 const transformURL = url => {
   if (url === '' || url.startsWith('http:') || url.startsWith('https:')) {

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 import * as yup from 'yup';
 
 import { Typography } from '@mui/material';

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -3,23 +3,25 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+import * as yup from 'yup';
+
+import { Typography } from '@mui/material';
 
 import { useDocumentTitle } from 'common/document';
 import Form from 'forms/components/Form';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+
 import {
   fetchGroupForm,
   resetFormSuccess,
   saveGroup,
   setFormNewValues,
 } from 'group/groupSlice';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
+
 import theme from 'theme';
-import * as yup from 'yup';
 
 const transformURL = url => {
   if (url === '' || url.startsWith('http:') || url.startsWith('https:')) {

--- a/src/group/components/GroupForm.test.js
+++ b/src/group/components/GroupForm.test.js
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
-import GroupForm from 'group/components/GroupForm';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useNavigate, useParams } from 'react-router-dom';
+
+import GroupForm from 'group/components/GroupForm';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/group/components/GroupForm.test.js
+++ b/src/group/components/GroupForm.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { act } from 'react-dom/test-utils';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/src/group/components/GroupForm.test.js
+++ b/src/group/components/GroupForm.test.js
@@ -1,9 +1,10 @@
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
+
+import GroupForm from 'group/components/GroupForm';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { useParams, useNavigate } from 'react-router-dom';
-
-import { render, screen, fireEvent } from 'tests/utils';
-import GroupForm from 'group/components/GroupForm';
+import { useNavigate, useParams } from 'react-router-dom';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/group/components/GroupForm.test.js
+++ b/src/group/components/GroupForm.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import GroupForm from 'group/components/GroupForm';

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import { Button, Link, Typography } from '@mui/material';
 
@@ -20,6 +19,8 @@ import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
 import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
+
+import { withProps } from 'react-hoc';
 
 import theme from 'theme';
 

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -4,21 +4,23 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 
-import { Button, Link, Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Button, Link, Typography } from '@mui/material';
 
 import TableResponsive from 'common/components/TableResponsive';
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+
 import { GroupContextProvider } from 'group/groupContext';
 import { fetchGroups } from 'group/groupSlice';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
 import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
+
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -1,22 +1,24 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
-import { Typography, Link, Button } from '@mui/material';
-
-import { fetchGroups } from 'group/groupSlice';
 import { withProps } from 'react-hoc';
-import { useDocumentTitle } from 'common/document';
-import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
-import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
-import PageLoader from 'layout/PageLoader';
-import { GroupContextProvider } from 'group/groupContext';
-import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
-import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
-import PageHeader from 'layout/PageHeader';
-import PageContainer from 'layout/PageContainer';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+
+import { Button, Link, Typography } from '@mui/material';
+
+import _ from 'lodash/fp';
+
 import TableResponsive from 'common/components/TableResponsive';
+import { useDocumentTitle } from 'common/document';
+import { GroupContextProvider } from 'group/groupContext';
+import { fetchGroups } from 'group/groupSlice';
+import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
+import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
+import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
+import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { useSearchParams } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
+import { useSearchParams } from 'react-router-dom';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -4,9 +4,9 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useSearchParams } from 'react-router-dom';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-
 import _ from 'lodash/fp';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import GroupList from 'group/components/GroupList';
 import * as terrasoApi from 'terrasoBackend/api';

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -1,11 +1,12 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useSearchParams } from 'react-router-dom';
+// prettier-ignore
+import { fireEvent, render, screen, within } from 'tests/utils';
 
-import { render, screen, within, fireEvent } from 'tests/utils';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import GroupList from 'group/components/GroupList';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { useSearchParams } from 'react-router-dom';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -1,11 +1,14 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-import GroupList from 'group/components/GroupList';
-import _ from 'lodash/fp';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useSearchParams } from 'react-router-dom';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import _ from 'lodash/fp';
+
+import GroupList from 'group/components/GroupList';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import EmailIcon from '@mui/icons-material/Email';
 import PublicIcon from '@mui/icons-material/Public';
 import {
@@ -17,18 +19,18 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+import Restricted from 'permissions/components/Restricted';
+
 import { GroupContextProvider } from 'group/groupContext';
 import { fetchGroupView } from 'group/groupSlice';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
-import Restricted from 'permissions/components/Restricted';
+
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import EmailIcon from '@mui/icons-material/Email';
 import PublicIcon from '@mui/icons-material/Public';
@@ -30,6 +29,8 @@ import { fetchGroupView } from 'group/groupSlice';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
+
+import { withProps } from 'react-hoc';
 
 import theme from 'theme';
 

--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -1,32 +1,34 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
-import { useParams, Link as RouterLink, useNavigate } from 'react-router-dom';
+import { withProps } from 'react-hoc';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+
+import EmailIcon from '@mui/icons-material/Email';
+import PublicIcon from '@mui/icons-material/Public';
 import {
-  Typography,
-  Grid,
+  Button,
   Card,
-  CardHeader,
   CardContent,
+  CardHeader,
+  Grid,
   Link,
   Stack,
-  Button,
+  Typography,
 } from '@mui/material';
-import PublicIcon from '@mui/icons-material/Public';
-import EmailIcon from '@mui/icons-material/Email';
 
-import { withProps } from 'react-hoc';
-import { fetchGroupView } from 'group/groupSlice';
+import _ from 'lodash/fp';
+
 import { useDocumentTitle } from 'common/document';
+import { GroupContextProvider } from 'group/groupContext';
+import { fetchGroupView } from 'group/groupSlice';
+import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
+import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import Restricted from 'permissions/components/Restricted';
-import { GroupContextProvider } from 'group/groupContext';
-import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
-import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
-import PageHeader from 'layout/PageHeader';
-import PageContainer from 'layout/PageContainer';
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/components/GroupView.test.js
+++ b/src/group/components/GroupView.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import GroupView from 'group/components/GroupView';

--- a/src/group/components/GroupView.test.js
+++ b/src/group/components/GroupView.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from 'tests/utils';
 
-import GroupView from 'group/components/GroupView';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+
+import GroupView from 'group/components/GroupView';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/group/components/GroupView.test.js
+++ b/src/group/components/GroupView.test.js
@@ -1,8 +1,9 @@
+// prettier-ignore
+import { render, screen } from 'tests/utils';
+
+import GroupView from 'group/components/GroupView';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-
-import { render, screen } from 'tests/utils';
-import GroupView from 'group/components/GroupView';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/group/components/GroupView.test.js
+++ b/src/group/components/GroupView.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { useParams } from 'react-router-dom';
 
 import GroupView from 'group/components/GroupView';

--- a/src/group/components/GroupsHomeCard.js
+++ b/src/group/components/GroupsHomeCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
 
 import {
   Button,

--- a/src/group/components/GroupsHomeCard.js
+++ b/src/group/components/GroupsHomeCard.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+
 import {
   Button,
   CardActions,
@@ -9,8 +11,8 @@ import {
   ListItem,
   Typography,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
+
+import _ from 'lodash/fp';
 
 import HomeCard from 'home/components/HomeCard';
 import theme from 'theme';

--- a/src/group/components/GroupsHomeCard.js
+++ b/src/group/components/GroupsHomeCard.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import {
   Button,
   CardActions,
@@ -12,9 +14,8 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import HomeCard from 'home/components/HomeCard';
+
 import theme from 'theme';
 
 const GroupItem = ({ group }) => {

--- a/src/group/groupContext.js
+++ b/src/group/groupContext.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+
 import _ from 'lodash/fp';
 
 const GroupContext = React.createContext();

--- a/src/group/groupService.js
+++ b/src/group/groupService.js
@@ -1,12 +1,13 @@
 import _ from 'lodash/fp';
 
-import * as terrasoApi from 'terrasoBackend/api';
 import {
   accountMembership,
   groupFields,
-  groupMembersInfo,
   groupMembers,
+  groupMembersInfo,
 } from 'group/groupFragments';
+import * as terrasoApi from 'terrasoBackend/api';
+
 import {
   extractAccountMembership,
   extractMembers,

--- a/src/group/groupSlice.js
+++ b/src/group/groupSlice.js
@@ -1,9 +1,10 @@
+import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
 
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk } from 'state/utils';
+
 import * as groupService from 'group/groupService';
 import * as groupUtils from 'group/groupUtils';
-import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   memberships: {},

--- a/src/group/groupSlice.js
+++ b/src/group/groupSlice.js
@@ -1,9 +1,9 @@
 import _ from 'lodash/fp';
-import { createSlice } from '@reduxjs/toolkit';
 
-import { createAsyncThunk } from 'state/utils';
+import { createSlice } from '@reduxjs/toolkit';
 import * as groupService from 'group/groupService';
 import * as groupUtils from 'group/groupUtils';
+import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   memberships: {},

--- a/src/group/membership/components/GroupMemberJoin.js
+++ b/src/group/membership/components/GroupMemberJoin.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { LoadingButton } from '@mui/lab';
 
 const GroupMemberJoin = props => {

--- a/src/group/membership/components/GroupMemberJoin.js
+++ b/src/group/membership/components/GroupMemberJoin.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { LoadingButton } from '@mui/lab';

--- a/src/group/membership/components/GroupMemberLeave.js
+++ b/src/group/membership/components/GroupMemberLeave.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+
+import _ from 'lodash/fp';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/group/membership/components/GroupMemberLeave.js
+++ b/src/group/membership/components/GroupMemberLeave.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/group/membership/components/GroupMemberRemove.js
+++ b/src/group/membership/components/GroupMemberRemove.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+
+import _ from 'lodash/fp';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/group/membership/components/GroupMemberRemove.js
+++ b/src/group/membership/components/GroupMemberRemove.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -4,19 +4,21 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+import { usePermission } from 'permissions';
+
 import { Typography } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+
 import { GroupContextProvider } from 'group/groupContext';
 import { fetchGroupForMembers } from 'group/groupSlice';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMemberRemove from 'group/membership/components/GroupMemberRemove';
 import GroupMembersList from 'group/membership/components/GroupMembersList';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import { usePermission } from 'permissions';
+
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -1,20 +1,22 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useDispatch, useSelector } from 'react-redux';
+import { withProps } from 'react-hoc';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
+
 import { Typography } from '@mui/material';
 
-import { usePermission } from 'permissions';
+import _ from 'lodash/fp';
+
 import { useDocumentTitle } from 'common/document';
-import { fetchGroupForMembers } from 'group/groupSlice';
-import { withProps } from 'react-hoc';
 import { GroupContextProvider } from 'group/groupContext';
-import GroupMembersList from 'group/membership/components/GroupMembersList';
+import { fetchGroupForMembers } from 'group/groupSlice';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMemberRemove from 'group/membership/components/GroupMemberRemove';
-import PageHeader from 'layout/PageHeader';
+import GroupMembersList from 'group/membership/components/GroupMembersList';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import { usePermission } from 'permissions';
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(GroupMemberLeave, {

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 
 import _ from 'lodash/fp';
 import { usePermission } from 'permissions';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { Typography } from '@mui/material';
 
@@ -18,6 +17,8 @@ import { fetchGroupForMembers } from 'group/groupSlice';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMemberRemove from 'group/membership/components/GroupMemberRemove';
 import GroupMembersList from 'group/membership/components/GroupMembersList';
+
+import { withProps } from 'react-hoc';
 
 import theme from 'theme';
 

--- a/src/group/membership/components/GroupMembersList.js
+++ b/src/group/membership/components/GroupMembersList.js
@@ -3,16 +3,18 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 
-import { MenuItem, Select, Stack, Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
 
-import AccountAvatar from 'account/components/AccountAvatar';
+import { MenuItem, Select, Stack, Typography } from '@mui/material';
+
 import TableResponsive from 'common/components/TableResponsive';
-import { useGroupContext } from 'group/groupContext';
-import { fetchMembers, removeMember, updateMemberRole } from 'group/groupSlice';
 import PageLoader from 'layout/PageLoader';
 import Restricted from 'permissions/components/Restricted';
+
+import AccountAvatar from 'account/components/AccountAvatar';
+import { useGroupContext } from 'group/groupContext';
+import { fetchMembers, removeMember, updateMemberRole } from 'group/groupSlice';
+
 import theme from 'theme';
 
 const ROLES = ['MEMBER', 'MANAGER'];

--- a/src/group/membership/components/GroupMembersList.js
+++ b/src/group/membership/components/GroupMembersList.js
@@ -1,16 +1,18 @@
-import React, { useEffect, useContext } from 'react';
-import _ from 'lodash/fp';
+import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { useSearchParams } from 'react-router-dom';
+
 import { MenuItem, Select, Stack, Typography } from '@mui/material';
 
-import { fetchMembers, removeMember, updateMemberRole } from 'group/groupSlice';
-import { useGroupContext } from 'group/groupContext';
+import _ from 'lodash/fp';
+
 import AccountAvatar from 'account/components/AccountAvatar';
-import Restricted from 'permissions/components/Restricted';
-import PageLoader from 'layout/PageLoader';
 import TableResponsive from 'common/components/TableResponsive';
+import { useGroupContext } from 'group/groupContext';
+import { fetchMembers, removeMember, updateMemberRole } from 'group/groupSlice';
+import PageLoader from 'layout/PageLoader';
+import Restricted from 'permissions/components/Restricted';
 import theme from 'theme';
 
 const ROLES = ['MEMBER', 'MANAGER'];

--- a/src/group/membership/components/GroupMembersList.js
+++ b/src/group/membership/components/GroupMembersList.js
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect } from 'react';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import { MenuItem, Select, Stack, Typography } from '@mui/material';
 

--- a/src/group/membership/components/GroupMembershipCard.js
+++ b/src/group/membership/components/GroupMembershipCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import {
   AvatarGroup,

--- a/src/group/membership/components/GroupMembershipCard.js
+++ b/src/group/membership/components/GroupMembershipCard.js
@@ -1,23 +1,26 @@
 import React from 'react';
-import _ from 'lodash/fp';
-import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
 import {
-  Typography,
-  Card,
-  CardHeader,
-  CardContent,
-  CardActions,
   AvatarGroup,
-  CircularProgress,
   Box,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  CircularProgress,
   Link,
+  Typography,
 } from '@mui/material';
 
-import { useGroupContext } from 'group/groupContext';
-import GroupMembershipJoinLeaveButton from './GroupMembershipJoinLeaveButton';
+import _ from 'lodash/fp';
+
 import AccountAvatar from 'account/components/AccountAvatar';
+import { useGroupContext } from 'group/groupContext';
 import theme from 'theme';
+
+import GroupMembershipJoinLeaveButton from './GroupMembershipJoinLeaveButton';
 
 const Loader = () => {
   const { t } = useTranslation();

--- a/src/group/membership/components/GroupMembershipCard.js
+++ b/src/group/membership/components/GroupMembershipCard.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import _ from 'lodash/fp';
+
 import {
   AvatarGroup,
   Box,
@@ -14,13 +16,12 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import AccountAvatar from 'account/components/AccountAvatar';
 import { useGroupContext } from 'group/groupContext';
-import theme from 'theme';
 
 import GroupMembershipJoinLeaveButton from './GroupMembershipJoinLeaveButton';
+
+import theme from 'theme';
 
 const Loader = () => {
   const { t } = useTranslation();

--- a/src/group/membership/components/GroupMembershipCard.test.js
+++ b/src/group/membership/components/GroupMembershipCard.test.js
@@ -1,13 +1,14 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
 
-import { render, screen, fireEvent } from 'tests/utils';
-import * as terrasoApi from 'terrasoBackend/api';
-import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
-import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
-import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import { GroupContextProvider } from 'group/groupContext';
+import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
+import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
+import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');
 

--- a/src/group/membership/components/GroupMembershipCard.test.js
+++ b/src/group/membership/components/GroupMembershipCard.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import { GroupContextProvider } from 'group/groupContext';

--- a/src/group/membership/components/GroupMembershipCard.test.js
+++ b/src/group/membership/components/GroupMembershipCard.test.js
@@ -1,12 +1,14 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import _ from 'lodash/fp';
+
 import { GroupContextProvider } from 'group/groupContext';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMemberLeave from 'group/membership/components/GroupMemberLeave';
 import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
-import _ from 'lodash/fp';
-import React from 'react';
-import { act } from 'react-dom/test-utils';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/group/membership/components/GroupMembershipCard.test.js
+++ b/src/group/membership/components/GroupMembershipCard.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import { GroupContextProvider } from 'group/groupContext';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';

--- a/src/group/membership/components/GroupMembershipCount.js
+++ b/src/group/membership/components/GroupMembershipCount.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useSelector } from 'react-redux';
 
 import { Typography } from '@mui/material';
 

--- a/src/group/membership/components/GroupMembershipCount.js
+++ b/src/group/membership/components/GroupMembershipCount.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Typography } from '@mui/material';
 
 const GroupMembershipCount = ({ groupSlug }) => {
   const { group } = useSelector(_.getOr({}, `group.memberships.${groupSlug}`));

--- a/src/group/membership/components/GroupMembershipCount.js
+++ b/src/group/membership/components/GroupMembershipCount.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useSelector } from 'react-redux';
+
 import { Typography } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 const GroupMembershipCount = ({ groupSlug }) => {
   const { group } = useSelector(_.getOr({}, `group.memberships.${groupSlug}`));

--- a/src/group/membership/components/GroupMembershipJoinLeaveButton.js
+++ b/src/group/membership/components/GroupMembershipJoinLeaveButton.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { joinGroup, leaveGroup } from 'group/groupSlice';
+import _ from 'lodash/fp';
+
 import { useGroupContext } from 'group/groupContext';
+import { joinGroup, leaveGroup } from 'group/groupSlice';
 import { useAnalytics } from 'monitoring/analytics';
 
 const GroupMembershipJoinLeaveButton = () => {

--- a/src/group/membership/components/GroupMembershipJoinLeaveButton.js
+++ b/src/group/membership/components/GroupMembershipJoinLeaveButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useAnalytics } from 'monitoring/analytics';
 

--- a/src/group/membership/components/GroupMembershipJoinLeaveButton.js
+++ b/src/group/membership/components/GroupMembershipJoinLeaveButton.js
@@ -3,9 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
 
+import { useAnalytics } from 'monitoring/analytics';
+
 import { useGroupContext } from 'group/groupContext';
 import { joinGroup, leaveGroup } from 'group/groupSlice';
-import { useAnalytics } from 'monitoring/analytics';
 
 const GroupMembershipJoinLeaveButton = () => {
   const dispatch = useDispatch();

--- a/src/home/components/Home.js
+++ b/src/home/components/Home.js
@@ -2,19 +2,20 @@ import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Alert, Grid, Stack } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Alert, Grid, Stack } from '@mui/material';
 
 import LoaderCard from 'common/components/LoaderCard';
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+
 import GroupDefaultCard from 'group/components/GroupDefaultHomeCard';
 import GroupsCard from 'group/components/GroupsHomeCard';
 import { fetchHomeData } from 'home/homeSlice';
 import LandscapeDefaultCard from 'landscape/components/LandscapeDefaultHomeCard';
 import LandscapesCard from 'landscape/components/LandscapesHomeCard';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
 import ToolHomeCard from 'tool/components/ToolHomeCard';
 
 const Landscapes = ({ landscapes, fetching }) => {

--- a/src/home/components/Home.js
+++ b/src/home/components/Home.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Alert, Grid, Stack } from '@mui/material';
 

--- a/src/home/components/Home.js
+++ b/src/home/components/Home.js
@@ -1,19 +1,21 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
-import { Grid, Alert, Stack } from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { fetchHomeData } from 'home/homeSlice';
-import { useDocumentTitle } from 'common/document';
+import { Alert, Grid, Stack } from '@mui/material';
+
+import _ from 'lodash/fp';
+
 import LoaderCard from 'common/components/LoaderCard';
-import LandscapesCard from 'landscape/components/LandscapesHomeCard';
-import LandscapeDefaultCard from 'landscape/components/LandscapeDefaultHomeCard';
-import GroupsCard from 'group/components/GroupsHomeCard';
+import { useDocumentTitle } from 'common/document';
 import GroupDefaultCard from 'group/components/GroupDefaultHomeCard';
-import ToolHomeCard from 'tool/components/ToolHomeCard';
-import PageHeader from 'layout/PageHeader';
+import GroupsCard from 'group/components/GroupsHomeCard';
+import { fetchHomeData } from 'home/homeSlice';
+import LandscapeDefaultCard from 'landscape/components/LandscapeDefaultHomeCard';
+import LandscapesCard from 'landscape/components/LandscapesHomeCard';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import ToolHomeCard from 'tool/components/ToolHomeCard';
 
 const Landscapes = ({ landscapes, fetching }) => {
   if (fetching) {

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -1,9 +1,11 @@
 import { render, screen } from 'tests/utils';
 
+import React from 'react';
+
+import _ from 'lodash/fp';
+
 import Home from 'home/components/Home';
 import { fetchHomeData } from 'home/homeService';
-import _ from 'lodash/fp';
-import React from 'react';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import Home from 'home/components/Home';

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -1,9 +1,10 @@
-import React from 'react';
-import _ from 'lodash/fp';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
+
 import Home from 'home/components/Home';
 import { fetchHomeData } from 'home/homeService';
+import _ from 'lodash/fp';
+import React from 'react';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/home/components/HomeCard.js
+++ b/src/home/components/HomeCard.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import _ from 'lodash/fp';
+
 import { Card } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 const HomeCard = props => (
   <Card

--- a/src/home/components/HomeCard.js
+++ b/src/home/components/HomeCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Card } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Card } from '@mui/material';
 
 const HomeCard = props => (
   <Card

--- a/src/home/homeService.js
+++ b/src/home/homeService.js
@@ -1,9 +1,9 @@
 import _ from 'lodash/fp';
 
-import * as terrasoApi from 'terrasoBackend/api';
 import { groupFields } from 'group/groupFragments';
-import { landscapeFields, defaultGroup } from 'landscape/landscapeFragments';
 import { extractAccountMembership } from 'group/groupUtils';
+import { defaultGroup, landscapeFields } from 'landscape/landscapeFragments';
+import * as terrasoApi from 'terrasoBackend/api';
 
 export const fetchHomeData = email => {
   const query = `

--- a/src/home/homeSlice.js
+++ b/src/home/homeSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import * as homeService from 'home/homeService';
+
 import { createAsyncThunk } from 'state/utils';
+
+import * as homeService from 'home/homeService';
 
 const initialState = {
   groups: [],

--- a/src/home/homeSlice.js
+++ b/src/home/homeSlice.js
@@ -1,7 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
-
-import { createAsyncThunk } from 'state/utils';
 import * as homeService from 'home/homeService';
+import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   groups: [],

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,18 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
+
 import { Box } from '@mui/material';
 
-import reportWebVitals from 'monitoring/reportWebVitals';
-import createStore from 'state/store';
-import rules from 'permissions/rules';
-import theme from 'theme';
 import AppBar from 'common/components/AppBar';
 import AppWrappers from 'common/components/AppWrappers';
-import Routes from 'navigation/Routes';
-import Navigation from 'navigation/Navigation';
 import Footer from 'layout/Footer';
+import reportWebVitals from 'monitoring/reportWebVitals';
+import Navigation from 'navigation/Navigation';
+import Routes from 'navigation/Routes';
 import SkipLinks from 'navigation/SkipLinks';
+import rules from 'permissions/rules';
+import createStore from 'state/store';
+import theme from 'theme';
 
 import 'index.css';
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import Routes from 'navigation/Routes';
 import SkipLinks from 'navigation/SkipLinks';
 import rules from 'permissions/rules';
 import createStore from 'state/store';
+
 import theme from 'theme';
 
 import 'index.css';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+
 import ReactDOM from 'react-dom';
 
 import { Box } from '@mui/material';

--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -1,8 +1,9 @@
-import React, { useCallback, useState, useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
-import { useParams, useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
+import { Trans, useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+
 import {
   Alert,
   Button,
@@ -12,19 +13,21 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { Trans, useTranslation } from 'react-i18next';
 
-import theme from 'theme';
+import _ from 'lodash/fp';
+
+import InlineHelp from 'common/components/InlineHelp';
+import { useDocumentTitle } from 'common/document';
 import { GEOJSON_MAX_SIZE } from 'config';
 import { fetchLandscapeForm, saveLandscape } from 'landscape/landscapeSlice';
 import { isValidGeoJson } from 'landscape/landscapeUtils';
-import { useDocumentTitle } from 'common/document';
-import { sendToRollbar } from 'monitoring/logger';
 import PageContainer from 'layout/PageContainer';
-import LandscapeMap from './LandscapeMap';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
-import InlineHelp from 'common/components/InlineHelp';
+import { sendToRollbar } from 'monitoring/logger';
+import theme from 'theme';
+
+import LandscapeMap from './LandscapeMap';
 
 const openFile = file =>
   new Promise((resolve, reject) => {

--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -4,6 +4,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import {
   Alert,
   Button,
@@ -14,20 +16,21 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import InlineHelp from 'common/components/InlineHelp';
 import { useDocumentTitle } from 'common/document';
-import { GEOJSON_MAX_SIZE } from 'config';
-import { fetchLandscapeForm, saveLandscape } from 'landscape/landscapeSlice';
-import { isValidGeoJson } from 'landscape/landscapeUtils';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import { sendToRollbar } from 'monitoring/logger';
-import theme from 'theme';
+
+import { fetchLandscapeForm, saveLandscape } from 'landscape/landscapeSlice';
+import { isValidGeoJson } from 'landscape/landscapeUtils';
+
+import { GEOJSON_MAX_SIZE } from 'config';
 
 import LandscapeMap from './LandscapeMap';
+
+import theme from 'theme';
 
 const openFile = file =>
   new Promise((resolve, reject) => {

--- a/src/landscape/components/LandscapeBoundaries.js
+++ b/src/landscape/components/LandscapeBoundaries.js
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
+
+import _ from 'lodash/fp';
 import { useDropzone } from 'react-dropzone';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import {
   Alert,

--- a/src/landscape/components/LandscapeBoundaries.test.js
+++ b/src/landscape/components/LandscapeBoundaries.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen, waitFor } from 'tests/utils';
 
 import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';

--- a/src/landscape/components/LandscapeBoundaries.test.js
+++ b/src/landscape/components/LandscapeBoundaries.test.js
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen, waitFor } from 'tests/utils';
 
-import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useNavigate, useParams } from 'react-router-dom';
+
+import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeBoundaries.test.js
+++ b/src/landscape/components/LandscapeBoundaries.test.js
@@ -1,9 +1,10 @@
+// prettier-ignore
+import { fireEvent, render, screen, waitFor } from 'tests/utils';
+
+import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { useParams, useNavigate } from 'react-router-dom';
-
-import { render, screen, fireEvent, waitFor } from 'tests/utils';
-import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
+import { useNavigate, useParams } from 'react-router-dom';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeBoundaries.test.js
+++ b/src/landscape/components/LandscapeBoundaries.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from 'tests/utils';
 
 import React from 'react';
+
 import { act } from 'react-dom/test-utils';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/src/landscape/components/LandscapeDefaultHomeCard.js
+++ b/src/landscape/components/LandscapeDefaultHomeCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 

--- a/src/landscape/components/LandscapeDefaultHomeCard.js
+++ b/src/landscape/components/LandscapeDefaultHomeCard.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import {
-  Box,
-  CardActions,
-  Typography,
-  Button,
-  Alert,
-  Divider,
-} from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import {
+  Alert,
+  Box,
+  Button,
+  CardActions,
+  Divider,
+  Typography,
+} from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';
-import { Link } from 'react-router-dom';
 import theme from 'theme';
 
 const Actions = () => {

--- a/src/landscape/components/LandscapeDefaultHomeCard.js
+++ b/src/landscape/components/LandscapeDefaultHomeCard.js
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';
+
 import theme from 'theme';
 
 const Actions = () => {

--- a/src/landscape/components/LandscapeForm.js
+++ b/src/landscape/components/LandscapeForm.js
@@ -1,20 +1,21 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
-import { useParams, useNavigate } from 'react-router-dom';
-import * as yup from 'yup';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
+import { useDocumentTitle } from 'common/document';
+import Form from 'forms/components/Form';
 import {
   fetchLandscapeForm,
   saveLandscape,
   setFormNewValues,
 } from 'landscape/landscapeSlice';
-import { useDocumentTitle } from 'common/document';
-import Form from 'forms/components/Form';
-import PageLoader from 'layout/PageLoader';
-import PageHeader from 'layout/PageHeader';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+import * as yup from 'yup';
 
 const VALIDATION_SCHEMA = yup
   .object({

--- a/src/landscape/components/LandscapeForm.js
+++ b/src/landscape/components/LandscapeForm.js
@@ -4,18 +4,19 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import * as yup from 'yup';
 
 import { useDocumentTitle } from 'common/document';
 import Form from 'forms/components/Form';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+
 import {
   fetchLandscapeForm,
   saveLandscape,
   setFormNewValues,
 } from 'landscape/landscapeSlice';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
-import * as yup from 'yup';
 
 const VALIDATION_SCHEMA = yup
   .object({

--- a/src/landscape/components/LandscapeForm.js
+++ b/src/landscape/components/LandscapeForm.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 import * as yup from 'yup';
 
 import { useDocumentTitle } from 'common/document';

--- a/src/landscape/components/LandscapeForm.test.js
+++ b/src/landscape/components/LandscapeForm.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import LandscapeForm from 'landscape/components/LandscapeForm';

--- a/src/landscape/components/LandscapeForm.test.js
+++ b/src/landscape/components/LandscapeForm.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { act } from 'react-dom/test-utils';
 import { useParams } from 'react-router-dom';
 

--- a/src/landscape/components/LandscapeForm.test.js
+++ b/src/landscape/components/LandscapeForm.test.js
@@ -1,9 +1,10 @@
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
+
+import LandscapeForm from 'landscape/components/LandscapeForm';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useParams } from 'react-router-dom';
-
-import { render, screen, fireEvent } from 'tests/utils';
-import LandscapeForm from 'landscape/components/LandscapeForm';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeForm.test.js
+++ b/src/landscape/components/LandscapeForm.test.js
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
-import LandscapeForm from 'landscape/components/LandscapeForm';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useParams } from 'react-router-dom';
+
+import LandscapeForm from 'landscape/components/LandscapeForm';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeList.js
+++ b/src/landscape/components/LandscapeList.js
@@ -4,21 +4,23 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 
-import { Link, Typography } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Link, Typography } from '@mui/material';
 
 import TableResponsive from 'common/components/TableResponsive';
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+
 import { GroupContextProvider } from 'group/groupContext';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
 import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
 import { fetchLandscapes } from 'landscape/landscapeSlice';
 import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
+
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {

--- a/src/landscape/components/LandscapeList.js
+++ b/src/landscape/components/LandscapeList.js
@@ -1,23 +1,24 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
-import { Typography, Link } from '@mui/material';
-
-import { fetchLandscapes } from 'landscape/landscapeSlice';
 import { withProps } from 'react-hoc';
-import { useDocumentTitle } from 'common/document';
-import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
-import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
-import PageLoader from 'layout/PageLoader';
-import PageHeader from 'layout/PageHeader';
-import PageContainer from 'layout/PageContainer';
-import { GroupContextProvider } from 'group/groupContext';
-import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
-import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
-import TableResponsive from 'common/components/TableResponsive';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 
+import { Link, Typography } from '@mui/material';
+
+import _ from 'lodash/fp';
+
+import TableResponsive from 'common/components/TableResponsive';
+import { useDocumentTitle } from 'common/document';
+import { GroupContextProvider } from 'group/groupContext';
+import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
+import GroupMembershipCount from 'group/membership/components/GroupMembershipCount';
+import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
+import { fetchLandscapes } from 'landscape/landscapeSlice';
+import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
 import theme from 'theme';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {

--- a/src/landscape/components/LandscapeList.js
+++ b/src/landscape/components/LandscapeList.js
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import { Link, Typography } from '@mui/material';
 
@@ -20,6 +19,8 @@ import GroupMembershipCount from 'group/membership/components/GroupMembershipCou
 import GroupMembershipJoinLeaveButton from 'group/membership/components/GroupMembershipJoinLeaveButton';
 import { fetchLandscapes } from 'landscape/landscapeSlice';
 import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
+
+import { withProps } from 'react-hoc';
 
 import theme from 'theme';
 

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -3,9 +3,9 @@ import { fireEvent, render, screen, within } from 'tests/utils';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-
 import _ from 'lodash/fp';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import LandscapeList from 'landscape/components/LandscapeList';
 import * as terrasoApi from 'terrasoBackend/api';

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-import LandscapeList from 'landscape/components/LandscapeList';
-import _ from 'lodash/fp';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import _ from 'lodash/fp';
+
+import LandscapeList from 'landscape/components/LandscapeList';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -1,10 +1,11 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-import useMediaQuery from '@mui/material/useMediaQuery';
+// prettier-ignore
+import { fireEvent, render, screen, within } from 'tests/utils';
 
-import { render, screen, within, fireEvent } from 'tests/utils';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import LandscapeList from 'landscape/components/LandscapeList';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/landscape/components/LandscapeMap.js
+++ b/src/landscape/components/LandscapeMap.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Box } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Box } from '@mui/material';
 
 import Map from 'gis/components/Map';
 import {

--- a/src/landscape/components/LandscapeMap.js
+++ b/src/landscape/components/LandscapeMap.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import _ from 'lodash/fp';
+
 import { Box } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 import Map from 'gis/components/Map';
 import {

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
+
+import _ from 'lodash/fp';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import LaunchIcon from '@mui/icons-material/Launch';
 import PublicIcon from '@mui/icons-material/Public';
@@ -33,6 +32,8 @@ import GroupMembershipCard from 'group/membership/components/GroupMembershipCard
 import LandscapeMap from 'landscape/components/LandscapeMap';
 import { fetchLandscapeView } from 'landscape/landscapeSlice';
 import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
+
+import { withProps } from 'react-hoc';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.view_leave_label',

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -1,35 +1,37 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
-import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { withProps } from 'react-hoc';
 import { Trans, useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+
+import LaunchIcon from '@mui/icons-material/Launch';
+import PublicIcon from '@mui/icons-material/Public';
 import {
-  Typography,
-  Grid,
+  Button,
   Card,
   CardActions,
-  CardHeader,
   CardContent,
+  CardHeader,
+  Grid,
   Link,
   Stack,
-  Button,
+  Typography,
 } from '@mui/material';
-import PublicIcon from '@mui/icons-material/Public';
-import LaunchIcon from '@mui/icons-material/Launch';
 
-import { fetchLandscapeView } from 'landscape/landscapeSlice';
-import { withProps } from 'react-hoc';
-import { useDocumentTitle } from 'common/document';
-import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
-import PageLoader from 'layout/PageLoader';
-import { GroupContextProvider } from 'group/groupContext';
-import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
-import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
-import PageHeader from 'layout/PageHeader';
-import PageContainer from 'layout/PageContainer';
-import LandscapeMap from 'landscape/components/LandscapeMap';
-import Restricted from 'permissions/components/Restricted';
+import _ from 'lodash/fp';
+
 import InlineHelp from 'common/components/InlineHelp';
+import { useDocumentTitle } from 'common/document';
+import { GroupContextProvider } from 'group/groupContext';
+import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
+import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
+import LandscapeMap from 'landscape/components/LandscapeMap';
+import { fetchLandscapeView } from 'landscape/landscapeSlice';
+import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+import Restricted from 'permissions/components/Restricted';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.view_leave_label',

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -4,6 +4,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import LaunchIcon from '@mui/icons-material/Launch';
 import PublicIcon from '@mui/icons-material/Public';
 import {
@@ -18,20 +20,19 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import InlineHelp from 'common/components/InlineHelp';
 import { useDocumentTitle } from 'common/document';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
+import PageLoader from 'layout/PageLoader';
+import Restricted from 'permissions/components/Restricted';
+
 import { GroupContextProvider } from 'group/groupContext';
 import GroupMemberJoin from 'group/membership/components/GroupMemberJoin';
 import GroupMembershipCard from 'group/membership/components/GroupMembershipCard';
 import LandscapeMap from 'landscape/components/LandscapeMap';
 import { fetchLandscapeView } from 'landscape/landscapeSlice';
 import LandscapeMemberLeave from 'landscape/membership/components/LandscapeMemberLeave';
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
-import PageLoader from 'layout/PageLoader';
-import Restricted from 'permissions/components/Restricted';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.view_leave_label',

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { useParams } from 'react-router-dom';
 
 import LandscapeView from 'landscape/components/LandscapeView';

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -1,8 +1,9 @@
+// prettier-ignore
+import { render, screen } from 'tests/utils';
+
+import LandscapeView from 'landscape/components/LandscapeView';
 import React from 'react';
 import { useParams } from 'react-router-dom';
-
-import { render, screen } from 'tests/utils';
-import LandscapeView from 'landscape/components/LandscapeView';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from 'tests/utils';
 
-import LandscapeView from 'landscape/components/LandscapeView';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+
+import LandscapeView from 'landscape/components/LandscapeView';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('terrasoBackend/api');

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import LandscapeView from 'landscape/components/LandscapeView';

--- a/src/landscape/components/LandscapesHomeCard.js
+++ b/src/landscape/components/LandscapesHomeCard.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
+
 import {
   Avatar,
   Box,
@@ -11,8 +13,8 @@ import {
   ListItem,
   Typography,
 } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
+
+import _ from 'lodash/fp';
 
 import HomeCard from 'home/components/HomeCard';
 import theme from 'theme';

--- a/src/landscape/components/LandscapesHomeCard.js
+++ b/src/landscape/components/LandscapesHomeCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
 
 import {
   Avatar,

--- a/src/landscape/components/LandscapesHomeCard.js
+++ b/src/landscape/components/LandscapesHomeCard.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import {
   Avatar,
   Box,
@@ -14,9 +16,8 @@ import {
   Typography,
 } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import HomeCard from 'home/components/HomeCard';
+
 import theme from 'theme';
 
 const getAcronym = name => name.match(/\b(\w)/g).join('');

--- a/src/landscape/landscapeService.js
+++ b/src/landscape/landscapeService.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
 
-import * as terrasoApi from 'terrasoBackend/api';
 import * as gisService from 'gis/gisService';
-import { landscapeFields, defaultGroup } from 'landscape/landscapeFragments';
-import { extractAccountMembership, extractMembersInfo } from 'group/groupUtils';
 import { accountMembership } from 'group/groupFragments';
+import { extractAccountMembership, extractMembersInfo } from 'group/groupUtils';
+import { defaultGroup, landscapeFields } from 'landscape/landscapeFragments';
+import * as terrasoApi from 'terrasoBackend/api';
 
 const cleanLandscape = landscape =>
   _.flow(

--- a/src/landscape/landscapeSlice.js
+++ b/src/landscape/landscapeSlice.js
@@ -1,10 +1,11 @@
+import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
 
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk } from 'state/utils';
+
 import { setMemberships } from 'group/groupSlice';
 import * as groupUtils from 'group/groupUtils';
 import * as landscapeService from 'landscape/landscapeService';
-import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   list: {

--- a/src/landscape/landscapeSlice.js
+++ b/src/landscape/landscapeSlice.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
-import { createSlice } from '@reduxjs/toolkit';
 
-import { createAsyncThunk } from 'state/utils';
-import * as landscapeService from 'landscape/landscapeService';
+import { createSlice } from '@reduxjs/toolkit';
 import { setMemberships } from 'group/groupSlice';
 import * as groupUtils from 'group/groupUtils';
+import * as landscapeService from 'landscape/landscapeService';
+import { createAsyncThunk } from 'state/utils';
 
 const initialState = {
   list: {

--- a/src/landscape/membership/components/LandscapeMemberLeave.js
+++ b/src/landscape/membership/components/LandscapeMemberLeave.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+
+import _ from 'lodash/fp';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/landscape/membership/components/LandscapeMemberLeave.js
+++ b/src/landscape/membership/components/LandscapeMemberLeave.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/landscape/membership/components/LandscapeMemberRemove.js
+++ b/src/landscape/membership/components/LandscapeMemberRemove.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
+
+import _ from 'lodash/fp';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/landscape/membership/components/LandscapeMemberRemove.js
+++ b/src/landscape/membership/components/LandscapeMemberRemove.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 import ConfirmButton from 'common/components/ConfirmButton';
 

--- a/src/landscape/membership/components/LandscapeMembers.js
+++ b/src/landscape/membership/components/LandscapeMembers.js
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react';
-import { withProps } from 'react-hoc';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 
 import _ from 'lodash/fp';
 import { usePermission } from 'permissions';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { Typography } from '@mui/material';
 
@@ -17,6 +16,8 @@ import PageLoader from 'layout/PageLoader';
 import { GroupContextProvider } from 'group/groupContext';
 import GroupMembersList from 'group/membership/components/GroupMembersList';
 import { fetchLandscapeForMembers } from 'landscape/landscapeSlice';
+
+import { withProps } from 'react-hoc';
 
 import LandscapeMemberLeave from './LandscapeMemberLeave';
 import LandscapeMemberRemove from './LandscapeMemberRemove';

--- a/src/landscape/membership/components/LandscapeMembers.js
+++ b/src/landscape/membership/components/LandscapeMembers.js
@@ -1,22 +1,25 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
-import { useSelector, useDispatch } from 'react-redux';
+import { withProps } from 'react-hoc';
 import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
+
 import { Typography } from '@mui/material';
 
-import { fetchLandscapeForMembers } from 'landscape/landscapeSlice';
-import { usePermission } from 'permissions';
-import { withProps } from 'react-hoc';
+import _ from 'lodash/fp';
+
 import { useDocumentTitle } from 'common/document';
-import GroupMembersList from 'group/membership/components/GroupMembersList';
 import { GroupContextProvider } from 'group/groupContext';
+import GroupMembersList from 'group/membership/components/GroupMembersList';
+import { fetchLandscapeForMembers } from 'landscape/landscapeSlice';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
+import { usePermission } from 'permissions';
+import theme from 'theme';
+
 import LandscapeMemberLeave from './LandscapeMemberLeave';
 import LandscapeMemberRemove from './LandscapeMemberRemove';
-import PageHeader from 'layout/PageHeader';
-import PageContainer from 'layout/PageContainer';
-import theme from 'theme';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.members_list_leave',

--- a/src/landscape/membership/components/LandscapeMembers.js
+++ b/src/landscape/membership/components/LandscapeMembers.js
@@ -4,22 +4,24 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+import { usePermission } from 'permissions';
+
 import { Typography } from '@mui/material';
 
-import _ from 'lodash/fp';
-
 import { useDocumentTitle } from 'common/document';
-import { GroupContextProvider } from 'group/groupContext';
-import GroupMembersList from 'group/membership/components/GroupMembersList';
-import { fetchLandscapeForMembers } from 'landscape/landscapeSlice';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
-import { usePermission } from 'permissions';
-import theme from 'theme';
+
+import { GroupContextProvider } from 'group/groupContext';
+import GroupMembersList from 'group/membership/components/GroupMembersList';
+import { fetchLandscapeForMembers } from 'landscape/landscapeSlice';
 
 import LandscapeMemberLeave from './LandscapeMemberLeave';
 import LandscapeMemberRemove from './LandscapeMemberRemove';
+
+import theme from 'theme';
 
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.members_list_leave',

--- a/src/landscape/membership/components/LandscapeMembers.test.js
+++ b/src/landscape/membership/components/LandscapeMembers.test.js
@@ -1,10 +1,11 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-import useMediaQuery from '@mui/material/useMediaQuery';
+// prettier-ignore
+import { fireEvent, render, screen, within } from 'tests/utils';
 
-import { render, screen, within, fireEvent } from 'tests/utils';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/landscape/membership/components/LandscapeMembers.test.js
+++ b/src/landscape/membership/components/LandscapeMembers.test.js
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
-import _ from 'lodash/fp';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import _ from 'lodash/fp';
+
+import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
 import * as terrasoApi from 'terrasoBackend/api';
 
 // Omit console error for DataGrid issue: https://github.com/mui/mui-x/issues/3850

--- a/src/landscape/membership/components/LandscapeMembers.test.js
+++ b/src/landscape/membership/components/LandscapeMembers.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/src/landscape/membership/components/LandscapeMembers.test.js
+++ b/src/landscape/membership/components/LandscapeMembers.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 

--- a/src/landscape/membership/components/LandscapeMembers.test.js
+++ b/src/landscape/membership/components/LandscapeMembers.test.js
@@ -3,9 +3,9 @@ import { fireEvent, render, screen, within } from 'tests/utils';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-
 import _ from 'lodash/fp';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
 import * as terrasoApi from 'terrasoBackend/api';

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { Link, Typography, Grid } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
+
+import { Grid, Link, Typography } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import theme from 'theme';
 

--- a/src/layout/NotFound.js
+++ b/src/layout/NotFound.js
@@ -1,12 +1,13 @@
 import React from 'react';
+
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Box, Link, Stack, Typography } from '@mui/material';
 
-import notFoundImage from 'assets/not-found.png';
-
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
+
+import notFoundImage from 'assets/not-found.png';
 
 const HELP_URL = 'https://terraso.org/contact-us/';
 

--- a/src/layout/NotFound.js
+++ b/src/layout/NotFound.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import PageContainer from 'layout/PageContainer';
-import PageHeader from 'layout/PageHeader';
 import { Box, Link, Stack, Typography } from '@mui/material';
 
 import notFoundImage from 'assets/not-found.png';
+import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
 
 const HELP_URL = 'https://terraso.org/contact-us/';
 

--- a/src/layout/NotFound.js
+++ b/src/layout/NotFound.js
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Box, Link, Stack, Typography } from '@mui/material';
 
 import notFoundImage from 'assets/not-found.png';
+
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 

--- a/src/layout/PageContainer.js
+++ b/src/layout/PageContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import _ from 'lodash/fp';
+
 import { Container } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 const PageContainer = props => {
   return (

--- a/src/layout/PageContainer.js
+++ b/src/layout/PageContainer.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Container } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Container } from '@mui/material';
 
 const PageContainer = props => {
   return (

--- a/src/layout/PageHeader.js
+++ b/src/layout/PageHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Typography } from '@mui/material';
 
 const PageHeader = ({ header, typographyProps = {} }) => (

--- a/src/layout/PageLoader.js
+++ b/src/layout/PageLoader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { Backdrop, CircularProgress } from '@mui/material';

--- a/src/layout/PageLoader.js
+++ b/src/layout/PageLoader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { Backdrop, CircularProgress } from '@mui/material';
 
 const PageLoader = () => {

--- a/src/localization/components/LocalePicker.js
+++ b/src/localization/components/LocalePicker.js
@@ -4,9 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
 
-import { savePreference } from 'account/accountSlice';
 import LocalePickerSelect from 'localization/components/LocalePickerSelect';
 import { LOCALES } from 'localization/i18n';
+
+import { savePreference } from 'account/accountSlice';
 
 const LocalePicker = () => {
   const { i18n } = useTranslation();

--- a/src/localization/components/LocalePicker.js
+++ b/src/localization/components/LocalePicker.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
 import LocalePickerSelect from 'localization/components/LocalePickerSelect';
 import { LOCALES } from 'localization/i18n';

--- a/src/localization/components/LocalePicker.js
+++ b/src/localization/components/LocalePicker.js
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { LOCALES } from 'localization/i18n';
+import _ from 'lodash/fp';
+
 import { savePreference } from 'account/accountSlice';
 import LocalePickerSelect from 'localization/components/LocalePickerSelect';
+import { LOCALES } from 'localization/i18n';
 
 const LocalePicker = () => {
   const { i18n } = useTranslation();

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -1,12 +1,13 @@
-import React from 'react';
-import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
-import useMediaQuery from '@mui/material/useMediaQuery';
+// prettier-ignore
+import { fireEvent, render, screen, within } from 'tests/utils';
 
-import i18n from 'localization/i18n';
-import { render, screen, fireEvent, within } from 'tests/utils';
-import * as terrasoApi from 'terrasoBackend/api';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import LocalePicker from 'localization/components/LocalePicker';
+import i18n from 'localization/i18n';
+import _ from 'lodash/fp';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('terrasoBackend/api');

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import _ from 'lodash/fp';
+import { act } from 'react-dom/test-utils';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -3,12 +3,13 @@ import { fireEvent, render, screen, within } from 'tests/utils';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-
 import _ from 'lodash/fp';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import LocalePicker from 'localization/components/LocalePicker';
 import i18n from 'localization/i18n';
+
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('@mui/material/useMediaQuery');

--- a/src/localization/components/LocalePicker.test.js
+++ b/src/localization/components/LocalePicker.test.js
@@ -1,11 +1,14 @@
 import { fireEvent, render, screen, within } from 'tests/utils';
 
-import useMediaQuery from '@mui/material/useMediaQuery';
-import LocalePicker from 'localization/components/LocalePicker';
-import i18n from 'localization/i18n';
-import _ from 'lodash/fp';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import _ from 'lodash/fp';
+
+import LocalePicker from 'localization/components/LocalePicker';
+import i18n from 'localization/i18n';
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('@mui/material/useMediaQuery');

--- a/src/localization/components/LocalePickerSelect.js
+++ b/src/localization/components/LocalePickerSelect.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
 
 import { MenuItem, Select as SelectBase } from '@mui/material';
 import { styled } from '@mui/material/styles';

--- a/src/localization/components/LocalePickerSelect.js
+++ b/src/localization/components/LocalePickerSelect.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import _ from 'lodash/fp';
+
 import { MenuItem, Select as SelectBase } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-import _ from 'lodash/fp';
-
 import { LOCALES } from 'localization/i18n';
+
 import theme from 'theme';
 
 const Select = styled(SelectBase)(({ theme }) => ({

--- a/src/localization/components/LocalePickerSelect.js
+++ b/src/localization/components/LocalePickerSelect.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import useMediaQuery from '@mui/material/useMediaQuery';
+
+import { MenuItem, Select as SelectBase } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { Select as SelectBase, MenuItem } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import _ from 'lodash/fp';
 
 import { LOCALES } from 'localization/i18n';
 import theme from 'theme';

--- a/src/localization/i18n.js
+++ b/src/localization/i18n.js
@@ -1,5 +1,6 @@
-import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+
+import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
 export const LOCALES = {

--- a/src/localization/i18n.js
+++ b/src/localization/i18n.js
@@ -1,7 +1,6 @@
-import { initReactI18next } from 'react-i18next';
-
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
 
 export const LOCALES = {
   'en-US': {

--- a/src/localization/i18n.test.js
+++ b/src/localization/i18n.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from 'tests/utils';
 
-import i18n from 'localization/i18n';
 import { act } from 'react-dom/test-utils';
 import { useTranslation } from 'react-i18next';
+
+import i18n from 'localization/i18n';
 
 i18n.init({
   lng: 'en-US',

--- a/src/localization/i18n.test.js
+++ b/src/localization/i18n.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import i18n from 'localization/i18n';

--- a/src/localization/i18n.test.js
+++ b/src/localization/i18n.test.js
@@ -1,8 +1,9 @@
+// prettier-ignore
 import { render, screen } from 'tests/utils';
-import { act } from 'react-dom/test-utils';
-import { useTranslation } from 'react-i18next';
 
 import i18n from 'localization/i18n';
+import { act } from 'react-dom/test-utils';
+import { useTranslation } from 'react-i18next';
 
 i18n.init({
   lng: 'en-US',

--- a/src/monitoring/analytics.js
+++ b/src/monitoring/analytics.js
@@ -1,6 +1,5 @@
-import { useTranslation } from 'react-i18next';
-
 import Plausible from 'plausible-tracker';
+import { useTranslation } from 'react-i18next';
 
 import { PLAUSIBLE_DOMAIN, TERRASO_ENV } from 'config';
 

--- a/src/monitoring/analytics.js
+++ b/src/monitoring/analytics.js
@@ -1,7 +1,7 @@
-import Plausible from 'plausible-tracker';
 import { useTranslation } from 'react-i18next';
 
 import { PLAUSIBLE_DOMAIN, TERRASO_ENV } from 'config';
+import Plausible from 'plausible-tracker';
 
 export const plausible = Plausible({
   domain: PLAUSIBLE_DOMAIN,

--- a/src/monitoring/analytics.js
+++ b/src/monitoring/analytics.js
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 
-import { PLAUSIBLE_DOMAIN, TERRASO_ENV } from 'config';
 import Plausible from 'plausible-tracker';
+
+import { PLAUSIBLE_DOMAIN, TERRASO_ENV } from 'config';
 
 export const plausible = Plausible({
   domain: PLAUSIBLE_DOMAIN,

--- a/src/monitoring/analytics.test.js
+++ b/src/monitoring/analytics.test.js
@@ -1,7 +1,8 @@
-import { plausible, useAnalytics } from 'monitoring/analytics';
+import { render } from 'tests/utils';
+
 import React from 'react';
 
-import { render } from 'tests/utils';
+import { plausible, useAnalytics } from 'monitoring/analytics';
 
 jest.mock('plausible-tracker', () => () => ({
   trackEvent: jest.fn(),

--- a/src/monitoring/analytics.test.js
+++ b/src/monitoring/analytics.test.js
@@ -1,7 +1,7 @@
+import { plausible, useAnalytics } from 'monitoring/analytics';
 import React from 'react';
 
 import { render } from 'tests/utils';
-import { useAnalytics, plausible } from 'monitoring/analytics';
 
 jest.mock('plausible-tracker', () => () => ({
   trackEvent: jest.fn(),

--- a/src/monitoring/error.js
+++ b/src/monitoring/error.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { ErrorBoundary } from 'react-error-boundary';
 
 import UnexpectedError from 'common/components/UnexpectedError';

--- a/src/monitoring/error.js
+++ b/src/monitoring/error.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import logger from 'monitoring/logger';
 import UnexpectedError from 'common/components/UnexpectedError';
+import logger from 'monitoring/logger';
 
 const errorHandler = error => {
   logger.error(error.message, error.stack);

--- a/src/monitoring/error.test.js
+++ b/src/monitoring/error.test.js
@@ -1,7 +1,8 @@
-import React from 'react';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
+
 import { rollbar } from 'monitoring/rollbar';
+import React from 'react';
 
 jest.mock('monitoring/rollbar');
 

--- a/src/monitoring/error.test.js
+++ b/src/monitoring/error.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import { rollbar } from 'monitoring/rollbar';

--- a/src/monitoring/error.test.js
+++ b/src/monitoring/error.test.js
@@ -1,7 +1,8 @@
 import { render, screen } from 'tests/utils';
 
-import { rollbar } from 'monitoring/rollbar';
 import React from 'react';
+
+import { rollbar } from 'monitoring/rollbar';
 
 jest.mock('monitoring/rollbar');
 

--- a/src/monitoring/logger.js
+++ b/src/monitoring/logger.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 
-import { rollbar, logLevel } from 'monitoring/rollbar';
+import { logLevel, rollbar } from 'monitoring/rollbar';
 
 const LOG_LEVELS = ['log', 'info', 'warn', 'error'];
 

--- a/src/monitoring/rollbar.js
+++ b/src/monitoring/rollbar.js
@@ -1,6 +1,5 @@
+import { ROLLBAR_TOKEN, TERRASO_ENV } from 'config';
 import Rollbar from 'rollbar';
-
-import { TERRASO_ENV, ROLLBAR_TOKEN } from 'config';
 
 const rollbarConfig = {
   accessToken: ROLLBAR_TOKEN,

--- a/src/monitoring/rollbar.js
+++ b/src/monitoring/rollbar.js
@@ -1,5 +1,6 @@
-import { ROLLBAR_TOKEN, TERRASO_ENV } from 'config';
 import Rollbar from 'rollbar';
+
+import { ROLLBAR_TOKEN, TERRASO_ENV } from 'config';
 
 const rollbarConfig = {
   accessToken: ROLLBAR_TOKEN,

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -1,9 +1,9 @@
 import React from 'react';
+
+import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-
-import _ from 'lodash/fp';
 
 import { Button, Container, List, ListItem } from '@mui/material';
 import { styled } from '@mui/material/styles';

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useLocation, Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+
+import { Button, Container, List, ListItem } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { Button, List, ListItem, Container } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 const PAGES = {
   '/': {

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 
+import _ from 'lodash/fp';
+
 import { Button, Container, List, ListItem } from '@mui/material';
 import { styled } from '@mui/material/styles';
-
-import _ from 'lodash/fp';
 
 const PAGES = {
   '/': {

--- a/src/navigation/Navigation.test.js
+++ b/src/navigation/Navigation.test.js
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
-import Navigation from 'navigation/Navigation';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
+
+import Navigation from 'navigation/Navigation';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/navigation/Navigation.test.js
+++ b/src/navigation/Navigation.test.js
@@ -1,9 +1,10 @@
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
+
+import Navigation from 'navigation/Navigation';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
-
-import { render, screen, fireEvent } from 'tests/utils';
-import Navigation from 'navigation/Navigation';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/navigation/Navigation.test.js
+++ b/src/navigation/Navigation.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React from 'react';
+
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
 

--- a/src/navigation/Navigation.test.js
+++ b/src/navigation/Navigation.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import Navigation from 'navigation/Navigation';

--- a/src/navigation/Routes.js
+++ b/src/navigation/Routes.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Route, Routes } from 'react-router-dom';
 
 import NotFound from 'layout/NotFound';

--- a/src/navigation/Routes.js
+++ b/src/navigation/Routes.js
@@ -1,22 +1,22 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
-import Home from 'home/components/Home';
-import GroupList from 'group/components/GroupList';
-import GroupForm from 'group/components/GroupForm';
-import GroupView from 'group/components/GroupView';
-import GroupMembers from 'group/membership/components/GroupMembers';
-import LandscapeList from 'landscape/components/LandscapeList';
-import LandscapeForm from 'landscape/components/LandscapeForm';
-import LandscapeView from 'landscape/components/LandscapeView';
-import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
-import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
-import ToolsList from 'tool/components/ToolList';
 import AccountLogin from 'account/components/AccountLogin';
 import AccountProfile from 'account/components/AccountProfile';
 import RequireAuth from 'account/components/RequireAuth';
-import NotFound from 'layout/NotFound';
 import ContactForm from 'contact/ContactForm';
+import GroupForm from 'group/components/GroupForm';
+import GroupList from 'group/components/GroupList';
+import GroupView from 'group/components/GroupView';
+import GroupMembers from 'group/membership/components/GroupMembers';
+import Home from 'home/components/Home';
+import LandscapeBoundaries from 'landscape/components/LandscapeBoundaries';
+import LandscapeForm from 'landscape/components/LandscapeForm';
+import LandscapeList from 'landscape/components/LandscapeList';
+import LandscapeView from 'landscape/components/LandscapeView';
+import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
+import NotFound from 'layout/NotFound';
+import ToolsList from 'tool/components/ToolList';
 
 const path = (path, Component, auth = true) => ({
   path,

--- a/src/navigation/Routes.js
+++ b/src/navigation/Routes.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import NotFound from 'layout/NotFound';
+
 import AccountLogin from 'account/components/AccountLogin';
 import AccountProfile from 'account/components/AccountProfile';
 import RequireAuth from 'account/components/RequireAuth';
@@ -15,7 +17,6 @@ import LandscapeForm from 'landscape/components/LandscapeForm';
 import LandscapeList from 'landscape/components/LandscapeList';
 import LandscapeView from 'landscape/components/LandscapeView';
 import LandscapeMembers from 'landscape/membership/components/LandscapeMembers';
-import NotFound from 'layout/NotFound';
 import ToolsList from 'tool/components/ToolList';
 
 const path = (path, Component, auth = true) => ({

--- a/src/navigation/SkipLinks.js
+++ b/src/navigation/SkipLinks.js
@@ -2,9 +2,9 @@ import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import { Link } from '@mui/material';
-
 import _ from 'lodash/fp';
+
+import { Link } from '@mui/material';
 
 import 'navigation/SkipLinks.css';
 

--- a/src/navigation/SkipLinks.js
+++ b/src/navigation/SkipLinks.js
@@ -1,8 +1,10 @@
-import React, { useRef, useEffect } from 'react';
-import _ from 'lodash/fp';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+
 import { Link } from '@mui/material';
+
+import _ from 'lodash/fp';
 
 import 'navigation/SkipLinks.css';
 

--- a/src/navigation/SkipLinks.js
+++ b/src/navigation/SkipLinks.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
 
 import _ from 'lodash/fp';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import { Link } from '@mui/material';
 

--- a/src/navigation/SkipLinks.test.js
+++ b/src/navigation/SkipLinks.test.js
@@ -1,10 +1,12 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
-import { Box } from '@mui/material';
-import SkipLinks from 'navigation/SkipLinks';
 import React, { useRef } from 'react';
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
+
+import { Box } from '@mui/material';
+
+import SkipLinks from 'navigation/SkipLinks';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/navigation/SkipLinks.test.js
+++ b/src/navigation/SkipLinks.test.js
@@ -1,10 +1,11 @@
+// prettier-ignore
+import { fireEvent, render, screen } from 'tests/utils';
+
+import { Box } from '@mui/material';
+import SkipLinks from 'navigation/SkipLinks';
 import React, { useRef } from 'react';
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
-import { Box } from '@mui/material';
-
-import { render, screen, fireEvent } from 'tests/utils';
-import SkipLinks from 'navigation/SkipLinks';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/navigation/SkipLinks.test.js
+++ b/src/navigation/SkipLinks.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { fireEvent, render, screen } from 'tests/utils';
 
 import { Box } from '@mui/material';

--- a/src/navigation/SkipLinks.test.js
+++ b/src/navigation/SkipLinks.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from 'tests/utils';
 
 import React, { useRef } from 'react';
+
 import { act } from 'react-dom/test-utils';
 import { useLocation } from 'react-router-dom';
 

--- a/src/notifications/NotificationsWrapper.js
+++ b/src/notifications/NotificationsWrapper.js
@@ -1,8 +1,10 @@
-import React, { useEffect, createRef } from 'react';
+import React, { createRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector, useDispatch } from 'react-redux';
-import { SnackbarProvider } from 'notistack';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { Alert } from '@mui/material';
+
+import { SnackbarProvider } from 'notistack';
 
 import { removeMessage } from './notificationsSlice';
 

--- a/src/notifications/NotificationsWrapper.js
+++ b/src/notifications/NotificationsWrapper.js
@@ -2,9 +2,9 @@ import React, { createRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Alert } from '@mui/material';
-
 import { SnackbarProvider } from 'notistack';
+
+import { Alert } from '@mui/material';
 
 import { removeMessage } from './notificationsSlice';
 

--- a/src/notifications/NotificationsWrapper.js
+++ b/src/notifications/NotificationsWrapper.js
@@ -1,8 +1,8 @@
 import React, { createRef, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { SnackbarProvider } from 'notistack';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Alert } from '@mui/material';
 

--- a/src/notifications/notificationsSlice.js
+++ b/src/notifications/notificationsSlice.js
@@ -1,6 +1,5 @@
-import _ from 'lodash/fp';
-
 import { createSlice } from '@reduxjs/toolkit';
+import _ from 'lodash/fp';
 import { v4 as uuidv4 } from 'uuid';
 
 const initialState = {

--- a/src/notifications/notificationsSlice.js
+++ b/src/notifications/notificationsSlice.js
@@ -1,5 +1,6 @@
-import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
+
+import { createSlice } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
 
 const initialState = {

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { usePermission } from 'permissions';
+import { useTranslation } from 'react-i18next';
 
 import { CircularProgress } from '@mui/material';
 

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { CircularProgress } from '@mui/material';
 
 import { usePermission } from 'permissions';

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { CircularProgress } from '@mui/material';
-
 import { usePermission } from 'permissions';
+
+import { CircularProgress } from '@mui/material';
 
 const Restricted = props => {
   const { t } = useTranslation();

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import Restricted from 'permissions/components/Restricted';

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -1,7 +1,8 @@
-import React from 'react';
-
+// prettier-ignore
 import { render, screen } from 'tests/utils';
+
 import Restricted from 'permissions/components/Restricted';
+import React from 'react';
 
 const setup = async (props, rules) => {
   await render(

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -1,7 +1,8 @@
 import { render, screen } from 'tests/utils';
 
-import Restricted from 'permissions/components/Restricted';
 import React from 'react';
+
+import Restricted from 'permissions/components/Restricted';
 
 const setup = async (props, rules) => {
   await render(

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -1,6 +1,7 @@
-import React, { useState, useContext, useEffect, useRef } from 'react';
-import _ from 'lodash/fp';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
+
+import _ from 'lodash/fp';
 
 const defaultBehaviour = {
   isAllowedTo: () => Promise.resolve(false),

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import _ from 'lodash/fp';
+import { useSelector } from 'react-redux';
 
 const defaultBehaviour = {
   isAllowedTo: () => Promise.resolve(false),

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
+
+import notificationsReducer from 'notifications/notificationsSlice';
+
 import accountReducer from 'account/accountSlice';
 import groupReducer from 'group/groupSlice';
 import userHomeReducer from 'home/homeSlice';
 import landscapeReducer from 'landscape/landscapeSlice';
-import notificationsReducer from 'notifications/notificationsSlice';
 
 const createStore = intialState =>
   configureStore({

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,8 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
-
 import accountReducer from 'account/accountSlice';
-import userHomeReducer from 'home/homeSlice';
 import groupReducer from 'group/groupSlice';
+import userHomeReducer from 'home/homeSlice';
 import landscapeReducer from 'landscape/landscapeSlice';
 import notificationsReducer from 'notifications/notificationsSlice';
 

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
-import { createAsyncThunk as createAsyncThunkBase } from '@reduxjs/toolkit';
 
-import { addMessage } from 'notifications/notificationsSlice';
+import { createAsyncThunk as createAsyncThunkBase } from '@reduxjs/toolkit';
 import { signOut } from 'account/accountSlice';
 import { refreshToken } from 'account/auth';
 import { UNAUTHENTICATED } from 'account/authConstants';
+import { addMessage } from 'notifications/notificationsSlice';
 
 const executeAuthRequest = (dispatch, action) =>
   action().catch(async error => {

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -1,10 +1,11 @@
+import { createAsyncThunk as createAsyncThunkBase } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
 
-import { createAsyncThunk as createAsyncThunkBase } from '@reduxjs/toolkit';
+import { addMessage } from 'notifications/notificationsSlice';
+
 import { signOut } from 'account/accountSlice';
 import { refreshToken } from 'account/auth';
 import { UNAUTHENTICATED } from 'account/authConstants';
-import { addMessage } from 'notifications/notificationsSlice';
 
 const executeAuthRequest = (dispatch, action) =>
   action().catch(async error => {

--- a/src/state/utils.test.js
+++ b/src/state/utils.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from 'tests/utils';
 
-import { fetchAuthURLs } from 'account/accountSlice';
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+
+import { fetchAuthURLs } from 'account/accountSlice';
 
 const TestComponent = () => {
   const dispatch = useDispatch();

--- a/src/state/utils.test.js
+++ b/src/state/utils.test.js
@@ -1,4 +1,3 @@
-// prettier-ignore
 import { render, screen } from 'tests/utils';
 
 import { fetchAuthURLs } from 'account/accountSlice';

--- a/src/state/utils.test.js
+++ b/src/state/utils.test.js
@@ -1,8 +1,9 @@
+// prettier-ignore
+import { render, screen } from 'tests/utils';
+
+import { fetchAuthURLs } from 'account/accountSlice';
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-
-import { render, screen } from 'tests/utils';
-import { fetchAuthURLs } from 'account/accountSlice';
 
 const TestComponent = () => {
   const dispatch = useDispatch();

--- a/src/state/utils.test.js
+++ b/src/state/utils.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from 'tests/utils';
 
 import React, { useEffect } from 'react';
+
 import { useDispatch } from 'react-redux';
 
 import { fetchAuthURLs } from 'account/accountSlice';

--- a/src/terrasoBackend/api.js
+++ b/src/terrasoBackend/api.js
@@ -1,9 +1,11 @@
 import _ from 'lodash/fp';
 
+import logger from 'monitoring/logger';
+
 import { getToken } from 'account/auth';
 import { UNAUTHENTICATED } from 'account/authConstants';
+
 import { GRAPH_QL_ENDPOINT, TERRASO_API_URL } from 'config';
-import logger from 'monitoring/logger';
 
 const parseMessage = message => {
   try {

--- a/src/terrasoBackend/api.js
+++ b/src/terrasoBackend/api.js
@@ -1,9 +1,9 @@
 import _ from 'lodash/fp';
 
 import { getToken } from 'account/auth';
-import logger from 'monitoring/logger';
-import { TERRASO_API_URL, GRAPH_QL_ENDPOINT } from 'config';
 import { UNAUTHENTICATED } from 'account/authConstants';
+import { GRAPH_QL_ENDPOINT, TERRASO_API_URL } from 'config';
+import logger from 'monitoring/logger';
 
 const parseMessage = message => {
   try {

--- a/src/terrasoBackend/api.test.js
+++ b/src/terrasoBackend/api.test.js
@@ -1,5 +1,5 @@
-import * as terrasoApi from 'terrasoBackend/api';
 import { rollbar } from 'monitoring/rollbar';
+import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('monitoring/rollbar');
 

--- a/src/terrasoBackend/api.test.js
+++ b/src/terrasoBackend/api.test.js
@@ -1,4 +1,5 @@
 import { rollbar } from 'monitoring/rollbar';
+
 import * as terrasoApi from 'terrasoBackend/api';
 
 jest.mock('monitoring/rollbar');

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import { cleanup, render as rtlRender } from '@testing-library/react';
-import AppWrappers from 'common/components/AppWrappers';
-import { AXE_TEST_TIMEOUT } from 'config';
 import { axe, toHaveNoViolations } from 'jest-axe';
+
+import AppWrappers from 'common/components/AppWrappers';
 import rules from 'permissions/rules';
 import createStore from 'state/store';
+
+import { AXE_TEST_TIMEOUT } from 'config';
+
 import theme from 'theme';
 
 const executeAxe = process.env['TEST_A11Y'] === 'true';

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import { cleanup, render as rtlRender } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import { act } from 'react-dom/test-utils';
 
 import AppWrappers from 'common/components/AppWrappers';
 import rules from 'permissions/rules';

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render as rtlRender, cleanup } from '@testing-library/react';
-import { axe, toHaveNoViolations } from 'jest-axe';
 
+import { cleanup, render as rtlRender } from '@testing-library/react';
+import AppWrappers from 'common/components/AppWrappers';
 import { AXE_TEST_TIMEOUT } from 'config';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import rules from 'permissions/rules';
 import createStore from 'state/store';
 import theme from 'theme';
-import rules from 'permissions/rules';
-import AppWrappers from 'common/components/AppWrappers';
 
 const executeAxe = process.env['TEST_A11Y'] === 'true';
 

--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Card, Link, Stack, Typography } from '@mui/material';
-import LaunchIcon from '@mui/icons-material/Launch';
 import { useTranslation } from 'react-i18next';
-import theme from 'theme';
+
+import LaunchIcon from '@mui/icons-material/Launch';
+import { Card, Link, Stack, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
+
+import theme from 'theme';
 
 const Tool = ({ tool }) => {
   const { t } = useTranslation();

--- a/src/tool/components/Tool.js
+++ b/src/tool/components/Tool.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import LaunchIcon from '@mui/icons-material/Launch';

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -5,6 +5,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { Link, Stack, Typography } from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';
+
 import theme from 'theme';
 
 const ToolHomeCard = () => {

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
+
 import { Link, Stack, Typography } from '@mui/material';
 
 import HomeCard from 'home/components/HomeCard';

--- a/src/tool/components/ToolList.js
+++ b/src/tool/components/ToolList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 import { Typography } from '@mui/material';

--- a/src/tool/components/ToolList.js
+++ b/src/tool/components/ToolList.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+
 import { Typography } from '@mui/material';
 
 import { useDocumentTitle } from 'common/document';
-import Tool from 'tool/components/Tool';
-import PageHeader from 'layout/PageHeader';
 import PageContainer from 'layout/PageContainer';
+import PageHeader from 'layout/PageHeader';
 import theme from 'theme';
+import Tool from 'tool/components/Tool';
 
 const ToolList = ({ tools }) => {
   const { t } = useTranslation();

--- a/src/tool/components/ToolList.js
+++ b/src/tool/components/ToolList.js
@@ -6,8 +6,10 @@ import { Typography } from '@mui/material';
 import { useDocumentTitle } from 'common/document';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
-import theme from 'theme';
+
 import Tool from 'tool/components/Tool';
+
+import theme from 'theme';
 
 const ToolList = ({ tools }) => {
   const { t } = useTranslation();


### PR DESCRIPTION
## Description
Sorts the imports at the beginning oof each file. Adds a prettier plugin and configuration to handle the sorting.

Order is:
* tests/utils
* react
* @mui
* lodash
* third-party modules
* local modules

Tests will fail if `tests/utils` is imported too late, so all of those imports are moved to the top.