### PR TITLE
fix: Avoid null dereference in population formatting

### DIFF
--- a/src/landscape/components/LandscapeProfile/ProfileCard.js
+++ b/src/landscape/components/LandscapeProfile/ProfileCard.js
@@ -55,7 +55,7 @@ const FIELDS = [
   },
   {
     label: 'landscape.profile_profile_card_population_label',
-    getValue: landscape => landscape.population.toLocaleString(),
+    getValue: landscape => landscape.population?.toLocaleString(),
   },
   {
     label: 'landscape.profile_profile_card_landscape_size_label',

--- a/src/landscape/components/LandscapeProfile/ProfileCard.js
+++ b/src/landscape/components/LandscapeProfile/ProfileCard.js
@@ -55,7 +55,7 @@ const FIELDS = [
   },
   {
     label: 'landscape.profile_profile_card_population_label',
-    getValue: landscape => landscape.population,
+    getValue: landscape => landscape.population.toLocaleString(),
   },
   {
     label: 'landscape.profile_profile_card_landscape_size_label',


### PR DESCRIPTION
## Description
Avoid null dereference in population formatting.