### PR TITLE
fix: update title bar logo alt text

### DIFF
--- a/src/common/components/AppBar.js
+++ b/src/common/components/AppBar.js
@@ -62,7 +62,7 @@ const AppBarComponent = () => {
             src={isSmall ? logoSquare : logo}
             width={isSmall ? 35 : 125}
             height="35"
-            alt={t('common.terraso_projectName')}
+            alt={t('common.terraso_logoText')}
           />
         </ConditionalLink>
         <Box sx={{ flexGrow: 1 }} />

--- a/src/common/components/AppBar.test.js
+++ b/src/common/components/AppBar.test.js
@@ -69,7 +69,7 @@ test('AppBar: Display terraso title', async () => {
 test('AppBar: Logo display', async () => {
   useMediaQuery.mockReturnValue(false);
   await setup();
-  expect(screen.getByRole('img', { name: 'Terraso' })).toHaveAttribute(
+  expect(screen.getByRole('img', { name: /Terraso/i })).toHaveAttribute(
     'src',
     'logo.svg'
   );
@@ -77,7 +77,7 @@ test('AppBar: Logo display', async () => {
 test('AppBar: Logo display (small)', async () => {
   useMediaQuery.mockReturnValue(true);
   await setup();
-  expect(screen.getByRole('img', { name: 'Terraso' })).toHaveAttribute(
+  expect(screen.getByRole('img', { name: /Terraso/i })).toHaveAttribute(
     'src',
     'logo-square.svg'
   );
@@ -88,7 +88,7 @@ test('AppBar: Sign out', async () => {
   });
   useMediaQuery.mockReturnValue(false);
   await setup();
-  expect(screen.getByRole('img', { name: 'Terraso' })).toHaveAttribute(
+  expect(screen.getByRole('img', { name: /Terraso/i })).toHaveAttribute(
     'src',
     'logo.svg'
   );

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -597,6 +597,7 @@
     "common": {
         "dialog_cancel_label": "Cancel",
         "terraso_projectName": "Terraso",
+        "terraso_logoText": "Logo: Terraso",
         "unexpected_error": "Oops, something went wrong. Try again in a few minutes. {{error, errorParam(label: Error)}}",
         "loader_label": "Loading",
         "not_found_title": "Page not found",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -472,6 +472,7 @@
     "common": {
         "dialog_cancel_label": "Cancelar",
         "terraso_projectName": "Terraso",
+        "terraso_logoText": "Logo: Terraso",
         "unexpected_error": "Ups! Algo salió mal. Vuelve a intentarlo en unos minutos. {{error, errorParam(label: Error)}}",
         "loader_label": "Cargando",
         "not_found_title": "Página no encontrada",


### PR DESCRIPTION
## Description
changes alt text of title bar logo from "Terraso" to "Logo: Terraso"

not actually trying to merge this, not sure what the exact workflow is for updating text + i18n yet, just going thru the motions of a PR

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #526 

### Verification steps
alt text of title bar logo should now read "Logo: Terraso" instead of "Terraso"