### PR TITLE
fix: for visualization_file_load_error, show file name instead of [Object object]

### DIFF
--- a/src/sharedData/visualization/components/VisualizationWrapper.js
+++ b/src/sharedData/visualization/components/VisualizationWrapper.js
@@ -132,7 +132,7 @@ const VisualizationWrapper = props => {
                 {loadingFileError && (
                   <Alert severity="error">
                     {t('sharedData.visualization_file_load_error', {
-                      name: data.dataEntry,
+                      name: data.dataEntry.name,
                     })}
                   </Alert>
                 )}


### PR DESCRIPTION
## Description
for visualization_file_load_error, show file name instead of [Object object]

Before:
<img width="1650" alt="image" src="https://user-images.githubusercontent.com/86784/196781930-97581428-fab9-414d-8ec9-10865055f209.png">

After:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/86784/196781948-e142b525-d9a5-46d8-a614-cc0ccac6ec88.png">


### Verification steps
1. Go to https://app.staging.terraso.net/landscapes/abancay-apurimac/map/landscape-details
2. Observe error message