### PR TITLE
fix: increase size of drop pin button icon

### DIFF
--- a/src/gis/components/Map.css
+++ b/src/gis/components/Map.css
@@ -4,3 +4,8 @@
 .leaflet-control-geosearch .results > * {
   font-size: 15px;
 }
+
+.leaflet-draw.leaflet-control .leaflet-draw-draw-marker {
+  background-size: 900px 45px;
+  background-position: -413px;
+}


### PR DESCRIPTION
## Description
Increases the size of the drop pin icon by 50%

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #337.