### PR TITLE
fix: tag shared links by group/landscape and track logins

### DIFF
--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -94,7 +94,7 @@ const AccountForm = () => {
               startIcon={<GoogleIcon sx={{ paddingRight: '5px' }} />}
               href={appendReferrer(urls.google, referrer)}
               onClick={() =>
-                trackEvent('User login', { props: { source: 'google' } })
+                trackEvent('user.login', { props: { source: 'google' } })
               }
             >
               {t('account.google_login')}
@@ -107,7 +107,7 @@ const AccountForm = () => {
               startIcon={<AppleIcon sx={{ paddingRight: '5px' }} />}
               href={appendReferrer(urls.apple, referrer)}
               onClick={() =>
-                trackEvent('User login', { props: { source: 'apple' } })
+                trackEvent('user.login', { props: { source: 'apple' } })
               }
             >
               {t('account.apple_login')}
@@ -124,7 +124,7 @@ const AccountForm = () => {
               }
               href={appendReferrer(urls.microsoft, referrer)}
               onClick={() =>
-                trackEvent('User login', { props: { source: 'microsoft' } })
+                trackEvent('user.login', { props: { source: 'microsoft' } })
               }
             >
               {t('account.microsoft_login')}

--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -32,6 +32,7 @@ import { useDocumentTitle } from 'common/document';
 import PageHeader from 'layout/PageHeader';
 import PageLoader from 'layout/PageLoader';
 import LocalePicker from 'localization/components/LocalePicker';
+import { useAnalytics } from 'monitoring/analytics';
 import { useFetchData } from 'state/utils';
 
 import { fetchAuthURLs } from 'account/accountSlice';
@@ -51,6 +52,7 @@ const appendReferrer = (url, referrer) =>
 
 const AccountForm = () => {
   const { t } = useTranslation();
+  const { trackEvent } = useAnalytics();
   const [searchParams] = useSearchParams();
   const { fetching, urls } = useSelector(state => state.account.login);
   const referrer = searchParams.get('referrer');
@@ -91,6 +93,9 @@ const AccountForm = () => {
               variant="outlined"
               startIcon={<GoogleIcon sx={{ paddingRight: '5px' }} />}
               href={appendReferrer(urls.google, referrer)}
+              onClick={() =>
+                trackEvent('User login', { props: { source: 'google' } })
+              }
             >
               {t('account.google_login')}
             </Button>
@@ -101,6 +106,9 @@ const AccountForm = () => {
               variant="outlined"
               startIcon={<AppleIcon sx={{ paddingRight: '5px' }} />}
               href={appendReferrer(urls.apple, referrer)}
+              onClick={() =>
+                trackEvent('User login', { props: { source: 'apple' } })
+              }
             >
               {t('account.apple_login')}
             </Button>
@@ -115,6 +123,9 @@ const AccountForm = () => {
                 />
               }
               href={appendReferrer(urls.microsoft, referrer)}
+              onClick={() =>
+                trackEvent('User login', { props: { source: 'microsoft' } })
+              }
             >
               {t('account.microsoft_login')}
             </Button>

--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -153,7 +153,9 @@ const AccountProfile = () => {
         );
 
         if (preferenceKey === 'notifications') {
-          trackEvent('Preference', { props: { emailNotifications: newValue } });
+          trackEvent('preference.update', {
+            props: { emailNotifications: newValue },
+          });
         }
       }
     });

--- a/src/common/components/ExternalLink.js
+++ b/src/common/components/ExternalLink.js
@@ -36,7 +36,7 @@ const ExternalLink = ({ href, component, children, linkProps }) => {
 
   const onClick = event => {
     window.open(href, '_blank', 'noopener,noreferrer');
-    trackEvent('Outbound Link: Click', {
+    trackEvent('link.click', {
       props: props,
     });
     event.preventDefault();

--- a/src/common/components/ExternalLink.js
+++ b/src/common/components/ExternalLink.js
@@ -16,6 +16,8 @@
  */
 import React from 'react';
 
+import _ from 'lodash/fp';
+
 import { Link } from '@mui/material';
 
 import { useAnalytics } from 'monitoring/analytics';
@@ -26,15 +28,28 @@ import { useAnalytics } from 'monitoring/analytics';
 // https://github.com/plausible/plausible-tracker/issues/12
 const ExternalLink = ({ href, component, children, linkProps }) => {
   const { trackEvent } = useAnalytics();
+  let props = { url: href };
+
+  if (linkProps?.trackingProps) {
+    props = { ...linkProps.trackingProps, ...props };
+  }
+
   const onClick = event => {
     window.open(href, '_blank', 'noopener,noreferrer');
-    trackEvent('Outbound Link: Click', { props: { url: href } });
+    trackEvent('Outbound Link: Click', {
+      props: props,
+    });
     event.preventDefault();
     event.stopPropagation();
   };
 
   return (
-    <Link href={href} component={component} onClick={onClick} {...linkProps}>
+    <Link
+      href={href}
+      component={component}
+      onClick={onClick}
+      {..._.omit('trackingProps', linkProps)}
+    >
       {children}
     </Link>
   );

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -213,7 +213,7 @@ const GroupForm = () => {
       })
     ).then(() => {
       if (isNew) {
-        trackEvent('Create Group', {});
+        trackEvent('group.create', {});
       }
     });
   };

--- a/src/group/membership/components/GroupMembershipJoinLeaveButton.js
+++ b/src/group/membership/components/GroupMembershipJoinLeaveButton.js
@@ -53,7 +53,7 @@ const GroupMembershipJoinLeaveButton = () => {
   const userMembership = _.get('membersInfo.accountMembership', group);
 
   const onJoin = successMessage => () => {
-    trackEvent('joinGroup', { props: { group: groupSlug } });
+    trackEvent('group.join', { props: { group: groupSlug } });
     dispatch(
       joinGroup({
         groupSlug,
@@ -65,7 +65,7 @@ const GroupMembershipJoinLeaveButton = () => {
   };
 
   const onRemove = successMessage => () => {
-    trackEvent('leaveGroup', { props: { group: groupSlug } });
+    trackEvent('group.leave', { props: { group: groupSlug } });
     dispatch(
       leaveGroup({
         groupSlug,

--- a/src/landscape/components/LandscapeForm/BoundaryStepUpdate.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepUpdate.js
@@ -78,7 +78,7 @@ const LandscapeBoundariesUpdate = () => {
     ).then(data => {
       const success = _.get('meta.requestStatus', data) === 'fulfilled';
       if (success) {
-        trackEvent('Update landscape boundary', {
+        trackEvent('landscape.boundary.edit', {
           props: {
             landscapeName: updatedLandscape.name,
             country: updatedLandscape.location,

--- a/src/landscape/components/LandscapeForm/New.js
+++ b/src/landscape/components/LandscapeForm/New.js
@@ -117,7 +117,7 @@ const LandscapeNew = () => {
         return Promise.reject();
       }
       navigate(`/landscapes/${landscape.slug}`);
-      trackEvent('Landscape creation - exit', {
+      trackEvent('landscape.create.exit', {
         props: {
           landscapeName: updatedLandscape.name,
           country: updatedLandscape.location,
@@ -126,7 +126,7 @@ const LandscapeNew = () => {
         },
       });
       if (updatedLandscape.boundaryOption) {
-        trackEvent('Create landscape boundary', {
+        trackEvent('landscape.boundary.create', {
           props: {
             landscapeName: updatedLandscape.name,
             country: updatedLandscape.location,
@@ -153,7 +153,7 @@ const LandscapeNew = () => {
         return;
       }
       if (!updatedLandscape.id) {
-        trackEvent('Landscape created', {
+        trackEvent('landscape.create', {
           props: {
             landscapeName: updatedLandscape.name,
             country: updatedLandscape.location,

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -193,7 +193,7 @@ const SharedDataEntryBase = props => {
             </ConfirmButton>
           </Restricted>
           <Restricted permission="sharedData.download" resource={group}>
-            <DownloadComponent dataEntry={dataEntry} />
+            <DownloadComponent group={group} dataEntry={dataEntry} />
           </Restricted>
         </Grid>
         <Grid item xs={1} order={{ xs: 9 }} display={{ md: 'none' }} />

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -69,7 +69,7 @@ const SharedDataEntryBase = props => {
         const success = _.get('meta.requestStatus', data) === 'fulfilled';
         if (success) {
           updateOwner();
-          trackEvent('deletedataEntry', { props: { owner: owner.slug } });
+          trackEvent('dataEntry.delete', { props: { owner: owner.slug } });
         }
         dispatch(resetProcessing(dataEntry.id));
       }
@@ -88,7 +88,7 @@ const SharedDataEntryBase = props => {
       const success = _.get('meta.requestStatus', data) === 'fulfilled';
       if (success) {
         updateOwner();
-        trackEvent('editdataEntry', { props: { owner: owner.slug } });
+        trackEvent('dataEntry.edit', { props: { owner: owner.slug } });
       }
       dispatch(resetProcessing(dataEntry.id));
     });

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -40,7 +40,7 @@ const DownloadComponent = props => {
         trackingProps: { group: group.slug },
       }}
       onClick={() =>
-        trackEvent('dataEntry.link.clicked', { props: { group: group.slug } })
+        trackEvent('dataEntry.link.click', { props: { group: group.slug } })
       }
       aria-label={t('sharedData.download_label', {
         name: dataEntry.name,

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -22,12 +22,14 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IconButton } from '@mui/material';
 
 import ExternalLink from 'common/components/ExternalLink';
+import { useAnalytics } from 'monitoring/analytics';
 
 import LinkIcon from './LinkIcon';
 import SharedDataEntryBase, { ICON_SIZE } from './SharedDataEntryBase';
 
 const DownloadComponent = props => {
   const { t } = useTranslation();
+  const { trackEvent } = useAnalytics();
   const { dataEntry, group } = props;
 
   return (
@@ -37,6 +39,9 @@ const DownloadComponent = props => {
       linkProps={{
         trackingProps: { group: group.slug },
       }}
+      onClick={() =>
+        trackEvent('dataEntry.link.clicked', { props: { group: group.slug } })
+      }
       aria-label={t('sharedData.download_label', {
         name: dataEntry.name,
       })}

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -28,12 +28,15 @@ import SharedDataEntryBase, { ICON_SIZE } from './SharedDataEntryBase';
 
 const DownloadComponent = props => {
   const { t } = useTranslation();
-  const { dataEntry } = props;
+  const { dataEntry, group } = props;
 
   return (
     <ExternalLink
       component={IconButton}
       href={dataEntry.url}
+      linkProps={{
+        trackingProps: { group: group.slug },
+      }}
       aria-label={t('sharedData.download_label', {
         name: dataEntry.name,
       })}

--- a/src/sharedData/components/SharedDataUpload/index.js
+++ b/src/sharedData/components/SharedDataUpload/index.js
@@ -128,7 +128,7 @@ const SharedDataUpload = props => {
               },
             });
           } else {
-            trackEvent('uploadFile', {
+            trackEvent('dataEntry.file.upload', {
               props: {
                 owner: owner.slug,
                 name: _.get('value.meta.arg.file.name', result),

--- a/src/sharedData/sharedDataHooks.js
+++ b/src/sharedData/sharedDataHooks.js
@@ -23,7 +23,7 @@ export const useSharedData = () => {
   const { owner } = useGroupContext();
 
   const downloadFile = file => {
-    trackEvent('downloadFile', { props: { owner: owner.slug } });
+    trackEvent('dataEntry.file.download', { props: { owner: owner.slug } });
     window.open(file.url, '_blank');
   };
 

--- a/src/sharedData/visualization/components/VisualizationConfigForm/PreviewStep.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/PreviewStep.js
@@ -93,7 +93,7 @@ const PreviewStep = props => {
     ).then(data => {
       const success = _.get('meta.requestStatus', data) === 'fulfilled';
       if (success) {
-        trackEvent('Map: Created', {
+        trackEvent('map.create', {
           props: {
             owner: owner.name,
             file: visualizationConfig?.selectedFile.name,

--- a/src/storyMap/components/StoryMapNew.js
+++ b/src/storyMap/components/StoryMapNew.js
@@ -110,7 +110,7 @@ const StoryMapNew = () => {
     setSaved(null);
     if (published) {
       const url = generateStoryMapUrl({ slug, storyMapId });
-      trackEvent('Storymap Published', {
+      trackEvent('storymap.publish', {
         props: {
           url: `${window.location.origin}${url}`,
           [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,

--- a/src/storyMap/components/StoryMapUpdate.js
+++ b/src/storyMap/components/StoryMapUpdate.js
@@ -66,7 +66,7 @@ const StoryMapUpdate = props => {
     setSaved(null);
     if (published) {
       const url = generateStoryMapUrl({ slug, storyMapId });
-      trackEvent('Storymap Published', {
+      trackEvent('storymap.publish', {
         props: {
           url: `${window.location.origin}${url}`,
           [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,


### PR DESCRIPTION
## Description
Plausible
- tag tracking for shared links by group/landscape
- track logins by SSO type

### Checklist
- [X] Corresponding issue has been opened

### Related Issues
Fixes #803, #484.