### PR TITLE
fix: Layers not always changing on story map transition

### DIFF
--- a/src/storyMap/components/StoryMap.js
+++ b/src/storyMap/components/StoryMap.js
@@ -373,40 +373,39 @@ const StoryMap = props => {
 
         // Check if the map is already at the transition center
         const decimalPlaces = CURRENT_LOCATION_CHECK_PRESSISION;
-        if (
+        const isInLocation =
           mapCenter.lng.toFixed(decimalPlaces) ===
             transitionCenter.lng.toFixed(decimalPlaces) &&
           mapCenter.lat.toFixed(decimalPlaces) ===
-            transitionCenter.lat.toFixed(decimalPlaces)
-        ) {
-          return;
-        }
+            transitionCenter.lat.toFixed(decimalPlaces);
 
-        map[animation || transition.mapAnimation || 'flyTo'](
-          transition.location
-        );
+        if (!isInLocation) {
+          map[animation || transition.mapAnimation || 'flyTo'](
+            transition.location
+          );
 
-        // If you do not want to have a dynamic inset map,
-        // rather want to keep it a static view but still change the
-        // bbox as main map move: comment out the below if section.
-        if (config.inset) {
-          if (transition.location.zoom < 5) {
-            insetMap.flyTo({ center: transition.location.center, zoom: 0 });
-          } else {
-            insetMap.flyTo({ center: transition.location.center, zoom: 3 });
+          // If you do not want to have a dynamic inset map,
+          // rather want to keep it a static view but still change the
+          // bbox as main map move: comment out the below if section.
+          if (config.inset) {
+            if (transition.location.zoom < 5) {
+              insetMap.flyTo({ center: transition.location.center, zoom: 0 });
+            } else {
+              insetMap.flyTo({ center: transition.location.center, zoom: 3 });
+            }
           }
-        }
-        if (config.showMarkers) {
-          if (!marker) {
-            const newMarker = new mapboxgl.Marker({
-              color: config.markerColor,
-            })
-              .setLngLat(transition.location.center)
-              .addTo(map);
+          if (config.showMarkers) {
+            if (!marker) {
+              const newMarker = new mapboxgl.Marker({
+                color: config.markerColor,
+              })
+                .setLngLat(transition.location.center)
+                .addTo(map);
 
-            setMarker(newMarker);
-          } else {
-            marker.setLngLat(transition.location.center);
+              setMarker(newMarker);
+            } else {
+              marker.setLngLat(transition.location.center);
+            }
           }
         }
       }


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
The story map flow provides a way to change the layers being displayed on each chapter, through the `onChapterEnter` and `onChapterExit` properties of the chapter or the title transition. Right now the `onChapterEnter` is not always executing because there is a condition for the location change on the map that will return early if there is no need for a location change, but there is a situation where there can be layer changes without a location change.

This fix is removing the early return so that the rest of the functionality can still be executed.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
