### PR TITLE
fix: match heights of member and about cards

### DIFF
--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -51,7 +51,16 @@ const MemberJoinButton = withProps(GroupMemberJoin, {
 const GroupCard = ({ group }) => {
   const { t } = useTranslation();
   return (
-    <Card component="section" aria-labelledby="group-view-card-title">
+    <Card
+      component="section"
+      aria-labelledby="group-view-card-title"
+      style={{
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'flex-start',
+        flexDirection: 'column',
+      }}
+    >
       <CardHeader
         disableTypography
         title={
@@ -60,7 +69,7 @@ const GroupCard = ({ group }) => {
           </Typography>
         }
       />
-      <CardContent>
+      <CardContent sx={{ display: 'flex', flexGrow: 1 }}>
         <Typography variant="body2" color="text.secondary">
           {group.description}
         </Typography>
@@ -161,10 +170,10 @@ const GroupView = () => {
           <SocialShare name={group.name} />
         </Stack>
         <Grid container spacing={2}>
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} md={6} style={{ display: 'flex' }}>
             <GroupCard group={group} />
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} md={6} style={{ display: 'flex' }}>
             <GroupMembershipCard
               onViewMembers={() => navigate(`/groups/${group.slug}/members`)}
             />

--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -69,12 +69,14 @@ const GroupCard = ({ group }) => {
           </Typography>
         }
       />
-      <CardContent sx={{ display: 'flex', flexGrow: 1 }}>
+      <CardContent>
         <Typography variant="body2" color="text.secondary">
           {group.description}
         </Typography>
       </CardContent>
-      <CardContent>
+      <CardContent
+        sx={{ display: 'flex', flexGrow: 1, flexDirection: 'column' }}
+      >
         {group.email && (
           <Stack
             direction="row"
@@ -96,6 +98,8 @@ const GroupCard = ({ group }) => {
             </Link>
           </Stack>
         )}
+      </CardContent>
+      <CardContent>
         <Restricted permission="group.change" resource={group}>
           <Button
             variant="outlined"

--- a/src/group/membership/components/GroupMembershipCard.js
+++ b/src/group/membership/components/GroupMembershipCard.js
@@ -91,6 +91,7 @@ const GroupMembershipCard = props => {
         width: '100%',
         display: 'flex',
         flexDirection: 'column',
+        justifyContent: 'space-between',
       }}
     >
       <CardHeader

--- a/src/group/membership/components/GroupMembershipCard.js
+++ b/src/group/membership/components/GroupMembershipCard.js
@@ -84,7 +84,15 @@ const GroupMembershipCard = props => {
   const membersInfo = _.getOr([], 'membersInfo', group);
 
   return (
-    <Card component="section" aria-labelledby="membership-card-title">
+    <Card
+      component="section"
+      aria-labelledby="membership-card-title"
+      style={{
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <CardHeader
         disableTypography
         title={
@@ -99,7 +107,7 @@ const GroupMembershipCard = props => {
         onViewMembers={onViewMembers}
       />
       {fetching ? null : (
-        <CardActions>
+        <CardActions sx={{ display: 'block', paddingBottom: '24px' }}>
           <GroupMembershipJoinLeaveButton />
         </CardActions>
       )}

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -71,12 +71,12 @@ const LandscapeCard = ({ landscape }) => {
           </Typography>
         }
       />
-      <CardContent sx={{ display: 'flex', flexGrow: 1 }}>
+      <CardContent>
         <Typography variant="body2" color="text.secondary">
           {landscape.description}
         </Typography>
       </CardContent>
-      <CardContent>
+      <CardContent sx={{ display: 'flex', flexGrow: 1 }}>
         {landscape.website && (
           <Stack direction="row" alignItems="center" spacing={1}>
             <PublicIcon sx={{ color: 'gray.lite1' }} />
@@ -85,6 +85,8 @@ const LandscapeCard = ({ landscape }) => {
             </Link>
           </Stack>
         )}
+      </CardContent>
+      <CardContent>
         <Restricted permission="landscape.change" resource={landscape}>
           <Button
             variant="outlined"

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -42,8 +42,6 @@ import SharedDataCard from 'sharedData/components/SharedDataCard';
 
 import { withProps } from 'react-hoc';
 
-import theme from 'theme';
-
 const MemberLeaveButton = withProps(LandscapeMemberLeave, {
   renderLabel: () => 'landscape.view_leave_label',
 });
@@ -55,23 +53,30 @@ const MemberJoinButton = withProps(GroupMemberJoin, {
 const LandscapeCard = ({ landscape }) => {
   const { t } = useTranslation();
   return (
-    <Card component="section" aria-labelledby="landscape-view-card-title">
+    <Card
+      component="section"
+      aria-labelledby="landscape-view-card-title"
+      style={{
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'flex-start',
+        flexDirection: 'column',
+      }}
+    >
       <CardHeader
         disableTypography
         title={
-          <Typography
-            variant="h2"
-            id="landscape-view-card-title"
-            sx={{ paddingTop: 0 }}
-          >
+          <Typography variant="h2" id="landscape-view-card-title">
             {t('landscape.view_card_title', { name: landscape.name })}
           </Typography>
         }
       />
-      <CardContent>
+      <CardContent sx={{ display: 'flex', flexGrow: 1 }}>
         <Typography variant="body2" color="text.secondary">
           {landscape.description}
         </Typography>
+      </CardContent>
+      <CardContent>
         {landscape.website && (
           <Stack direction="row" alignItems="center" spacing={1}>
             <PublicIcon sx={{ color: 'gray.lite1' }} />
@@ -85,9 +90,6 @@ const LandscapeCard = ({ landscape }) => {
             variant="outlined"
             component={RouterLink}
             to={`/landscapes/${landscape.slug}/edit`}
-            sx={{
-              marginTop: theme.spacing(1),
-            }}
           >
             {t('landscape.view_update_button')}
           </Button>
@@ -210,10 +212,10 @@ const LandscapeView = () => {
               </Restricted>
             </Card>
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} md={6} style={{ display: 'flex' }}>
             <LandscapeCard landscape={landscape} />
           </Grid>
-          <Grid item xs={12} md={6}>
+          <Grid item xs={12} md={6} style={{ display: 'flex' }}>
             <GroupMembershipCard
               onViewMembers={() =>
                 navigate(`/landscapes/${landscape.slug}/members`)


### PR DESCRIPTION
## Description
Match heights of member and about cards on group and landscape pages.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #362.

Based on https://stackoverflow.com/questions/55824260/same-height-cards-in-material-ui