### PR TITLE
fix: add paragraph breaks before "learn more" in help text

### DIFF
--- a/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
+++ b/src/landscape/components/LandscapeForm/DevelopmentStrategyStep.js
@@ -28,14 +28,17 @@ const OpportunitiesHelperText = () => {
 
   return (
     <Box sx={{ p: 2, pr: 5 }}>
-      <Trans i18nKey="landscape.form_development_opportunities_helper_text">
-        prefix
-        <ExternalLink
-          href={t('landscape.form_development_opportunities_helper_text_url')}
-        >
-          text
-        </ExternalLink>
-      </Trans>
+      <Typography>
+        <Trans i18nKey="landscape.form_development_opportunities_helper_text">
+          prefix
+          <ExternalLink
+            linkProps={{ display: 'inline-block', mt: 2 }}
+            href={t('landscape.form_development_opportunities_helper_text_url')}
+          >
+            text
+          </ExternalLink>
+        </Trans>
+      </Typography>
     </Box>
   );
 };
@@ -45,16 +48,19 @@ const DevelopmentStrategyHelperText = () => {
 
   return (
     <Box sx={{ p: 2, pr: 5 }}>
-      <Trans i18nKey="landscape.form_development_problem_situtation_helper_text">
-        prefix
-        <ExternalLink
-          href={t(
-            'landscape.form_development_problem_situtation_helper_text_url'
-          )}
-        >
-          text
-        </ExternalLink>
-      </Trans>
+      <Typography>
+        <Trans i18nKey="landscape.form_development_problem_situtation_helper_text">
+          prefix
+          <ExternalLink
+            linkProps={{ display: 'inline-block', mt: 2 }}
+            href={t(
+              'landscape.form_development_problem_situtation_helper_text_url'
+            )}
+          >
+            text
+          </ExternalLink>
+        </Trans>
+      </Typography>
     </Box>
   );
 };
