### PR TITLE
fix: add CSS to wrap long URLs

### DIFF
--- a/src/group/components/GroupView.js
+++ b/src/group/components/GroupView.js
@@ -104,7 +104,7 @@ const GroupCard = ({ group }) => {
         {group.website && (
           <Stack direction="row" alignItems="center" spacing={1}>
             <PublicIcon sx={{ color: 'gray.lite1' }} />
-            <Link href={group.website} underline="none">
+            <Link href={group.website} underline="none" className="wrap-url">
               {group.website}
             </Link>
           </Stack>

--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,7 @@ code {
   white-space: nowrap;
   width: 1px;
 }
+
+.wrap-url {
+  word-break: break-word;
+}

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -82,7 +82,11 @@ const LandscapeCard = ({ landscape }) => {
         {landscape.website && (
           <Stack direction="row" alignItems="center" spacing={1}>
             <PublicIcon sx={{ color: 'gray.lite1' }} />
-            <Link href={landscape.website} underline="none">
+            <Link
+              href={landscape.website}
+              underline="none"
+              className="wrap-url"
+            >
               {landscape.website}
             </Link>
           </Stack>


### PR DESCRIPTION
## Description
Apply the "word-break: break-word" CSS property to the link container to allow the link to reflow and become fully visible on mobile devices.

### Related Issues
Fixes #.507.