### PR TITLE
fix: Display null columns in Mapping data preview

### DIFF
--- a/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.js
@@ -135,13 +135,14 @@ const DatasetPreview = () => {
       }),
     [colCount, rowCount]
   );
+
   const sample = useMemo(
     () =>
       SheetsJs.utils.sheet_to_json(sheet, {
         range: sampleRange,
-        header: 1,
+        header: headers,
       }),
-    [sheet, sampleRange]
+    [sheet, sampleRange, headers]
   );
 
   return (
@@ -176,8 +177,8 @@ const DatasetPreview = () => {
           <TableBody>
             {_.tail(sample).map((row, rowIndex) => (
               <TableRow key={rowIndex}>
-                {row.map((cell, colIndex) => (
-                  <TableCell key={colIndex}>{_.toString(cell)}</TableCell>
+                {headers.map((header, colIndex) => (
+                  <TableCell key={header}>{_.toString(row[header])}</TableCell>
                 ))}
               </TableRow>
             ))}

--- a/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.js
@@ -122,7 +122,7 @@ const FORM_FIELDS = [
   },
 ];
 
-const DatasetPreview = () => {
+export const DatasetPreview = () => {
   const { t } = useTranslation();
   const { sheetContext } = useVisualizationContext();
   const { sheet, colCount, rowCount, headers } = sheetContext;

--- a/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.test.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.test.js
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import * as SheetsJs from 'xlsx';
+import _ from 'lodash/fp';
+
+import { VisualizationContext } from 'sharedData/visualization/visualizationContext';
+import { DatasetPreview } from './SetDatasetStep';
+
+// these libraries will print warning if they are not mocked!
+jest.mock('react-redux');
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: jest.fn(),
+  }),
+}));
+
+function mockCSVProps(headers, rows) {
+  const sheet = SheetsJs.utils.aoa_to_sheet([headers, ...rows]);
+  const rowCount = rows.length;
+  const colCount = headers.length;
+  const headersIndexes = _.fromPairs(
+    headers.map((header, index) => [header, index])
+  );
+  const selectedFile = { id: 1 };
+  return {
+    visualizationConfig: { selectedFile },
+    sheetContext: {
+      selectedFile,
+      sheet,
+      headers,
+      colCount,
+      rowCount,
+      headersIndexes,
+    },
+  };
+}
+
+test('Dataset Preview rendered', async () => {
+  const value = mockCSVProps(
+    ['foo', 'bar', 'blem'],
+    [
+      [1, 2, 3],
+      [2, 1, 2],
+      [4, 5, 6],
+    ]
+  );
+  render(
+    <VisualizationContext.Provider value={value}>
+      <DatasetPreview />
+    </VisualizationContext.Provider>
+  );
+
+  expect(screen.getByRole('table')).toBeInTheDocument();
+  expect(
+    screen.queryAllByRole('columnheader').map(node => node.textContent)
+  ).toEqual(['foo', 'bar', 'blem']);
+  expect(screen.queryAllByRole('cell').map(node => node.textContent)).toEqual([
+    '1',
+    '2',
+    '3',
+    '2',
+    '1',
+    '2',
+    '4',
+    '5',
+    '6',
+  ]);
+});

--- a/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.test.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/SetDatasetStep.test.js
@@ -66,3 +66,20 @@ test('Dataset Preview rendered', async () => {
     '6',
   ]);
 });
+
+test('Dataset Preview with null columns', async () => {
+  const defectiveArray = [];
+  defectiveArray[0] = 1;
+  defectiveArray[2] = 3;
+  const value = mockCSVProps(['foo', 'bar', 'baz'], [defectiveArray]);
+  render(
+    <VisualizationContext.Provider value={value}>
+      <DatasetPreview />
+    </VisualizationContext.Provider>
+  );
+  expect(screen.queryAllByRole('cell').map(node => node.textContent)).toEqual([
+    '1',
+    '',
+    '3',
+  ]);
+});


### PR DESCRIPTION
## Description

Previously the data visualization in creating a map would not display null columns. This is due to the somewhat weird properties of Javascript arrays.

The problem: `Sheets.utils.sheet_to_json`, when called with '{header:
1}' will leave blank spots in the array. For example: `1,,3` becomes
`Array(3)[1, <1 empty slot>, 3]`. This is a Javascript array
quirk. However the previous code iterated over an array, to these
blank columns were just "skipped".

This PR changes `Sheets.utils.sheet_to_json` to use `{header:
headers}`. Because the headers are parsed from the sheet itself, this
should preserve the order of the headers as well.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #574

### Verification steps

In contrast to the bug report, you can see that the null rows are now displayed as blank columns.

![image](https://user-images.githubusercontent.com/18663493/207159390-6fe8f3d5-be52-4af9-ac8a-5a5f903fb501.png)

