### PR TITLE
fix: remove quotes and change capitalization for shared files card

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -85,7 +85,7 @@
         "members_list_column_actions_description": "Actions",
         "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). There should at least be one manager.",
         "unique": "The group “{{body.variables.input.name}}” already exists.",
-        "shared_data_upload_title": "Share files with “{{name}}“"
+        "shared_data_upload_title": "Share Files with {{name}}"
     },
     "tool": {
         "requirements": "System requirements",
@@ -248,7 +248,7 @@
         "form_location_select": "Select location",
         "form_name_placeholder": "Your landscape’s official name",
         "boundaries_file_no_accepted": "The file(s) cannot be added.",
-        "shared_data_upload_title": "Share files with “{{name}}“"
+        "shared_data_upload_title": "Share Files with {{name}}"
     },
     "sharedData": {
         "title": "Shared files",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -85,7 +85,7 @@
         "members_list_column_actions_description": "Acciones",
         "delete_not_allowed_manager_count": "$t(terraso_api.delete_not_allowed_base). Debe existir al menos un administrador.",
         "unique": "El grupo “{{body.variables.input.name}}” ya existe.",
-        "shared_data_upload_title": "Compartir archivos con “{{name}}“"
+        "shared_data_upload_title": "Compartir archivos con {{name}}"
     },
     "tool": {
         "avilability": "Disponibilidad",
@@ -249,7 +249,7 @@
         "form_location_select": "Selecciona una ubicación",
         "form_name_placeholder": "El nombre oficial de tu paisaje",
         "boundaries_file_no_accepted": "No se pueden agregar los archivos.",
-        "shared_data_upload_title": "Compartir archivos con “{{name}}“"
+        "shared_data_upload_title": "Compartir archivos con {{name}}"
     },
     "common": {
         "dialog_cancel_label": "Cancelar",


### PR DESCRIPTION
## Description
Update capitalization and quotation marks for shared files card.

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [X] Strings are localized

### Related Issues
Fixes #387.