### PR TITLE
Feat: replaced warning icon with notification bell for pending members

### DIFF
--- a/src/group/membership/components/GroupMembershipPendingWarning.js
+++ b/src/group/membership/components/GroupMembershipPendingWarning.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Trans } from 'react-i18next';
 
-import WarningIcon from '@mui/icons-material/Warning';
+import NotificationImportantIcon from '@mui/icons-material/NotificationImportant';
 import { Link, Stack, Typography } from '@mui/material';
 
 import { withProps } from 'react-hoc';
@@ -22,7 +22,7 @@ const GroupMembershipPendingWarning = props => {
 
   return (
     <Stack direction="row" spacing={1} sx={sx}>
-      <WarningIcon sx={{ color: 'gray.mid2' }} />
+      <NotificationImportantIcon sx={{ color: 'gray.mid2' }} />
       <Trans i18nKey="group.members_pending_message" count={count}>
         <Typography>
           <CountComponent>link</CountComponent>

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -189,7 +189,7 @@
         "skip_to_main_navigation": "Skip to main navigation"
     },
     "landscape": {
-        "create": "Create a Landscape",
+        "create": "Add a Landscape",
         "home_title": "Landscapes",
         "home_default_title": "Landscape",
         "form_edit_title": "Update the “{{name}}” Landscape",
@@ -207,7 +207,7 @@
         "list_join_button": "Connect",
         "list_member_button": "Member",
         "list_manager_button": "Manager",
-        "list_new_button": "Create Landscape",
+        "list_new_button": "Add Landscape",
         "members_remove_confirmation_button": "Remove Member",
         "list_column_name": "Landscape",
         "role_member": "Member",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -189,7 +189,7 @@
         "skip_to_main_navigation": "Skip to main navigation"
     },
     "landscape": {
-        "create": "Add a Landscape",
+        "create": "Create a Landscape",
         "home_title": "Landscapes",
         "home_default_title": "Landscape",
         "form_edit_title": "Update the “{{name}}” Landscape",
@@ -207,7 +207,7 @@
         "list_join_button": "Connect",
         "list_member_button": "Member",
         "list_manager_button": "Manager",
-        "list_new_button": "Add Landscape",
+        "list_new_button": "Create Landscape",
         "members_remove_confirmation_button": "Remove Member",
         "list_column_name": "Landscape",
         "role_member": "Member",


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Replaced warning icon with notification bell icon for pending members.

### Checklist
- [x] Corresponding issue has been opened
- [x] English strings reviewed and copyedited
- [x] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop
- [x] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))


### Related Issues
Fixes #443 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
<img width="388" alt="image" src="https://user-images.githubusercontent.com/81892579/180245183-7e2007bd-51f7-471a-994a-c699a31e1386.png">
