### PR TITLE
fix: Keep boundary current option and remove save for now

### DIFF
--- a/src/landscape/components/LandscapeForm/Actions.js
+++ b/src/landscape/components/LandscapeForm/Actions.js
@@ -43,13 +43,15 @@ const Actions = props => {
           {t('landscape.form_back')}
         </Button>
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
-          <Button
-            variant="outlined"
-            onClick={onSaveWrapper}
-            sx={{ pl: 2, pr: 2 }}
-          >
-            {t('landscape.form_save_now')}
-          </Button>
+          {onSave && (
+            <Button
+              variant="outlined"
+              onClick={onSaveWrapper}
+              sx={{ pl: 2, pr: 2 }}
+            >
+              {t('landscape.form_save_now')}
+            </Button>
+          )}
           <Button variant="contained" onClick={onNext} sx={{ pl: 6, pr: 6 }}>
             {nextLabel || t('landscape.form_next')}
           </Button>

--- a/src/landscape/components/LandscapeForm/Actions.js
+++ b/src/landscape/components/LandscapeForm/Actions.js
@@ -8,23 +8,16 @@ import { useFormGetContext } from 'forms/formContext';
 
 const Actions = props => {
   const { t } = useTranslation();
-  const {
-    isNew,
-    onCancel,
-    updatedValues,
-    setUpdatedLandscape,
-    onSave,
-    nextLabel,
-    isForm,
-  } = props;
+  const { isNew, onCancel, updatedValues, onNext, onSave, nextLabel, isForm } =
+    props;
   const formContext = useFormGetContext();
 
-  const onNext = useCallback(async () => {
+  const onNextWrapper = useCallback(async () => {
     const success = isForm ? await formContext.trigger?.() : true;
     if (success) {
-      setUpdatedLandscape(updatedValues);
+      onNext(updatedValues);
     }
-  }, [formContext, updatedValues, setUpdatedLandscape, isForm]);
+  }, [formContext, updatedValues, onNext, isForm]);
 
   const onSaveWrapper = useCallback(async () => {
     const success = isForm ? await formContext.trigger?.() : true;
@@ -52,7 +45,11 @@ const Actions = props => {
               {t('landscape.form_save_now')}
             </Button>
           )}
-          <Button variant="contained" onClick={onNext} sx={{ pl: 6, pr: 6 }}>
+          <Button
+            variant="contained"
+            onClick={onNextWrapper}
+            sx={{ pl: 6, pr: 6 }}
+          >
             {nextLabel || t('landscape.form_next')}
           </Button>
         </Stack>
@@ -62,7 +59,11 @@ const Actions = props => {
 
   return (
     <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-      <Button variant="contained" onClick={onSaveWrapper} sx={{ pl: 6, pr: 6 }}>
+      <Button
+        variant="contained"
+        onClick={onSave ? onSaveWrapper : onNextWrapper}
+        sx={{ pl: 6, pr: 6 }}
+      >
         {t('landscape.form_update')}
       </Button>
       <Button variant="text" onClick={onCancel} sx={{ pl: 6, pr: 6 }}>

--- a/src/landscape/components/LandscapeForm/AffiliationStep.js
+++ b/src/landscape/components/LandscapeForm/AffiliationStep.js
@@ -209,7 +209,7 @@ const AffiliationStep = props => {
         onCancel={onCancel}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
         nextLabel={t('landscape.form_add_label')}
       />
     </>

--- a/src/landscape/components/LandscapeForm/BoundaryStep.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStep.js
@@ -370,11 +370,13 @@ const getOptionComponent = option => {
 };
 
 const BoundaryStep = props => {
-  const [option, setOption] = useState(OPTION_SELECT_OPTIONS);
   const [boundingBox, setBoundingBox] = useState();
   const isMounted = useIsMounted();
-  const OptionComponent = getOptionComponent(option);
   const { landscape, onSave, setUpdatedLandscape } = props;
+  const [option, setOption] = useState(
+    landscape.boundaryOption || OPTION_SELECT_OPTIONS
+  );
+  const OptionComponent = getOptionComponent(option);
   const [areaPolygon, setAreaPolygon] = useState(landscape.areaPolygon);
 
   useEffect(() => {
@@ -393,7 +395,11 @@ const BoundaryStep = props => {
         }
       });
     }
-  }, [landscape, isMounted]);
+  }, [landscape.location, isMounted]);
+
+  useEffect(() => {
+    setAreaPolygon(landscape.areaPolygon);
+  }, [landscape.areaPolygon]);
 
   const onSaveWrapper = useCallback(
     updatedValues => {

--- a/src/landscape/components/LandscapeForm/BoundaryStep.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStep.js
@@ -75,7 +75,7 @@ const GeoJson = props => {
         onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
       />
     </>
   );
@@ -219,7 +219,7 @@ const MapDrawPolygon = props => {
         onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
       />
     </>
   );
@@ -263,7 +263,7 @@ const MapPin = props => {
         onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
       />
     </>
   );

--- a/src/landscape/components/LandscapeForm/BoundaryStep.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStep.js
@@ -36,7 +36,7 @@ import Actions from './Actions';
 const OPTION_GEOJSON = 'geo-json';
 const OPTION_MAP_DRAW_POLYGON = 'map-draw-polygon';
 const OPTION_MAP_PIN = 'map-pin';
-const OPTION_SELECT_OPTIONS = 'options';
+const OPTION_BOUNDARY_CHOICES = 'options';
 const OPTION_SKIP_BOUNDARY = 'skip-boundary';
 
 const POLYGON_FILTER = feature => _.get('geometry.type', feature) === 'Polygon';
@@ -72,7 +72,7 @@ const GeoJson = props => {
       </Paper>
       <Actions
         isNew={isNew}
-        onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
+        onCancel={() => setOption(OPTION_BOUNDARY_CHOICES)}
         onSave={onSave}
         updatedValues={updatedValues}
         onNext={setUpdatedLandscape}
@@ -216,7 +216,7 @@ const MapDrawPolygon = props => {
       </Paper>
       <Actions
         isNew={isNew}
-        onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
+        onCancel={() => setOption(OPTION_BOUNDARY_CHOICES)}
         onSave={onSave}
         updatedValues={updatedValues}
         onNext={setUpdatedLandscape}
@@ -260,7 +260,7 @@ const MapPin = props => {
       </Paper>
       <Actions
         isNew={isNew}
-        onCancel={() => setOption(OPTION_SELECT_OPTIONS)}
+        onCancel={() => setOption(OPTION_BOUNDARY_CHOICES)}
         onSave={onSave}
         updatedValues={updatedValues}
         onNext={setUpdatedLandscape}
@@ -374,7 +374,7 @@ const BoundaryStep = props => {
   const isMounted = useIsMounted();
   const { landscape, onSave, setUpdatedLandscape } = props;
   const [option, setOption] = useState(
-    landscape.boundaryOption || OPTION_SELECT_OPTIONS
+    landscape.boundaryOption || OPTION_BOUNDARY_CHOICES
   );
   const OptionComponent = getOptionComponent(option);
   const [areaPolygon, setAreaPolygon] = useState(landscape.areaPolygon);

--- a/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
+++ b/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
@@ -115,7 +115,7 @@ const DevelopmentStrategyStep = props => {
         onCancel={onCancel}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
       />
     </>
   );

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -136,7 +136,7 @@ const InfoStep = props => {
         isNew={isNew}
         onCancel={() => navigate(-1)}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
         nextLabel={isNew ? null : 'landscape.form_save_label'}
       />
     </>

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -7,12 +7,7 @@ import * as yup from 'yup';
 
 import { MenuItem, Select, Typography } from '@mui/material';
 
-import {
-  countriesList,
-  countryMap,
-  scrollToNavBar,
-  transformURL,
-} from 'common/utils';
+import { countriesList, countryMap, transformURL } from 'common/utils';
 import Form from 'forms/components/Form';
 import { FormContextProvider } from 'forms/formContext';
 import PageHeader from 'layout/PageHeader';
@@ -113,11 +108,6 @@ const InfoStep = props => {
     ? t('landscape.form_edit_title', { name: _.getOr('', 'name', landscape) })
     : t('landscape.form_new_title');
 
-  const onSave = updatedLandscape => {
-    setUpdatedLandscape(updatedLandscape);
-    scrollToNavBar();
-  };
-
   return (
     <>
       <PageHeader
@@ -145,7 +135,6 @@ const InfoStep = props => {
         isForm
         isNew={isNew}
         onCancel={() => navigate(-1)}
-        onSave={onSave}
         updatedValues={updatedValues}
         setUpdatedLandscape={setUpdatedLandscape}
         nextLabel={isNew ? null : 'landscape.form_save_label'}

--- a/src/landscape/components/LandscapeForm/ProfileStep.js
+++ b/src/landscape/components/LandscapeForm/ProfileStep.js
@@ -261,7 +261,7 @@ const ProfileStep = props => {
         onCancel={onCancel}
         onSave={onSave}
         updatedValues={updatedValues}
-        setUpdatedLandscape={setUpdatedLandscape}
+        onNext={setUpdatedLandscape}
       />
     </>
   );


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

- Keep boundary step seelcted option when going back
- Remove save for now from key info step