### PR TITLE
fix: reorder map controls per spec

### DIFF
--- a/src/gis/components/Map.css
+++ b/src/gis/components/Map.css
@@ -4,3 +4,21 @@
 .leaflet-control-geosearch .results > * {
   font-size: 15px;
 }
+
+.leaflet-control-geosearch.leaflet-geosearch-bar {
+  margin: 10px;
+  left: 45px;
+}
+
+.leaflet-draw.leaflet-control {
+  left: 410px;
+}
+
+.leaflet-touch .leaflet-draw.leaflet-control {
+  right: 0;
+  left: inherit;
+}
+
+.leaflet-touch .leaflet-geosearch-bar form {
+  width: 130%;
+}

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -59,7 +59,7 @@ const LeafletDraw = props => {
     });
 
     return () => map.removeControl(drawControl);
-  }, [map, setPinLocation]);
+  }, [map, setPinLocation, isSmall]);
   return null;
 };
 

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -214,7 +214,7 @@ const Map = props => {
         enableSearch={props.enableSearch}
         enableDraw={props.enableDraw}
       />
-      {'undefined' !== typeof props.enableSearch && (
+      {props.enableSearch && (
         <ZoomControl position={isSmall ? 'bottomleft' : 'topleft'} />
       )}
       {props.children}

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -35,7 +35,6 @@ const LeafletDraw = props => {
   const map = useMap();
   const { setPinLocation } = props;
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
-  console.log(isSmall);
 
   useEffect(() => {
     const options = {

--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -8,15 +8,20 @@ import {
   MapContainer,
   Marker,
   TileLayer,
+  ZoomControl,
   useMap,
 } from 'react-leaflet';
 import { v4 as uuidv4 } from 'uuid';
+
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-geosearch/dist/geosearch.css';
 import 'gis/components/Map.css';
+
+import theme from 'theme';
 
 delete L.Icon.Default.prototype._getIconUrl;
 
@@ -29,10 +34,12 @@ L.Icon.Default.mergeOptions({
 const LeafletDraw = props => {
   const map = useMap();
   const { setPinLocation } = props;
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  console.log(isSmall);
 
   useEffect(() => {
     const options = {
-      position: 'topright',
+      position: isSmall ? 'topright' : 'topleft',
       draw: {
         polyline: false,
         polygon: false,
@@ -72,6 +79,7 @@ const LeafletSearch = props => {
     });
 
     map.addControl(searchControl);
+    map.removeControl(map.zoomControl);
 
     const getPinData = event => {
       if (event?.location?.lat) {
@@ -179,6 +187,7 @@ const Location = props => {
 
 const Map = props => {
   const [map, setMap] = useState();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   useEffect(() => {
     if (map?.target && props.center) {
@@ -206,7 +215,9 @@ const Map = props => {
         enableSearch={props.enableSearch}
         enableDraw={props.enableDraw}
       />
-
+      {'undefined' !== typeof props.enableSearch && (
+        <ZoomControl position={isSmall ? 'bottomleft' : 'topleft'} />
+      )}
       {props.children}
     </MapContainer>
   );


### PR DESCRIPTION
## Description
Makes search field top left and pin to the right of that.

<img width="313" alt="image" src="https://user-images.githubusercontent.com/86784/168381990-4473e424-f49e-4eea-bae9-113cbeb4c6ac.png">

### Checklist
- [X] Verified on mobile
- [X] Verified on desktop
