### PR TITLE
fix: improve group list view formatting

### DIFF
--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import _ from 'lodash/fp';
 import { Trans, useTranslation } from 'react-i18next';
@@ -63,6 +63,19 @@ const GroupList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { groups, fetching, message } = useSelector(_.getOr({}, 'group.list'));
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const linkStyle = useMemo(
+    () =>
+      isSmall
+        ? {
+            wordBreak: 'break-word',
+          }
+        : {
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+          },
+    [isSmall]
+  );
 
   useDocumentTitle(t('group.list_document_title'));
 
@@ -96,20 +109,7 @@ const GroupList = () => {
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.email && (
-          <Link
-            href={`mailto:${group.email}`}
-            sx={
-              isSmall
-                ? {
-                    wordBreak: 'break-word',
-                  }
-                : {
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                  }
-            }
-          >
+          <Link href={`mailto:${group.email}`} sx={linkStyle}>
             {group.email}
           </Link>
         ),
@@ -122,20 +122,7 @@ const GroupList = () => {
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.website && (
-          <Link
-            href={group.website}
-            sx={
-              isSmall
-                ? {
-                    wordBreak: 'break-word',
-                  }
-                : {
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                  }
-            }
-          >
+          <Link href={group.website} sx={linkStyle}>
             {group.website.replace(/^https?:\/\//, '')}
           </Link>
         ),

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -78,7 +78,7 @@ const GroupList = () => {
     {
       field: 'name',
       headerName: t('group.list_column_name'),
-      flex: 1.5,
+      flex: 2,
       minWidth: 200,
       renderCell: ({ row: group, formattedValue }) => (
         <Link component={RouterLink} to={`/groups/${group.slug}`}>
@@ -90,7 +90,7 @@ const GroupList = () => {
       field: 'email',
       headerName: t('group.list_column_contact'),
       sortable: false,
-      flex: 1.5,
+      flex: 1.25,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.email && (
@@ -110,7 +110,7 @@ const GroupList = () => {
       field: 'website',
       headerName: t('group.list_column_website'),
       sortable: false,
-      flex: 1.5,
+      flex: 1.25,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.website && (
@@ -132,7 +132,7 @@ const GroupList = () => {
       headerName: t('group.list_column_actions_description'),
       sortable: false,
       align: 'center',
-      flex: 1,
+      flex: 0.5,
       cardSize: 6,
       getActions: ({ row: group }) => [<MembershipButton group={group} />],
     },

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -94,7 +94,16 @@ const GroupList = () => {
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.email && (
-          <Link href={`mailto:${group.email}`}>{group.email}</Link>
+          <Link
+            href={`mailto:${group.email}`}
+            sx={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {group.email}
+          </Link>
         ),
     },
     {
@@ -104,7 +113,18 @@ const GroupList = () => {
       flex: 1.5,
       minWidth: 200,
       renderCell: ({ row: group }) =>
-        group.website && <Link href={group.website}>{group.website}</Link>,
+        group.website && (
+          <Link
+            href={group.website}
+            sx={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {group.website.replace(/^https?:\/\//, '')}
+          </Link>
+        ),
     },
     {
       field: 'actions',

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -105,7 +105,7 @@ const GroupList = () => {
       field: 'email',
       headerName: t('group.list_column_contact'),
       sortable: false,
-      flex: 1.2,
+      flex: 1.15,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.email && (
@@ -118,7 +118,7 @@ const GroupList = () => {
       field: 'website',
       headerName: t('group.list_column_website'),
       sortable: false,
-      flex: 1.2,
+      flex: 1.15,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.website && (
@@ -133,7 +133,7 @@ const GroupList = () => {
       headerName: t('group.list_column_actions_description'),
       sortable: false,
       align: 'center',
-      flex: 0.6,
+      flex: 0.7,
       cardSize: 6,
       getActions: ({ row: group }) => [<MembershipButton group={group} />],
     },

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -105,7 +105,7 @@ const GroupList = () => {
       field: 'email',
       headerName: t('group.list_column_contact'),
       sortable: false,
-      flex: 1.25,
+      flex: 1.2,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.email && (
@@ -118,7 +118,7 @@ const GroupList = () => {
       field: 'website',
       headerName: t('group.list_column_website'),
       sortable: false,
-      flex: 1.25,
+      flex: 1.2,
       minWidth: 200,
       renderCell: ({ row: group }) =>
         group.website && (
@@ -133,7 +133,7 @@ const GroupList = () => {
       headerName: t('group.list_column_actions_description'),
       sortable: false,
       align: 'center',
-      flex: 0.5,
+      flex: 0.6,
       cardSize: 6,
       getActions: ({ row: group }) => [<MembershipButton group={group} />],
     },

--- a/src/group/components/GroupList.js
+++ b/src/group/components/GroupList.js
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 
 import { Button, Link, Stack, Typography } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import TableResponsive from 'common/components/TableResponsive';
 import { useDocumentTitle } from 'common/document';
@@ -61,6 +62,7 @@ const GroupList = () => {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const { groups, fetching, message } = useSelector(_.getOr({}, 'group.list'));
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   useDocumentTitle(t('group.list_document_title'));
 
@@ -96,11 +98,17 @@ const GroupList = () => {
         group.email && (
           <Link
             href={`mailto:${group.email}`}
-            sx={{
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-            }}
+            sx={
+              isSmall
+                ? {
+                    wordBreak: 'break-word',
+                  }
+                : {
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                  }
+            }
           >
             {group.email}
           </Link>
@@ -116,11 +124,17 @@ const GroupList = () => {
         group.website && (
           <Link
             href={group.website}
-            sx={{
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-            }}
+            sx={
+              isSmall
+                ? {
+                    wordBreak: 'break-word',
+                  }
+                : {
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                  }
+            }
           >
             {group.website.replace(/^https?:\/\//, '')}
           </Link>

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -124,7 +124,7 @@ test('GroupList: Display list', async () => {
     within(rows[2]).getByRole('cell', { name: 'Group name 1' })
   ).toHaveAttribute('data-field', 'name');
   expect(
-    within(rows[2]).getByRole('cell', { name: 'https://www.group.org' })
+    within(rows[2]).getByRole('cell', { name: 'www.group.org' })
   ).toHaveAttribute('data-field', 'website');
   expect(
     within(rows[2]).getByRole('cell', { name: 'email@email.com' })
@@ -259,7 +259,7 @@ test('GroupList: Display list (small screen)', async () => {
   expect(rows.length).toBe(15);
   expect(within(rows[1]).getByText('Group name 1')).toBeInTheDocument();
   expect(
-    within(rows[1]).getByText('https://www.group.org')
+    within(rows[1]).getByText('www.group.org')
   ).toBeInTheDocument();
   expect(within(rows[1]).getByText('email@email.com')).toBeInTheDocument();
   expect(within(rows[1]).getByText('Join')).toBeInTheDocument();


### PR DESCRIPTION
## Description
* tail-truncate website and email with ellipses
* widen group name column and shrink other columns
* don't display `https://` on websites

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #654.