### PR TITLE
fix: add page titles for story map new/edit/home pages

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -913,6 +913,7 @@
         "terraso_api.title.required_published": "Could not publish your story map without a title. Enter a title and try again.",
         "new_document_title": "Create Story Map",
         "home_document_title": "Story Maps",
-        "edit_document_title": "Edit: {{name}}"
+        "edit_document_title": "Edit: {{name}}",
+        "view_document_title": "{{name}}"
     }
 }

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -910,6 +910,9 @@
         "form_location_dialog_geocoder_placeholder": "Search",
         "outline_no_title": "Chapter {{index}}",
         "terraso_api.title.required_draft": "Could not save your draft without a title. Enter a title and try again.",
-        "terraso_api.title.required_published": "Could not publish your story map without a title. Enter a title and try again."
+        "terraso_api.title.required_published": "Could not publish your story map without a title. Enter a title and try again.",
+        "new_document_title": "Create Story Map",
+        "home_document_title": "Story Maps",
+        "edit_document_title": "Edit: {{name}}"
     }
 }

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -915,6 +915,9 @@
         "form_location_dialog_geocoder_placeholder": "Buscar",
         "outline_no_title": "Capítulo {{index}}",
         "terraso_api.title.required_draft": "No se pudo guardar el borrador sin un título. Introduce un título y vuelve a intentarlo.",
-        "terraso_api.title.required_published": "No se pudo publicar tu story map sin un título. Introduce un título y vuelva a intentarlo."
+        "terraso_api.title.required_published": "No se pudo publicar tu story map sin un título. Introduce un título y vuelva a intentarlo.",
+        "new_document_title": "Crear Story Map",
+        "home_document_title": "Story Maps",
+        "edit_document_title": "Editar: {{name}}"
     }
 }

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -918,6 +918,7 @@
         "terraso_api.title.required_published": "No se pudo publicar tu story map sin un título. Introduce un título y vuelva a intentarlo.",
         "new_document_title": "Crear Story Map",
         "home_document_title": "Story Maps",
-        "edit_document_title": "Editar: {{name}}"
+        "edit_document_title": "Editar: {{name}}",
+        "view_document_title": "{{name}}"
     }
 }

--- a/src/storyMap/components/StoryMapForm.test.js
+++ b/src/storyMap/components/StoryMapForm.test.js
@@ -298,7 +298,9 @@ test('StoryMapForm: Change title', async () => {
   );
   await act(async () =>
     fireEvent.change(
-      within(titleSection).getByRole('textbox', { name: 'Story map title (Required)' }),
+      within(titleSection).getByRole('textbox', {
+        name: 'Story map title (Required)',
+      }),
       { target: { value: 'New title' } }
     )
   );

--- a/src/storyMap/components/StoryMapNew.js
+++ b/src/storyMap/components/StoryMapNew.js
@@ -24,6 +24,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Paper, useMediaQuery } from '@mui/material';
 
+import { useDocumentTitle } from 'common/document';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 import { useAnalytics } from 'monitoring/analytics';
@@ -94,9 +95,12 @@ const BASE_CONFIG = {
 
 const StoryMapNew = () => {
   const dispatch = useDispatch();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { trackEvent } = useAnalytics();
   const [saved, setSaved] = useState();
+
+  useDocumentTitle(t('storyMap.new_document_title'));
 
   useEffect(() => {
     if (!saved) {

--- a/src/storyMap/components/StoryMapUpdate.js
+++ b/src/storyMap/components/StoryMapUpdate.js
@@ -18,10 +18,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import _ from 'lodash/fp';
 import { usePermission } from 'permissions';
+import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { useDocumentTitle } from 'common/document';
 import PageLoader from 'layout/PageLoader';
 import { useAnalytics } from 'monitoring/analytics';
 import { ILM_OUTPUT_PROP, LANDSCAPE_NARRATIVES } from 'monitoring/ilm';
@@ -43,9 +45,17 @@ import { StoryMapConfigContextProvider } from './StoryMapForm/storyMapConfigCont
 const StoryMapUpdate = props => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
   const { storyMap } = props;
   const [saved, setSaved] = useState();
+
+  useDocumentTitle(
+    t('storyMap.edit_document_title', {
+      name: _.get('title', storyMap),
+    }),
+    saved
+  );
 
   useEffect(() => {
     if (!saved) {

--- a/src/storyMap/components/StoryMapsToolHome.js
+++ b/src/storyMap/components/StoryMapsToolHome.js
@@ -34,6 +34,7 @@ import {
 
 import ExternalLink from 'common/components/ExternalLink';
 import RouterLink from 'common/components/RouterLink';
+import { useDocumentTitle } from 'common/document';
 import PageContainer from 'layout/PageContainer';
 import PageHeader from 'layout/PageHeader';
 import { formatDate } from 'localization/utils';
@@ -46,6 +47,8 @@ import { generateStoryMapUrl } from 'storyMap/storyMapUtils';
 const StoryMapsToolsHome = () => {
   const { t, i18n } = useTranslation();
   const { list } = useSelector(_.get('storyMap.samples'));
+
+  useDocumentTitle(t('storyMap.home_document_title'));
 
   useBreadcrumbsParams(useMemo(() => ({ loading: false }), []));
 

--- a/src/storyMap/components/UserStoryMap.js
+++ b/src/storyMap/components/UserStoryMap.js
@@ -23,6 +23,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import RouterButton from 'common/components/RouterButton';
 import { useSocialShareContext } from 'common/components/SocialShare';
+import { useDocumentTitle } from 'common/document';
 import Container, { useContainerContext } from 'layout/Container';
 import PageLoader from 'layout/PageLoader';
 import { useBreadcrumbsParams } from 'navigation/breadcrumbsContext';
@@ -45,6 +46,13 @@ const UserStoryMap = () => {
   const { data: storyMap, fetching } = useSelector(_.get('storyMap.view'));
 
   const { setContainerProps } = useContainerContext();
+
+  useDocumentTitle(
+    t('storyMap.view_document_title', {
+      name: _.get('title', storyMap),
+    }),
+    fetching
+  );
 
   useEffect(() => {
     setContainerProps({ maxWidth: false });


### PR DESCRIPTION
## Description
Add page titles for story map new/edit/home pages.

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [X] Strings are localized

### Related Issues
Fixes #801.

### Verification steps

1. https://app.terraso.org/tools/story-maps
2. https://app.terraso.org/tools/story-maps/new
3. Create a story map, enter a title, click "Save draft"