### PR TITLE
fix: Add tooltip to Delete Icon for Landscape Profile Image

### DIFF
--- a/src/landscape/components/LandscapeProfile/ProfileCard.js
+++ b/src/landscape/components/LandscapeProfile/ProfileCard.js
@@ -231,7 +231,12 @@ const ProfileImage = props => {
                     'landscape.profile_image_delete_confirm_button'
                   )}
                 >
-                  <DeleteIcon sx={{ color: 'white' }} />
+                  <DeleteIcon
+                    sx={{
+                      color: 'white',
+                      accessTitle: t('generic.delete_tooltip'),
+                    }}
+                  />
                 </ConfirmButton>
               </Restricted>
             </Box>

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -1,4 +1,7 @@
 {
+    "generic": {
+        "delete_tooltip": "Delete"
+    },
     "home": {
         "title": "Home",
         "error": "Error loading data. {{error}}",


### PR DESCRIPTION
## Description

Adds a tooltip to match the spec. I added a separate section to the translations JSON because it seemed like a good idea to me, but we can easily change that.
