### PR TITLE
fix: Update GraphQL calls for Graphene v3 compatibility

### DIFF
--- a/src/group/groupFragments.js
+++ b/src/group/groupFragments.js
@@ -49,7 +49,7 @@ export const groupFields = `
 
 export const groupMembersPending = `
   fragment groupMembersPending on GroupNode {
-    pending: memberships(membershipStatus: "pending") {
+    pending: memberships(membershipStatus: PENDING) {
       totalCount
     }
   }
@@ -57,7 +57,7 @@ export const groupMembersPending = `
 
 export const groupMembersInfo = `
   fragment groupMembersInfo on GroupNode {
-    memberships(first: ${MEMBERS_INFO_SAMPLE_SIZE}, membershipStatus: "approved") {
+    memberships(first: ${MEMBERS_INFO_SAMPLE_SIZE}, membershipStatus: APPROVED) {
       totalCount
       edges {
         node {


### PR DESCRIPTION
## Description
Update GraphQL calls for Graphene v3 compatibility. Use an enum type, not a string. Requires corresponding backend change.

Release notes: https://github.com/graphql-python/graphene/wiki/v3-release-notes