### PR TITLE
refactor: allow Restricted component to hide children when users do not have a permission

### DIFF
--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -308,7 +308,11 @@ const LandscapeView = () => {
                   />
                   <LandscapeBoundaryDownload landscape={landscape} />
                 </Paper>
-                <Restricted permission="landscape.change" resource={landscape} toDisallowedUsers={true}>
+                <Restricted
+                  permission="landscape.change"
+                  resource={landscape}
+                  toDisallowedUsers={true}
+                >
                   <InlineHelp
                     items={[
                       {

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -17,7 +17,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
-import { usePermission } from 'permissions';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -257,11 +257,6 @@ const LandscapeView = () => {
     setRefreshing(refreshing);
   }, [refreshing, setRefreshing]);
 
-  const { loading: loadingIsManager, allowed: isManager } = usePermission(
-    'landscape.change',
-    landscape
-  );
-
   if (fetching) {
     return <PageLoader />;
   }
@@ -314,7 +309,7 @@ const LandscapeView = () => {
                   />
                   <LandscapeBoundaryDownload landscape={landscape} />
                 </Paper>
-                {!loadingIsManager && !isManager && (
+                <Restricted permission="landscape.change" resource={landscape} forUnallowedUsers={true}>
                   <InlineHelp
                     items={[
                       {
@@ -337,7 +332,7 @@ const LandscapeView = () => {
                       },
                     ]}
                   />
-                )}
+                </Restricted>
               </CardContent>
               <Restricted permission="landscape.change" resource={landscape}>
                 <CardActions sx={{ paddingTop: 0 }}>

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -308,7 +308,7 @@ const LandscapeView = () => {
                   />
                   <LandscapeBoundaryDownload landscape={landscape} />
                 </Paper>
-                <Restricted permission="landscape.change" resource={landscape} forUnallowedUsers={true}>
+                <Restricted permission="landscape.change" resource={landscape} toDisallowedUsers={true}>
                   <InlineHelp
                     items={[
                       {

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -245,7 +245,7 @@ test('LandscapeView: Not found', async () => {
 
 test('LandscapeView: Display data', async () => {
   await baseViewTest();
-  
+
   expect(
     screen.getByRole('button', { name: 'Leave: Landscape Name' })
   ).toBeInTheDocument();
@@ -255,7 +255,9 @@ test('LandscapeView: Display data', async () => {
 test('LandscapeView: Managers do not see warning', async () => {
   await baseViewTest('MANAGER');
 
-  expect(screen.queryByText('Something wrong with the map?')).not.toBeInTheDocument();
+  expect(
+    screen.queryByText('Something wrong with the map?')
+  ).not.toBeInTheDocument();
 });
 
 test('LandscapeView: Update Shared Data', async () => {

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -26,6 +26,7 @@ const Restricted = props => {
   const {
     permission,
     resource,
+    forUnallowedUsers = false,
     FallbackComponent,
     LoadingComponent,
     children,
@@ -40,7 +41,7 @@ const Restricted = props => {
     );
   }
 
-  if (allowed) {
+  if (forUnallowedUsers ? !allowed : allowed) {
     return <>{children}</>;
   }
 

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -26,7 +26,7 @@ const Restricted = props => {
   const {
     permission,
     resource,
-    forUnallowedUsers = false,
+    toDisallowedUsers = false,
     FallbackComponent,
     LoadingComponent,
     children,
@@ -41,7 +41,7 @@ const Restricted = props => {
     );
   }
 
-  if (forUnallowedUsers ? !allowed : allowed) {
+  if (toDisallowedUsers ? !allowed : allowed) {
     return <>{children}</>;
   }
 

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -109,7 +109,7 @@ test('Restricted: Display component for unallowed users', async () => {
     {
       resource: {},
       permission: 'resource.action',
-      forUnallowedUsers: true,
+      toDisallowedUsers: true,
       children: <div>Restricted content</div>,
     },
     rules
@@ -124,7 +124,7 @@ test('Restricted: Hide component for allowed users', async () => {
     {
       resource: {},
       permission: 'resource.action',
-      forUnallowedUsers: true,
+      toDisallowedUsers: true,
       children: <div>Restricted content</div>,
     },
     rules

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -101,6 +101,37 @@ test('Restricted: Hide denied component', async () => {
   expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
   expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
 });
+test('Restricted: Display component for unallowed users', async () => {
+  const rules = {
+    'resource.action': () => Promise.resolve(false),
+  };
+  await setup(
+    {
+      resource: {},
+      permission: 'resource.action',
+      forUnallowedUsers: true,
+      children: <div>Restricted content</div>,
+    },
+    rules
+  );
+  expect(screen.getByText('Restricted content')).toBeInTheDocument();
+});
+test('Restricted: Hide component for allowed users', async () => {
+  const rules = {
+    'resource.action': () => Promise.resolve(true),
+  };
+  await setup(
+    {
+      resource: {},
+      permission: 'resource.action',
+      forUnallowedUsers: true,
+      children: <div>Restricted content</div>,
+    },
+    rules
+  );
+  expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
+  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+});
 test('Restricted: Display fallback component', async () => {
   await setup({
     resource: {},


### PR DESCRIPTION
## Description
The Restricted component previously could only restrict a component to users with a permission, now it has an argument toggle whether it restricts to users with or without a permission. The new argument is used to clean up some code duplication i introduced in LandscapeView

### Verification steps
should be no visible changes, just a transparent refactor