### PR TITLE
feat: social sharing of groups and landscapes

### DIFF
--- a/src/common/components/SocialShare.js
+++ b/src/common/components/SocialShare.js
@@ -1,0 +1,163 @@
+import { useMemo, useState } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import CloseIcon from '@mui/icons-material/Close';
+import EmailIcon from '@mui/icons-material/Email';
+import FacebookIcon from '@mui/icons-material/Facebook';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import theme from 'theme';
+
+const SocialShare = ({ name }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [buttonCopied, setButtonCopied] = useState(false);
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => {
+    setOpen(false);
+    setButtonCopied(false);
+  };
+
+  const pageUrl = window.location;
+
+  const shareText = useMemo(
+    () => encodeURIComponent(t('share.invite_text', { name, url: pageUrl })),
+    [name, pageUrl, t]
+  );
+
+  const shareViaEmail = () => {
+    const subject = encodeURIComponent(t('share.invite_subject', { name }));
+    window.open(`mailto:?subject=${subject}&body=${shareText}`);
+  };
+
+  const shareViaWhatsApp = () => {
+    window.open(`https://wa.me/?text=${shareText}`);
+  };
+
+  const shareViaFacebook = () => {
+    const url = encodeURIComponent(pageUrl);
+    window.open(`http://www.facebook.com/share.php?u=${url}`);
+  };
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(pageUrl);
+    setButtonCopied(true);
+  };
+
+  return (
+    <>
+      <Button variant="outlined" onClick={handleOpen}>
+        {t('share.button')}
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <DialogTitle
+          component={Stack}
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Typography variant="h2" sx={{ padding: 0 }}>
+            {t('share.title', { name: name })}
+          </Typography>
+          <IconButton onClick={handleClose} sx={{ marginLeft: 3 }}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent sx={{ paddingBottom: 5 }}>
+          <Typography sx={{ marginBottom: 1 }}>
+            {t('share.services')}
+          </Typography>
+          <Stack
+            direction={isSmall ? 'column' : 'row'}
+            justifyContent="space-between"
+          >
+            <Button
+              variant="outlined"
+              startIcon={<EmailIcon sx={{ paddingRight: 1 }} />}
+              onClick={shareViaEmail}
+            >
+              {t('share.email')}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={
+                <WhatsAppIcon
+                  sx={{
+                    paddingRight: 1,
+                  }}
+                />
+              }
+              onClick={shareViaWhatsApp}
+              sx={{
+                marginTop: {
+                  xs: 2,
+                  sm: 'auto',
+                },
+                marginBottom: {
+                  xs: 2,
+                  sm: 'auto',
+                },
+              }}
+            >
+              {t('share.whatsapp')}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<FacebookIcon sx={{ paddingRight: 1 }} />}
+              onClick={shareViaFacebook}
+            >
+              {t('share.facebook')}
+            </Button>
+          </Stack>
+          <Typography variant="h5" component="h2" sx={{ marginTop: 4 }}>
+            {t('share.copy')}
+          </Typography>
+          <Stack direction={isSmall ? 'column' : 'row'} sx={{ width: '100%' }}>
+            <TextField
+              size="small"
+              variant="outlined"
+              value={pageUrl}
+              fullWidth
+              InputProps={{
+                sx: {
+                  paddingRight: 0,
+                },
+                endAdornment: (
+                  <Button
+                    variant="outlined"
+                    onClick={copyToClipboard}
+                    sx={{ marginLeft: 2, minWidth: '100px' }}
+                  >
+                    {buttonCopied
+                      ? t('share.copy_button_done')
+                      : t('share.copy_button')}
+                  </Button>
+                ),
+              }}
+            />
+          </Stack>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default SocialShare;

--- a/src/common/components/SocialShare.test.js
+++ b/src/common/components/SocialShare.test.js
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from 'tests/utils';
+
+import SocialShare from './SocialShare';
+
+const setup = async () => {
+  await render(<SocialShare name="Test Name" />);
+};
+
+beforeEach(() => {
+  global.window.open = jest.fn();
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: jest.fn(),
+    },
+  });
+});
+
+test('SocialShare: Show buttons', async () => {
+  await setup();
+
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
+  );
+
+  expect(screen.getByRole('button', { name: 'Email' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'WhatsApp' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Facebook' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Copy Link' })).toBeInTheDocument();
+});
+
+test('SocialShare: Test links', async () => {
+  await setup();
+
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }))
+  );
+
+  // Email
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Email' }))
+  );
+  const emailCall = global.window.open.mock.calls[0];
+  expect(emailCall[0]).toStrictEqual(
+    `mailto:?subject=${encodeURIComponent(
+      'Join Test Name on Terraso'
+    )}&body=${encodeURIComponent(
+      'Check out Test Name on Terraso and join me: http://localhost/'
+    )}`
+  );
+
+  // WhatsApp
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'WhatsApp' }))
+  );
+  const whatsAppCall = global.window.open.mock.calls[1];
+  expect(whatsAppCall[0]).toStrictEqual(
+    `https://wa.me/?text=${encodeURIComponent(
+      'Check out Test Name on Terraso and join me: http://localhost/'
+    )}`
+  );
+
+  // Facebook
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Facebook' }))
+  );
+  const facebookCall = global.window.open.mock.calls[2];
+  expect(facebookCall[0]).toStrictEqual(
+    `http://www.facebook.com/share.php?u=${encodeURIComponent(
+      'http://localhost/'
+    )}`
+  );
+
+  // Copy
+  await act(async () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Link' }))
+  );
+  const copyCall = navigator.clipboard.writeText.mock.calls[0];
+  expect(copyCall[0].toString()).toStrictEqual('http://localhost/');
+});

