### PR TITLE
fix: scroll to top between steps when creating landscapes

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -31,3 +31,9 @@ export const countryNameForCode = code => {
 // from https://stackoverflow.com/a/44325124; allow comma operator for speed
 export const countryMap = countries =>
   countries.reduce((obj, item) => ((obj[item.code] = item.name), obj), {}); // eslint-disable-line no-sequences
+
+export const scrollToNavBar = () => {
+  document
+    .getElementById('main-navigation')
+    .scrollIntoView({ behavior: 'smooth' });
+};

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -35,5 +35,5 @@ export const countryMap = countries =>
 export const scrollToNavBar = () => {
   document
     .getElementById('main-navigation')
-    .scrollIntoView({ behavior: 'smooth' });
+    ?.scrollIntoView({ behavior: 'smooth' });
 };

--- a/src/landscape/components/LandscapeForm/BoundaryStep.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStep.js
@@ -8,7 +8,7 @@ import PinDropIcon from '@mui/icons-material/PinDrop';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import { Button, Link, Paper, Stack, Typography } from '@mui/material';
 
-import { countryNameForCode } from 'common/utils';
+import { countryNameForCode, scrollToNavBar } from 'common/utils';
 import PageHeader from 'layout/PageHeader';
 
 import { getPlaceInfoByName } from 'gis/gisService';
@@ -160,7 +160,10 @@ const BoundaryOptions = props => {
             key={index}
             fullWidth
             variant="outlined"
-            onClick={option.onClick}
+            onClick={() => {
+              option.onClick();
+              scrollToNavBar();
+            }}
             sx={{
               justifyContent: 'start',
               padding: 4,

--- a/src/landscape/components/LandscapeForm/BoundaryStep.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStep.js
@@ -124,6 +124,11 @@ const BoundaryOptions = props => {
   const { t } = useTranslation();
   const { landscape, setOption, setActiveStepIndex, save } = props;
 
+  const onOptionClick = option => () => {
+    option.onClick();
+    scrollToNavBar();
+  };
+
   const options = [
     {
       Icon: UploadFileIcon,
@@ -141,6 +146,7 @@ const BoundaryOptions = props => {
       onClick: () => save(landscape),
     },
   ];
+
   return (
     <>
       <PageHeader
@@ -160,10 +166,7 @@ const BoundaryOptions = props => {
             key={index}
             fullWidth
             variant="outlined"
-            onClick={() => {
-              option.onClick();
-              scrollToNavBar();
-            }}
+            onClick={onOptionClick(option)}
             sx={{
               justifyContent: 'start',
               padding: 4,

--- a/src/landscape/components/LandscapeForm/InfoStep.js
+++ b/src/landscape/components/LandscapeForm/InfoStep.js
@@ -7,7 +7,12 @@ import * as yup from 'yup';
 
 import { MenuItem, Select, Typography } from '@mui/material';
 
-import { countriesList, countryMap, transformURL } from 'common/utils';
+import {
+  countriesList,
+  countryMap,
+  scrollToNavBar,
+  transformURL,
+} from 'common/utils';
 import Form from 'forms/components/Form';
 import PageHeader from 'layout/PageHeader';
 
@@ -117,6 +122,7 @@ const InfoStep = props => {
         validationSchema={VALIDATION_SCHEMA}
         onSave={updatedLandscape => {
           setUpdatedLandscape(updatedLandscape);
+          scrollToNavBar();
         }}
         saveLabel={
           isNew ? 'landscape.form_info_next' : 'landscape.form_save_label'

--- a/src/landscape/components/LandscapeForm/InfoStep.js
+++ b/src/landscape/components/LandscapeForm/InfoStep.js
@@ -108,6 +108,11 @@ const InfoStep = props => {
     ? t('landscape.form_edit_title', { name: _.getOr('', 'name', landscape) })
     : t('landscape.form_new_title');
 
+  const onSave = updatedLandscape => {
+    setUpdatedLandscape(updatedLandscape);
+    scrollToNavBar();
+  };
+
   return (
     <>
       <PageHeader
@@ -120,10 +125,7 @@ const InfoStep = props => {
         fields={FORM_FIELDS}
         values={landscape}
         validationSchema={VALIDATION_SCHEMA}
-        onSave={updatedLandscape => {
-          setUpdatedLandscape(updatedLandscape);
-          scrollToNavBar();
-        }}
+        onSave={onSave}
         saveLabel={
           isNew ? 'landscape.form_info_next' : 'landscape.form_save_label'
         }


### PR DESCRIPTION
## Description
When creating a landscape, scroll to the top of the viewport after each step.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #397.