### PR TITLE
fix: Make footer more accessible

### DIFF
--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -3,8 +3,9 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
-import { Grid, Link } from '@mui/material';
+import { Grid, Link, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { visuallyHidden } from '@mui/utils';
 
 import theme from 'theme';
 
@@ -93,6 +94,9 @@ const Footer = () => {
       }}
       justifyContent="space-between"
     >
+      <Typography sx={visuallyHidden} variant="h2">
+        {t('footer.heading')}
+      </Typography>
       <Grid
         sx={{
           width: '100%',

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -100,6 +100,8 @@ const Footer = () => {
           padding: spacing(2),
           maxWidth: 1200,
         }}
+        aria-label="Footer"
+        component="nav"
       >
         <Grid item xs={12} sm={8} component={LinksContainer}>
           {footerLinks.map((link, index) => (

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -103,7 +103,13 @@ const Footer = () => {
         aria-label="Footer"
         component="nav"
       >
-        <Grid item xs={12} sm={8} component={LinksContainer}>
+        <Grid
+          item
+          xs={12}
+          sm={8}
+          component={LinksContainer}
+          aria-label="Footer Navigation"
+        >
           {footerLinks.map((link, index) => (
             <FooterLink
               key={index}

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -80,7 +80,7 @@ const Footer = () => {
   // Convert to Array. Remove items where URL is #. Return values from new array.
   // IN: {"help":{"text":"Terraso Help","url":"https://terraso.org/help/"}, "terms":{"text":"Terms of Use","url":"#"}}
   // OUT: [{"text":"Terraso Help", "url":"https://terraso.org/help/"}]
-  const footerLinks = Object.entries(t('footer', { returnObjects: true }))
+  const footerLinks = Object.entries(t('footer.links', { returnObjects: true }))
     .filter(item => item[1].url !== '#')
     .map(item => item[1]);
 
@@ -104,7 +104,7 @@ const Footer = () => {
           padding: spacing(2),
           maxWidth: 1200,
         }}
-        aria-label="Footer"
+        aria-label={t('footer.heading')}
         component="nav"
       >
         <Grid
@@ -112,7 +112,7 @@ const Footer = () => {
           xs={12}
           sm={8}
           component={LinksContainer}
-          aria-label="Footer Navigation"
+          aria-label={t('footer.navigation')}
         >
           {footerLinks.map((link, index) => (
             <FooterLink

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -173,7 +173,7 @@
     },
     "footer": {
         "heading": "Footer",
-        "navgiation": "Footer Navigation",
+        "navigation": "Footer Navigation",
         "links": {
             "help": { "text": "Terraso Help", "url": "https://terraso.org/help/" },
             "contact": { "text": "Contact", "to": "/contact" },

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -172,12 +172,16 @@
         "form_language_label": "Language"
     },
     "footer": {
-        "help": { "text": "Terraso Help", "url": "https://terraso.org/help/" },
-        "contact": { "text": "Contact", "to": "/contact" },
-        "terms": { "text": "Terms of Use", "url": "#" },
-        "privacy": { "text": "Privacy Policy", "url": "https://techmatters.org/privacy-policy/" },
-        "data": { "text": "Data Policy", "url": "#"},
-        "about": { "text": "About Terraso", "url": "https://terraso.org/" }
+        "heading": "Footer",
+        "navgiation": "Footer Navigation",
+        "links": {
+            "help": { "text": "Terraso Help", "url": "https://terraso.org/help/" },
+            "contact": { "text": "Contact", "to": "/contact" },
+            "terms": { "text": "Terms of Use", "url": "#" },
+            "privacy": { "text": "Privacy Policy", "url": "https://techmatters.org/privacy-policy/" },
+            "data": { "text": "Data Policy", "url": "#"},
+            "about": { "text": "About Terraso", "url": "https://terraso.org/" }
+        }
     },
     "navigation": {
         "home": "Home",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -172,8 +172,8 @@
         "form_language_label": "Idioma"
     },
     "footer": {
-        "heading": "Footer",
-        "navigation": "Footer Navigation",
+        "heading": "Pie de página",
+        "navigation": "Navegación de pie de página",
         "links": {
             "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
             "contact": { "text": "Contacto", "to": "/contact" },

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -173,7 +173,7 @@
     },
     "footer": {
         "heading": "Footer",
-        "navgiation": "Footer Navigation",
+        "navigation": "Footer Navigation",
         "links": {
             "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
             "contact": { "text": "Contacto", "to": "/contact" },

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -172,12 +172,16 @@
         "form_language_label": "Idioma"
     },
     "footer": {
-        "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
-        "contact": { "text": "Contacto", "to": "/contact" },
-        "terms": { "text": "Términos de uso", "url": "#" },
-        "privacy": { "text": "Política de privacidad", "url": "https://techmatters.org/privacy-policy/" },
-        "data": { "text": "Política de datos", "url": "#"},
-        "about": { "text": "Acerca de Terraso", "url": "https://terraso.org/es/" }
+        "heading": "Footer",
+        "navgiation": "Footer Navigation",
+        "llinks": {
+            "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
+            "contact": { "text": "Contacto", "to": "/contact" },
+            "terms": { "text": "Términos de uso", "url": "#" },
+            "privacy": { "text": "Política de privacidad", "url": "https://techmatters.org/privacy-policy/" },
+            "data": { "text": "Política de datos", "url": "#"},
+            "about": { "text": "Acerca de Terraso", "url": "https://terraso.org/es/" }
+        }
     },
     "navigation": {
         "home": "Inicio",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -174,7 +174,7 @@
     "footer": {
         "heading": "Footer",
         "navgiation": "Footer Navigation",
-        "llinks": {
+        "links": {
             "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
             "contact": { "text": "Contacto", "to": "/contact" },
             "terms": { "text": "Términos de uso", "url": "#" },


### PR DESCRIPTION
## Description
* Add an off-screen heading `<h2>` with the text "Footer" as the first child in the <footer> element
* Wrap the footer links in a `<nav>` element with aria-label="Footer" to provide an accessible name for the landmark.
* Apply an aria-label on the `<ul>` with a value of "Footer Navigation".

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [x] Strings are localized

### Related Issues
Fixes #464.