--- a/src/common/components/Stepper.js
+++ b/src/common/components/Stepper.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import { useState } from 'react';
 
 import { Stepper as BaseStepper, Step, Typography } from '@mui/material';
 
 const Stepper = props => {
   const { steps } = props;
-  const [activeStepIndex, setActiveStepIndex] = React.useState(0);
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
 
   const activeStep = steps[activeStepIndex];
 

--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -18,6 +18,7 @@ import {
   Typography,
 } from '@mui/material';
 
+import SocialShare from 'common/components/SocialShare.js';
 import { useDocumentTitle } from 'common/document';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
@@ -84,6 +85,18 @@ const GroupCard = ({ group }) => {
             </Link>
           </Stack>
         )}
+        <Restricted permission="group.change" resource={group}>
+          <Button
+            variant="outlined"
+            component={RouterLink}
+            to={`/groups/${group.slug}/edit`}
+            sx={{
+              marginTop: theme.spacing(2),
+            }}
+          >
+            {t('group.view_update_button')}
+          </Button>
+        </Restricted>
       </CardContent>
     </Card>
   );
@@ -124,15 +137,7 @@ const GroupView = () => {
         }}
       >
         <PageHeader header={group.name} />
-        <Restricted permission="group.change" resource={group}>
-          <Button
-            variant="contained"
-            component={RouterLink}
-            to={`/groups/${group.slug}/edit`}
-          >
-            {t('group.view_update_button')}
-          </Button>
-        </Restricted>
+        <SocialShare name={group.name} />
       </Stack>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>

--- a/src/landscape/components/LandscapeNew.js
+++ b/src/landscape/components/LandscapeNew.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,7 +22,7 @@ const LandscapeNew = () => {
   const { saving, landscape, success } = useSelector(
     state => state.landscape.form
   );
-  const [updatedLandscape, setUpdatedLandscape] = React.useState();
+  const [updatedLandscape, setUpdatedLandscape] = useState();
 
   useDocumentTitle(t('landscape.form_new_document_title'));
 

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 
 import InlineHelp from 'common/components/InlineHelp';
+import SocialShare from 'common/components/SocialShare.js';
 import { useDocumentTitle } from 'common/document';
 import { countryNameForCode } from 'common/utils';
 import PageContainer from 'layout/PageContainer';
@@ -138,6 +139,7 @@ const LandscapeView = () => {
             {currentCountry?.name}
           </Typography>
         </div>
+        <SocialShare name={landscape.name} />
       </Stack>
       <Grid container spacing={2}>
         <Grid item xs={12} md={12}>

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -259,6 +259,19 @@
         "not_found_error_code": "Error code: 404",
         "not_found_help_message": "You can <1>let us know what went wrong</1>."
     },
+    "share": {
+        "button": "Share",
+        "title": "Share {{name}}",
+        "services": "Post the link in",
+        "copy": "Copy the link to share",
+        "copy_button": "Copy Link",
+        "copy_button_done": "Link Copied",
+        "invite_subject": "Join {{name}} on Terraso",
+        "invite_text": "Check out {{name}} on Terraso and join me: {{url}}",
+        "whatsapp": "WhatsApp",
+        "email": "Email",
+        "facebook": "Facebook"
+    },
     "form": {
         "required_label": "required",
         "validation_field_invalid": "{{path}} must be valid",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -258,6 +258,19 @@
         "not_found_error_code": "Código de error: 404",
         "not_found_help_message": "Puedes <1>contarnos qué salió mal</1>."
     },
+    "share": {
+        "button": "Comparte",
+        "title": "Comparte {{name}}",
+        "services": "Publicar el enlace en",
+        "copy": "Copia el enlace para compartir",
+        "copy_button": "Copia el enlace",
+        "copy_button_done": "Copiada",
+        "invite_subject": "Únete a {{name}} en Terraso",
+        "invite_text": "Echa un vistazo a {{name}} en Terraso y únete: {{url}}",
+        "whatsapp": "WhatsApp",
+        "email": "Email",
+        "facebook": "Facebook"
+    },
     "form": {
         "required_label": "Obligatorio",
         "validation_field_invalid": "{{path}} debe ser válido",


### PR DESCRIPTION
## Description
Adds a share button to group and landscape pages. When clicked, a modal appears, allowing the user to share via email, WhatsApp and Facebook and to copy the link to the clipboard.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [X] English strings reviewed and copyedited
- [x] Strings are localized
- [X] Verified on mobile
- [X] Verified on desktop
- [x] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues
Fixes #353.