### PR TITLE
fix: make list_new_description consistent for groups and landscapes

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -56,7 +56,7 @@
         "default_content": "Groups connect people with common interests and needs with and across landscapes.",
         "form_new_description": "Create a group to connect people with common interests and needs. Groups exist for people within and across landscapes.",
         "list_description": "A group can be an existing organization (like a landscape partnership or NGO) or any collection of people with a common interest.",
-        "list_new_description": "Can’t find the organizations or groups you are affiliated with? Create a group for it.",
+        "list_new_description": "Can’t find the organizations or groups you are affiliated with? Add it to Terraso.",
         "form_description_placeholder": "A short description of your group (600 characters maximum)",
         "form_email_placeholder": "info@mygroup.org",
         "form_website_placeholder": "https://www.mygroup.org",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -54,7 +54,7 @@
         "default_content": "Los grupos conectan a las personas con intereses y necesidades comunes dentro y fuera de los paisajes.",
         "form_new_description": "Cree un grupo para conectarse con personas que comparten sus intereses y necesidades. Hay grupos para personas en cada uno de los paisajes.",
         "list_description": "Un grupo puede ser una organización existente (como una asociación de paisajes o una ONG) o cualquier grupo de personas con un interés común.",
-        "list_new_description": "¿No puede encontrar las organizaciones o los grupos a los que está afiliado? Añádelo a Terraso.",
+        "list_new_description": "¿No puedes encontrar las organizaciones o los grupos a los que estás afiliado? Añádelo a Terraso.",
         "form_description_placeholder": "Una breve descripción de su grupo (máximo 600 caracteres)",
         "form_email_placeholder": "info@migroupo.org",
         "form_website_placeholder": "https://www.migroupo.org",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -54,7 +54,7 @@
         "default_content": "Los grupos conectan a las personas con intereses y necesidades comunes dentro y fuera de los paisajes.",
         "form_new_description": "Cree un grupo para conectarse con personas que comparten sus intereses y necesidades. Hay grupos para personas en cada uno de los paisajes.",
         "list_description": "Un grupo puede ser una organización existente (como una asociación de paisajes o una ONG) o cualquier grupo de personas con un interés común.",
-        "list_new_description": "¿No puede encontrar las organizaciones o los grupos a los que está afiliado? Cree un grupo para ellos.",
+        "list_new_description": "¿No puede encontrar las organizaciones o los grupos a los que está afiliado? Añádelo a Terraso.",
         "form_description_placeholder": "Una breve descripción de su grupo (máximo 600 caracteres)",
         "form_email_placeholder": "info@migroupo.org",
         "form_website_placeholder": "https://www.migroupo.org",


### PR DESCRIPTION
## Description
make the list_new_description consistent for groups and landscapes

### Checklist
- [X] English strings reviewed and copyedited
- [X] Strings are localized