### PR TITLE
fix: Set 4-space spacing for JSON files in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ trim_trailing_whitespace = true
 max_line_length = 0
 trim_trailing_whitespace = false
 
+[*.json]
+indent_size = 4
+
 [COMMIT_EDITMSG]
 max_line_length = 0

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -183,11 +183,17 @@
         "heading": "Footer",
         "navigation": "Footer Navigation",
         "links": {
-            "help": { "text": "Terraso Help", "url": "https://terraso.org/help/" },
+            "help": {
+                "text": "Terraso Help",
+                "url": "https://terraso.org/help/"
+            },
             "contact": { "text": "Contact", "to": "/contact" },
             "terms": { "text": "Terms of Use", "url": "#" },
-            "privacy": { "text": "Privacy Policy", "url": "https://techmatters.org/privacy-policy/" },
-            "data": { "text": "Data Policy", "url": "#"},
+            "privacy": {
+                "text": "Privacy Policy",
+                "url": "https://techmatters.org/privacy-policy/"
+            },
+            "data": { "text": "Data Policy", "url": "#" },
             "about": { "text": "About Terraso", "url": "https://terraso.org/" }
         }
     },

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -183,12 +183,21 @@
         "heading": "Pie de página",
         "navigation": "Navegación de pie de página",
         "links": {
-            "help": { "text": "Ayuda de Terraso", "url": "https://terraso.org/es/ayuda/" },
+            "help": {
+                "text": "Ayuda de Terraso",
+                "url": "https://terraso.org/es/ayuda/"
+            },
             "contact": { "text": "Contacto", "to": "/contact" },
             "terms": { "text": "Términos de uso", "url": "#" },
-            "privacy": { "text": "Política de privacidad", "url": "https://techmatters.org/privacy-policy/" },
-            "data": { "text": "Política de datos", "url": "#"},
-            "about": { "text": "Acerca de Terraso", "url": "https://terraso.org/es/" }
+            "privacy": {
+                "text": "Política de privacidad",
+                "url": "https://techmatters.org/privacy-policy/"
+            },
+            "data": { "text": "Política de datos", "url": "#" },
+            "about": {
+                "text": "Acerca de Terraso",
+                "url": "https://terraso.org/es/"
+            }
         }
     },
     "navigation": {


### PR DESCRIPTION
# Description

 My editor keeps on automatically formatting the JSON files to 2 space thanks to the editorconfig, which is inconvenient. This PR should change it to 4 spaces, which matches what the present files have.