### PR TITLE
fix: add margin to disclaimer text on login screen on mobile

### DIFF
--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -17,6 +17,8 @@ import { fetchAuthURLs } from 'account/accountSlice';
 
 import logo from 'assets/logo.svg';
 
+import theme from 'theme';
+
 const appendReferrer = (url, referrer) =>
   referrer ? `${url}&state=${referrer}` : url;
 
@@ -42,7 +44,7 @@ const AccountForm = () => {
       direction="column"
       alignItems="center"
       justifyContent="center"
-      style={{ height: '80vh' }}
+      style={{ height: '80vh', margin: `auto ${theme.spacing(2)}` }}
     >
       <Stack sx={{ maxWidth: 'sm' }} alignItems="center">
         <PageHeader header={t('account.welcome_to')} />


### PR DESCRIPTION
## Description
Add margin to disclaimer text on login screen on mobile.

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #404.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/86784/172193737-ac91812a-87d3-49d3-a16d-f7cda1579fe0.png">