### PR TITLE
fix: autoselect partnership affiliation

### DIFF
--- a/src/landscape/components/LandscapeForm/AffiliationStep.js
+++ b/src/landscape/components/LandscapeForm/AffiliationStep.js
@@ -198,7 +198,7 @@ const AffiliationStep = props => {
         prefix="landscape-affiliation"
         localizationPrefix="landscape.form_affiliation"
         fields={FORM_FIELDS}
-        values={landscape}
+        values={_.assign(landscape, { partnershipStatus: 'no' })}
         validationSchema={VALIDATION_SCHEMA}
         isMultiStep
         onChange={setUpdatedValues}


### PR DESCRIPTION
## Description

The landscape profile was throwing an error when the user tried to create a landscape without selecting a landscape partnership status. This change sets the default as 'no', so the user has a sensible default that will work if the form is submitted directly.