### PR TITLE
fix: set a default overflow-wrap for popup content in leaflet map widgets

### DIFF
--- a/src/gis/components/Map.css
+++ b/src/gis/components/Map.css
@@ -64,3 +64,7 @@
 .leaflet-disabled {
   opacity: 0.6;
 }
+
+.leaflet-popup-content-wrapper {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Description
sets the default text wrapping behavior for leaflet map popup widgets to "overflow-wrap: anywhere;" (see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Text/Wrapping_Text for details). this makes sure for now that text will never extend beyond the contents' box

i found this bug also existed on e.g. the landscapes view if a landscape name contained a very long word, and is fixed there as well

i'm not sure how to test for this

we would maybe like to do something more subtle eventually but i will let someone with a more designer brain put thought into that rather than overworking my store-brand brain

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #554 

### Verification steps
create a landscape with a name that contains a long word and select it in the map on the landscapes page, or create a data viz map that displays a string column which contains a long word
