### PR TITLE
fix: pluralized "livelihoods"

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -362,7 +362,7 @@
         "profile_profile_card_landscape_size_label": "Landscape Size",
         "form_step_profile_label": "Details",
         "form_step_affiliation_label": "Affiliations",
-        "form_profile_new_title": "People, land and livelihood",
+        "form_profile_new_title": "People, land and livelihoods",
         "form_profile_edit_title": "Update Landscape Profile",
         "form_profile_description": "Describe the people within your landscape and their livelihoods. (This step is optional.)",
         "form_profile_area_types": "What best describes the landscape area?",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -366,7 +366,7 @@
         "profile_profile_card_landscape_size_label": "Tamaño del paisaje",
         "form_step_profile_label": "Detalles",
         "form_step_affiliation_label": "Afiliaciones",
-        "form_profile_new_title": "Gente, tierra y sustento",
+        "form_profile_new_title": "Gente, tierra y medios de subsistencia",
         "form_profile_edit_title": "Actualizar perfil de paisaje",
         "form_profile_description": "Describe a las personas dentro de tu paisaje y sus medios de vida. (Este paso es opcional).",
         "form_profile_area_types": "¿Qué describe mejor el área del paisaje?",


### PR DESCRIPTION
## Description
Pluralized "livelihoods" on page title.

### Related Issues
Fixes #629.