### PR TITLE
fix:  on landscape form country menu: set width to auto, add ID

### DIFF
--- a/src/landscape/components/LandscapeForm/InfoStep.js
+++ b/src/landscape/components/LandscapeForm/InfoStep.js
@@ -75,6 +75,7 @@ const CountrySelector = props => {
       value={field.value}
       onChange={field.onChange}
       labelId="landscape-location-label"
+      id="landscape-country"
       renderValue={selected =>
         countryHash[selected] || (
           <Typography sx={{ color: 'gray.mid2' }}>

--- a/src/landscape/components/LandscapeForm/InfoStep.js
+++ b/src/landscape/components/LandscapeForm/InfoStep.js
@@ -75,11 +75,6 @@ const CountrySelector = props => {
       value={field.value}
       onChange={field.onChange}
       labelId="landscape-location-label"
-      sx={{
-        width: {
-          md: '25%',
-        },
-      }}
       renderValue={selected =>
         countryHash[selected] || (
           <Typography sx={{ color: 'gray.mid2' }}>

--- a/src/landscape/components/LandscapeNewFormDrawPolygon.test.js
+++ b/src/landscape/components/LandscapeNewFormDrawPolygon.test.js
@@ -26,7 +26,9 @@ const setup = async () => {
     name: 'Description (required)',
   });
   const website = screen.getByRole('textbox', { name: 'Website' });
-  const location = screen.getByRole('button', { name: 'Country or region' });
+  const location = screen.getByRole('button', {
+    name: 'Country or region Landscape location',
+  });
 
   const changeLocation = async newLocation => {
     await act(async () => fireEvent.mouseDown(location));

--- a/src/landscape/components/LandscapeNewFormGeoJson.test.js
+++ b/src/landscape/components/LandscapeNewFormGeoJson.test.js
@@ -27,7 +27,9 @@ const setup = async () => {
     name: 'Description (required)',
   });
   const website = screen.getByRole('textbox', { name: 'Website' });
-  const location = screen.getByRole('button', { name: 'Country or region' });
+  const location = screen.getByRole('button', {
+    name: 'Country or region Landscape location',
+  });
 
   const changeLocation = async newLocation => {
     await act(async () => fireEvent.mouseDown(location));

--- a/src/landscape/components/LandscapeNewFormInfo.test.js
+++ b/src/landscape/components/LandscapeNewFormInfo.test.js
@@ -24,7 +24,9 @@ const setup = async () => {
     name: 'Description (required)',
   });
   const website = screen.getByRole('textbox', { name: 'Website' });
-  const location = screen.getByRole('button', { name: 'Country or region' });
+  const location = screen.getByRole('button', {
+    name: 'Country or region Landscape location',
+  });
 
   const changeLocation = async newLocation => {
     await act(async () => fireEvent.mouseDown(location));

--- a/src/landscape/components/LandscapeNewFormPin.test.js
+++ b/src/landscape/components/LandscapeNewFormPin.test.js
@@ -26,7 +26,9 @@ const setup = async () => {
     name: 'Description (required)',
   });
   const website = screen.getByRole('textbox', { name: 'Website' });
-  const location = screen.getByRole('button', { name: 'Country or region' });
+  const location = screen.getByRole('button', {
+    name: 'Country or region Landscape location',
+  });
 
   const changeLocation = async newLocation => {
     await act(async () => fireEvent.mouseDown(location));

--- a/src/landscape/components/LandscapeUpdateProfile.test.js
+++ b/src/landscape/components/LandscapeUpdateProfile.test.js
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(),
 }));
 
-const setup = async () => {
+const setup = async (countryName = 'Landscape location') => {
   await render(<LandscapeProfileUpdate />);
   const name = screen.getByRole('textbox', {
     name: 'Name (required)',
@@ -24,7 +24,9 @@ const setup = async () => {
     name: 'Description (required)',
   });
   const website = screen.getByRole('textbox', { name: 'Website' });
-  const location = screen.getByRole('button', { name: 'Country or region' });
+  const location = screen.getByRole('button', {
+    name: `Country or region ${countryName}`,
+  });
 
   const changeLocation = async newLocation => {
     await act(async () => fireEvent.mouseDown(location));
@@ -82,7 +84,7 @@ test('LandscapeProfileUpdate: Fill form', async () => {
       },
     })
   );
-  const { inputs } = await setup();
+  const { inputs } = await setup('Ecuador');
 
   expect(terrasoApi.requestGraphQL).toHaveBeenCalledTimes(1);
   expect(inputs.name).toHaveValue('Landscape Name');
@@ -107,7 +109,7 @@ test('LandscapeProfileUpdate: Input change', async () => {
       },
     })
   );
-  const { inputs } = await setup();
+  const { inputs } = await setup('Argentina');
 
   expect(inputs.name).toHaveValue('Landscape Name');
   fireEvent.change(inputs.name, { target: { value: 'New name' } });
@@ -193,7 +195,7 @@ test('LandscapeProfileUpdate: Save form', async () => {
       },
     });
 
-  const { inputs } = await setup();
+  const { inputs } = await setup('Ecuador');
 
   fireEvent.change(inputs.name, { target: { value: 'New name' } });
   fireEvent.change(inputs.description, {
@@ -240,7 +242,7 @@ test('LandscapeProfileUpdate: Save form error', async () => {
     )
     .mockRejectedValueOnce('Save Error');
 
-  const { inputs } = await setup();
+  const { inputs } = await setup('Ecuador');
 
   fireEvent.change(inputs.name, { target: { value: 'New name' } });
   fireEvent.change(inputs.description, {


### PR DESCRIPTION
## Description
On the landscape creation form:

- automatically set the width of the popup menu so long country and region names are no longer truncated
- add an ID to the popup menu so aria-labelledby is includes both the label and the country name

### Related Issues
Fixes #509. Fixes #511.