### PR TITLE
Feat: Profile textarea auto size and counter

### DIFF
--- a/src/common/components/CharacterCounter.js
+++ b/src/common/components/CharacterCounter.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Typography } from '@mui/material';
+
+const CharacterCounter = props => {
+  const { text, max } = props;
+  const currentLen = text.length;
+  return (
+    <Typography variant="caption" sx={{ float: 'right' }}>
+      {currentLen} / {max}
+    </Typography>
+  );
+};
+
+export default CharacterCounter;

--- a/src/forms/components/FormField.js
+++ b/src/forms/components/FormField.js
@@ -99,7 +99,9 @@ const FormField = props => {
       </Stack>
       <FormFieldInput field={field} fieldState={fieldState} {...props} />
       {info && (
-        <FormHelperText id={`${id}-helper-text`}>{t(info)}</FormHelperText>
+        <FormHelperText id={`${id}-helper-text`}>
+          {typeof info === 'function' ? info({ fieldState, field }) : t(info)}
+        </FormHelperText>
       )}
       {error && (
         <FormHelperText

--- a/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
+++ b/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 
-import { Typography } from '@mui/material';
+import { TextareaAutosize, Typography } from '@mui/material';
 
 import Form from 'forms/components/Form';
 import { FormContextProvider } from 'forms/formContext';
@@ -12,6 +12,15 @@ import PageHeader from 'layout/PageHeader';
 import Actions from './Actions';
 
 const VALIDATION_SCHEMA = yup.object().shape({}).required();
+
+const getTextAreaProps = minRows => ({
+  inputProps: {
+    inputComponent: TextareaAutosize,
+    inputProps: {
+      minRows,
+    },
+  },
+});
 
 const FORM_FIELDS = [
   {
@@ -26,12 +35,7 @@ const FORM_FIELDS = [
     name: 'developmentStrategy.objectives',
     label: 'landscape.form_development_objectives',
     placeholder: 'landscape.form_development_objectives_placeholder',
-    props: {
-      inputProps: {
-        multiline: true,
-        rows: 6,
-      },
-    },
+    props: getTextAreaProps(6),
   },
   {
     name: 'form_development_problem_situtation_description',
@@ -45,23 +49,13 @@ const FORM_FIELDS = [
     name: 'developmentStrategy.problemSitutation',
     label: 'landscape.form_development_problem_situtation',
     placeholder: 'landscape.form_development_problem_situtation_placeholder',
-    props: {
-      inputProps: {
-        multiline: true,
-        rows: 2,
-      },
-    },
+    props: getTextAreaProps(2),
   },
   {
     name: 'developmentStrategy.interventionStrategy',
     label: 'landscape.form_development_intervention_strategy',
     placeholder: 'landscape.form_development_intervention_strategy_placeholder',
-    props: {
-      inputProps: {
-        multiline: true,
-        rows: 3,
-      },
-    },
+    props: getTextAreaProps(3),
   },
   {
     name: 'form_development_other_information_description',
@@ -75,12 +69,7 @@ const FORM_FIELDS = [
     name: 'developmentStrategy.otherInformation',
     label: 'landscape.form_development_other_information',
     placeholder: 'landscape.form_development_other_information_placeholder',
-    props: {
-      inputProps: {
-        multiline: true,
-        rows: 3,
-      },
-    },
+    props: getTextAreaProps(3),
   },
 ];
 

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -41,9 +41,9 @@ const FORM_FIELDS = [
     name: 'description',
     label: 'landscape.form_description_label',
     placeholder: 'landscape.form_description_placeholder',
-    info: ({ field: { value } }) => {
-      return <CharacterCounter text={value} max={MAX_DESCRIPTION_LENGTH} />;
-    },
+    info: ({ field: { value } }) => (
+      <CharacterCounter text={value} max={MAX_DESCRIPTION_LENGTH} />
+    ),
     props: {
       inputProps: {
         inputComponent: TextareaAutosize,

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -7,6 +7,7 @@ import * as yup from 'yup';
 
 import { MenuItem, Select, TextareaAutosize, Typography } from '@mui/material';
 
+import CharacterCounter from 'common/components/CharacterCounter';
 import { countriesList, countryMap, transformURL } from 'common/utils';
 import Form from 'forms/components/Form';
 import { FormContextProvider } from 'forms/formContext';
@@ -40,6 +41,9 @@ const FORM_FIELDS = [
     name: 'description',
     label: 'landscape.form_description_label',
     placeholder: 'landscape.form_description_placeholder',
+    info: ({ field: { value } }) => {
+      return <CharacterCounter text={value} max={MAX_DESCRIPTION_LENGTH} />;
+    },
     props: {
       inputProps: {
         inputComponent: TextareaAutosize,
@@ -125,13 +129,13 @@ const InfoStep = props => {
         {t('landscape.form_new_description')}
       </Typography>
       <Form
+        mode="onChange"
         aria-labelledby="landscape-form-page-title"
         prefix="landscape"
         localizationPrefix="landscape.form_key_info"
         fields={FORM_FIELDS}
         values={landscape}
         validationSchema={VALIDATION_SCHEMA}
-        cancelLabel="landscape.form_info_cancel"
         isMultiStep={isNew}
         onChange={setUpdatedValues}
       />

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { MenuItem, Select, Typography } from '@mui/material';
+import { MenuItem, Select, TextareaAutosize, Typography } from '@mui/material';
 
 import { countriesList, countryMap, transformURL } from 'common/utils';
 import Form from 'forms/components/Form';
@@ -42,8 +42,10 @@ const FORM_FIELDS = [
     placeholder: 'landscape.form_description_placeholder',
     props: {
       inputProps: {
-        multiline: true,
-        rows: 4,
+        inputComponent: TextareaAutosize,
+        inputProps: {
+          minRows: 4,
+        },
       },
     },
   },


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added aouto size textarea for landscape description and development strategy fields
- Added character counter fro landscape description

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))


### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/1316782/203373126-1bc7345f-8883-4778-a954-8fc5c84646ef.png">
