### PR TITLE
fix: hide "contact manager" msg for managers

### DIFF
--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -17,6 +17,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
+import { usePermission } from 'permissions';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -256,6 +257,11 @@ const LandscapeView = () => {
     setRefreshing(refreshing);
   }, [refreshing, setRefreshing]);
 
+  const { loading: loadingIsManager, allowed: isManager } = usePermission(
+    'landscape.change',
+    landscape
+  );
+
   if (fetching) {
     return <PageLoader />;
   }
@@ -308,28 +314,30 @@ const LandscapeView = () => {
                   />
                   <LandscapeBoundaryDownload landscape={landscape} />
                 </Paper>
-                <InlineHelp
-                  items={[
-                    {
-                      title: t('landscape.view_map_boundaries_help'),
-                      details: (
-                        <Trans i18nKey="landscape.view_map_boundaries_help_details">
-                          Prefix
-                          <ExternalLink
-                            href={t('landscape.view_map_boundaries_help_url')}
-                          >
-                            link
-                            <LaunchIcon
-                              fontSize="small"
-                              sx={{ verticalAlign: 'bottom' }}
-                            />
-                          </ExternalLink>
-                          .
-                        </Trans>
-                      ),
-                    },
-                  ]}
-                />
+                {!loadingIsManager && !isManager && (
+                  <InlineHelp
+                    items={[
+                      {
+                        title: t('landscape.view_map_boundaries_help'),
+                        details: (
+                          <Trans i18nKey="landscape.view_map_boundaries_help_details">
+                            Prefix
+                            <ExternalLink
+                              href={t('landscape.view_map_boundaries_help_url')}
+                            >
+                              link
+                              <LaunchIcon
+                                fontSize="small"
+                                sx={{ verticalAlign: 'bottom' }}
+                              />
+                            </ExternalLink>
+                            .
+                          </Trans>
+                        ),
+                      },
+                    ]}
+                  />
+                )}
               </CardContent>
               <Restricted permission="landscape.change" resource={landscape}>
                 <CardActions sx={{ paddingTop: 0 }}>

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -60,7 +60,7 @@ beforeEach(() => {
   global.URL.createObjectURL = jest.fn();
 });
 
-const baseViewTest = async () => {
+const baseViewTest = async (userRole = 'MEMBER') => {
   global.fetch.mockReturnValue(
     Promise.resolve({
       json: () => [],
@@ -84,7 +84,7 @@ const baseViewTest = async () => {
     'edges[0].node',
     {
       id: 'user-id',
-      userRole: 'MEMBER',
+      userRole: userRole,
       membershipStatus: 'APPROVED',
     },
     {}
@@ -190,9 +190,6 @@ const baseViewTest = async () => {
     screen.getByText(/6 Terraso members joined Landscape Name./i)
   ).toBeInTheDocument();
   expect(screen.getByText(/\+2/i)).toBeInTheDocument();
-  expect(
-    screen.getByRole('button', { name: 'Leave: Landscape Name' })
-  ).toBeInTheDocument();
 
   // Map
   expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument();
@@ -246,7 +243,20 @@ test('LandscapeView: Not found', async () => {
   expect(screen.getByText(/Landscape not found/i)).toBeInTheDocument();
 });
 
-test('LandscapeView: Display data', baseViewTest);
+test('LandscapeView: Display data', async () => {
+  await baseViewTest();
+  
+  expect(
+    screen.getByRole('button', { name: 'Leave: Landscape Name' })
+  ).toBeInTheDocument();
+  expect(screen.getByText('Something wrong with the map?')).toBeInTheDocument();
+});
+
+test('LandscapeView: Managers do not see warning', async () => {
+  await baseViewTest('MANAGER');
+
+  expect(screen.queryByText('Something wrong with the map?')).not.toBeInTheDocument();
+});
 
 test('LandscapeView: Update Shared Data', async () => {
   await baseViewTest();


### PR DESCRIPTION
## Description
Hides the "Something wrong with the map? ... contact manager" message on the landscape page from irrelevant users (i.e. managers).

I need help writing the tests for this, & for someone to confirm the way I determined if the user is a manager is idiomatic.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #453 

### Verification steps
View a landscape that you are a manager of & confirm the msg is not there, view a landscape that you are not a manager of and confirm the msg is there.
