### PR TITLE
fix: use same size for both subheadings in social share dialog

### DIFF
--- a/src/common/components/SocialShare.js
+++ b/src/common/components/SocialShare.js
@@ -127,9 +127,7 @@ const SocialShare = ({ name }) => {
               {t('share.facebook')}
             </Button>
           </Stack>
-          <Typography sx={{ marginTop: 4 }}>
-            {t('share.copy')}
-          </Typography>
+          <Typography sx={{ marginTop: 4 }}>{t('share.copy')}</Typography>
           <Stack direction={isSmall ? 'column' : 'row'} sx={{ width: '100%' }}>
             <TextField
               size="small"

--- a/src/common/components/SocialShare.js
+++ b/src/common/components/SocialShare.js
@@ -127,7 +127,7 @@ const SocialShare = ({ name }) => {
               {t('share.facebook')}
             </Button>
           </Stack>
-          <Typography variant="h5" component="h2" sx={{ marginTop: 4 }}>
+          <Typography sx={{ marginTop: 4 }}>
             {t('share.copy')}
           </Typography>
           <Stack direction={isSmall ? 'column' : 'row'} sx={{ width: '100%' }}>


### PR DESCRIPTION
## Description
Use the same size headings through social share dialog.

<img width="659" alt="image" src="https://user-images.githubusercontent.com/86784/171426124-da3edff6-3ba1-415a-a069-3851cf1ef6a4.png">

### Related Issues
Fixes #365.