### PR TITLE
fix: make footer same width as the rest of the page

### DIFF
--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -89,10 +89,7 @@ const Footer = () => {
         width: '100%',
         background: palette.secondary.main,
         color: palette.white,
-        padding: {
-          xs: spacing(2),
-          md: `${spacing(2)} ${spacing(10)} ${spacing(2)} ${spacing(10)}`,
-        },
+        padding: spacing(2),
       }}
     >
       <Grid item xs={12} md={8} component={LinksContainer}>

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
-import { Grid, Link, Typography } from '@mui/material';
+import { Grid, Link } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import theme from 'theme';
@@ -63,6 +63,9 @@ const LinksContainer = props => (
       padding: 0,
       margin: 0,
     }}
+    style={{
+      maxWidth: '100%',
+    }}
     justifyContent="flex-start"
     alignItems="center"
     {...props}
@@ -84,38 +87,54 @@ const Footer = () => {
     <Grid
       container
       component="footer"
-      justifyContent="space-between"
       sx={{
-        width: '100%',
         background: palette.secondary.main,
         color: palette.white,
-        padding: spacing(2),
       }}
+      justifyContent="space-between"
     >
-      <Grid item xs={12} md={8} component={LinksContainer}>
-        {footerLinks.map((link, index) => (
-          <FooterLink
-            key={index}
-            link={link}
-            showBorder={isBig && index < footerLinks.length - 1}
-          />
-        ))}
-      </Grid>
       <Grid
-        item
-        xs={12}
-        md="auto"
-        component={Typography}
-        variant="body2"
         sx={{
-          textAlign: 'right',
-          paddingTop: {
-            xs: spacing(1),
-            md: 0,
-          },
+          width: '100%',
+          margin: '0 auto',
+          padding: spacing(2),
+          maxWidth: 1200,
         }}
       >
-        © {year} Tech Matters
+        <Grid item xs={12} sm={8} component={LinksContainer}>
+          {footerLinks.map((link, index) => (
+            <FooterLink
+              key={index}
+              link={link}
+              showBorder={isBig && index < footerLinks.length - 1}
+            />
+          ))}
+          <Grid
+            item
+            component="li"
+            sx={{
+              flexGrow: 1,
+            }}
+          >
+            &nbsp;
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sm="auto"
+            component="li"
+            variant="body2"
+            sx={{
+              textAlign: 'right',
+              paddingTop: {
+                xs: spacing(1),
+                sm: 0,
+              },
+            }}
+          >
+            © {year} Tech Matters
+          </Grid>
+        </Grid>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
## Description
On desktop, make the footer same width as the rest of the page

### Before
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/86784/173489154-b2efa8c1-5d86-4414-91f9-b7a1bdf8d75f.png">

### After
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/86784/173489367-0dbe784d-7876-47c9-a966-02c2b00d5b72.png">
