### PR TITLE
fix: use "landscape" or "group" as appropriate on shared data card

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -252,7 +252,7 @@
     },
     "sharedData": {
         "title": "Shared files",
-        "description_with_files": "Only the members of your {{item}} can download the files. <1>Read more about sharing files</1>.",
+        "description_with_files": "Only the members of your {{entityType}} can download the files. <1>Read more about sharing files</1>.",
         "item_group": "group",
         "item_landscape": "landscape",
         "description_without_files": "Upload your data files ({{extensions}}) and share them with the {{name}} members. Only members can download the files. <1>Read more about sharing files</1>.",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -252,7 +252,9 @@
     },
     "sharedData": {
         "title": "Shared files",
-        "description_with_files": "Only the members of your group can download the files. <1>Read more about sharing files</1>.",
+        "description_with_files": "Only the members of your {{item}} can download the files. <1>Read more about sharing files</1>.",
+        "item_group": "group",
+        "item_landscape": "landscape",
         "description_without_files": "Upload your data files ({{extensions}}) and share them with the {{name}} members. Only members can download the files. <1>Read more about sharing files</1>.",
         "learn_more_url": "https://terraso.org/help/shared-files/",
         "upload_button": "Share Files",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -253,8 +253,8 @@
     "sharedData": {
         "title": "Shared files",
         "description_with_files": "Only the members of your {{entityType}} can download the files. <1>Read more about sharing files</1>.",
-        "item_group": "group",
-        "item_landscape": "landscape",
+        "entity_type_group": "group",
+        "entity_type_landscape": "landscape",
         "description_without_files": "Upload your data files ({{extensions}}) and share them with the {{name}} members. Only members can download the files. <1>Read more about sharing files</1>.",
         "learn_more_url": "https://terraso.org/help/shared-files/",
         "upload_button": "Share Files",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -271,7 +271,9 @@
     },
     "sharedData": {
         "title": "Archivos compartidos",
-        "description_with_files": "Solo los miembros de tu grupo pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
+        "description_with_files": "Solo los miembros de tu {{item}} pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
+        "item_group": "groupo",
+        "item_landscape": "paisaje",
         "description_without_files": "Sube tus archivos de datos ({{extensions}}) y compártelos con los miembros del {{name}}. Solo los miembros de tu grupo pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
         "learn_more_url": "https://terraso.org/es/ayuda/compartir-archivos/",
         "upload_button": "Compartir archivos",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -271,7 +271,7 @@
     },
     "sharedData": {
         "title": "Archivos compartidos",
-        "description_with_files": "Solo los miembros de tu {{item}} pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
+        "description_with_files": "Solo los miembros de tu {{entityType}} pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
         "item_group": "groupo",
         "item_landscape": "paisaje",
         "description_without_files": "Sube tus archivos de datos ({{extensions}}) y compártelos con los miembros del {{name}}. Solo los miembros de tu grupo pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -272,7 +272,7 @@
     "sharedData": {
         "title": "Archivos compartidos",
         "description_with_files": "Solo los miembros de tu {{entityType}} pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
-        "item_group": "groupo",
+        "entity_type_group": "grupo",
         "item_landscape": "paisaje",
         "description_without_files": "Sube tus archivos de datos ({{extensions}}) y compártelos con los miembros del {{name}}. Solo los miembros de tu grupo pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
         "learn_more_url": "https://terraso.org/es/ayuda/compartir-archivos/",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -273,7 +273,7 @@
         "title": "Archivos compartidos",
         "description_with_files": "Solo los miembros de tu {{entityType}} pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
         "entity_type_group": "grupo",
-        "item_landscape": "paisaje",
+        "entity_type_landscape": "paisaje",
         "description_without_files": "Sube tus archivos de datos ({{extensions}}) y compártelos con los miembros del {{name}}. Solo los miembros de tu grupo pueden descargar los archivos. <1>Más información sobre cómo compartir archivos</1>.",
         "learn_more_url": "https://terraso.org/es/ayuda/compartir-archivos/",
         "upload_button": "Compartir archivos",

--- a/src/sharedData/components/SharedDataCard.js
+++ b/src/sharedData/components/SharedDataCard.js
@@ -86,7 +86,7 @@ const SharedFilesCard = props => {
                   ext => `*.${ext}`
                 ).join(', '),
                 name: owner.name,
-                item: owner.defaultGroup
+                entityType: owner.defaultGroup
                   ? t('sharedData.item_landscape')
                   : t('sharedData.item_group'),
               }}

--- a/src/sharedData/components/SharedDataCard.js
+++ b/src/sharedData/components/SharedDataCard.js
@@ -86,6 +86,9 @@ const SharedFilesCard = props => {
                   ext => `*.${ext}`
                 ).join(', '),
                 name: owner.name,
+                item: owner.defaultGroup
+                  ? t('sharedData.item_landscape')
+                  : t('sharedData.item_group'),
               }}
             >
               Prefix

--- a/src/sharedData/components/SharedDataCard.js
+++ b/src/sharedData/components/SharedDataCard.js
@@ -87,8 +87,8 @@ const SharedFilesCard = props => {
                 ).join(', '),
                 name: owner.name,
                 entityType: owner.defaultGroup
-                  ? t('sharedData.item_landscape')
-                  : t('sharedData.item_group'),
+                  ? t('sharedData.entity_type_landscape')
+                  : t('sharedData.entity_type_group'),
               }}
             >
               Prefix


### PR DESCRIPTION
## Description
Update the shared files card to use "landscape" or "group" as appropriate (and not just "group").

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [X] Strings are localized

### Related Issues
Fixes #391.