@@ -65,21 +71,23 @@ const InterventionStrategyHelperText = () => {
   return (
     <Box sx={{ p: 2, pr: 5 }}>
       <Trans i18nKey="landscape.form_development_intervention_strategy_helper_text">
-        prefix
-        <ExternalLink
-          href={t(
-            'landscape.form_development_intervention_strategy_helper_text_url_landscape'
-          )}
-        >
-          text
-        </ExternalLink>
-        <ExternalLink
-          href={t(
-            'landscape.form_development_intervention_strategy_helper_text_url_finance'
-          )}
-        >
-          text
-        </ExternalLink>
+        <Typography>prefix</Typography>
+        <Typography sx={{ mt: 2 }}>
+          <ExternalLink
+            href={t(
+              'landscape.form_development_intervention_strategy_helper_text_url_landscape'
+            )}
+          >
+            text
+          </ExternalLink>
+          <ExternalLink
+            href={t(
+              'landscape.form_development_intervention_strategy_helper_text_url_finance'
+            )}
+          >
+            text
+          </ExternalLink>
+        </Typography>
       </Trans>
     </Box>
   );
@@ -90,20 +98,22 @@ const ObjectivesHelperText = () => {
 
   return (
     <Box sx={{ p: 2, pr: 5 }}>
-      <Trans i18nKey="landscape.form_development_goals_helper_text">
-        prefix
-        <ul>
-          <li>item</li>
-          <li>item</li>
-          <li>item</li>
-          <li>item</li>
-        </ul>
-        <ExternalLink
-          href={t('landscape.form_development_goals_helper_text_url')}
-        >
-          text
-        </ExternalLink>
-      </Trans>
+      <Typography>
+        <Trans i18nKey="landscape.form_development_goals_helper_text">
+          prefix
+          <ul>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+            <li>item</li>
+          </ul>
+          <ExternalLink
+            href={t('landscape.form_development_goals_helper_text_url')}
+          >
+            text
+          </ExternalLink>
+        </Trans>
+      </Typography>
     </Box>
   );
 };

--- a/src/landscape/components/LandscapeForm/ProfileStep.js
+++ b/src/landscape/components/LandscapeForm/ProfileStep.js
@@ -67,7 +67,9 @@ const AreaTypesHelperText = props => {
 const EcosystemTypesHelperText = () => {
   return (
     <Box sx={{ p: 2 }}>
-      <Trans i18nKey="landscape.form_profile_ecosystem_types_helper_text" />
+      <Typography>
+        <Trans i18nKey="landscape.form_profile_ecosystem_types_helper_text" />
+      </Typography>
     </Box>
   );
 };

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -435,7 +435,7 @@
         "boundary_success": "Boundary was updated",
         "form_development_problem_situtation_helper_text": "Examples of challenges include deforestation, poverty, lack of economic opportunities and funding. <1>Learn more about assessment of landscape challenges</1>.",
         "form_development_problem_situtation_helper_text_url": "https://terraso.org/guide/shared-understanding/assessment-of-landscape-challenges-and-opportunities/",
-        "form_development_intervention_strategy_helper_text": "<0>Examples include convening landscape partners to identify  solutions, conducting policy campaigns and building capacity of stakeholders.</0> <1>Learn more about <1>landscape action plan</1> and <1>finance strategy</2>.</1>",
+        "form_development_intervention_strategy_helper_text": "<0>Examples include convening landscape partners to identify  solutions, conducting policy campaigns and building capacity of stakeholders.</0> <1>Learn more about <0>landscape action plan</0> and <1>finance strategy</1>.</1>",
         "form_development_intervention_strategy_helper_text_url_landscape": "https://terraso.org/guide/vision-and-planning/landscape-action-plan-short-term/",
         "form_development_intervention_strategy_helper_text_url_finance": "https://terraso.org/guide/vision-and-planning/landscape-finance-strategy/",
         "form_development_goals_helper_text_url": "https://terraso.org/guide/vision-and-planning/",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -435,7 +435,7 @@
         "boundary_success": "Boundary was updated",
         "form_development_problem_situtation_helper_text": "Examples of challenges include deforestation, poverty, lack of economic opportunities and funding. <1>Learn more about assessment of landscape challenges</1>.",
         "form_development_problem_situtation_helper_text_url": "https://terraso.org/guide/shared-understanding/assessment-of-landscape-challenges-and-opportunities/",
-        "form_development_intervention_strategy_helper_text": "Examples include convening landscape partners to identify  solutions, conducting policy campaigns and building capacity of stakeholders. Learn more about <1>landscape action plan</1> and <1>finance strategy</2>.",
+        "form_development_intervention_strategy_helper_text": "<0>Examples include convening landscape partners to identify  solutions, conducting policy campaigns and building capacity of stakeholders.</0> <1>Learn more about <1>landscape action plan</1> and <1>finance strategy</2>.</1>",
         "form_development_intervention_strategy_helper_text_url_landscape": "https://terraso.org/guide/vision-and-planning/landscape-action-plan-short-term/",
         "form_development_intervention_strategy_helper_text_url_finance": "https://terraso.org/guide/vision-and-planning/landscape-finance-strategy/",
         "form_development_goals_helper_text_url": "https://terraso.org/guide/vision-and-planning/",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -439,7 +439,7 @@
         "boundary_success": "Límite fue actualizado",
         "form_development_problem_situtation_helper_text": "Ejemplos de desafíos incluyen la deforestación, la pobreza, la falta de oportunidades económicas y financiamiento. <1>Obtenga más información sobre la evaluación de los desafíos del paisaje</1>.",
         "form_development_problem_situtation_helper_text_url": "https://terraso.org/guide/shared-understanding/assessment-of-landscape-challenges-and-opportunities/",
-        "form_development_intervention_strategy_helper_text": "Los ejemplos incluyen convocar a socios del paisaje para identificar soluciones, realizar campañas de políticas y desarrollar la capacidad de las partes interesadas. Obtenga más información sobre el <1>plan de acción paisajístico</1> y la <1>estrategia financiera</2>.",
+        "form_development_intervention_strategy_helper_text": "<0>Los ejemplos incluyen convocar a socios del paisaje para identificar soluciones, realizar campañas de políticas y desarrollar la capacidad de las partes interesadas.</0> <1>Obtenga más información sobre el <0>plan de acción paisajístico</0> y la <1>estrategia financiera</1>.</1>",
         "form_development_intervention_strategy_helper_text_url_landscape": "https://terraso.org/guide/vision-and-planning/landscape-action-plan-short-term/",
         "form_development_intervention_strategy_helper_text_url_finance": "https://terraso.org/guide/vision-and-planning/landscape-finance-strategy/",
         "form_development_goals_helper_text_url": "https://terraso.org/guide/vision-and-planning/",


### PR DESCRIPTION
## Description
Add paragraph breaks before "learn more" in help text.

### Related Issues
Fixes #650.