### PR TITLE
fix: correct grammar in group intro message

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -54,7 +54,7 @@
         "form_cancel_label": "Cancel",
         "view_join_label": "Join Group",
         "view_leave_label": "Leave Group",
-        "default_content": "Groups connect people with common interests and needs with and across landscapes.",
+        "default_content": "Groups connect people with common interests and needs within and across landscapes.",
         "form_new_description": "Create a group to connect people with common interests and needs. Groups exist for people within and across landscapes.",
         "list_description": "A group can be an existing organization (like a landscape partnership or NGO) or any collection of people with a common interest.",
         "list_new_description": "Can’t find the organizations or groups you are affiliated with? Add it to Terraso.",


### PR DESCRIPTION
## Description
Fix a grammatical error in group intro text.

### Checklist
- [X] English strings reviewed and copyedited
- [x] Strings are localized