### PR TITLE
fix: improve permission checks for file uploads and group member lists

### DIFF
--- a/src/common/components/EditableText.js
+++ b/src/common/components/EditableText.js
@@ -51,24 +51,48 @@ const EditableText = props => {
     setIsHovering(false);
   }, [value, setIsEditing]);
 
-  const handleSave = () => {
+  const handleSave = useCallback(() => {
     if (editedValue === value) {
       reset();
       return;
     }
     onSave(editedValue);
-  };
+  }, [value, editedValue, onSave, reset]);
 
-  const onSaveClick = () => {
-    handleSave();
-  };
+  const handleInputChange = useCallback(
+    event => setEditedValue(event.target.value),
+    []
+  );
 
-  const onKeyDown = event => {
-    if (event.keyCode === 13) {
-      // Enter key
-      handleSave();
-    }
-  };
+  const onInputKeyDown = useCallback(
+    event => {
+      if (event.keyCode === 13) {
+        // Enter key
+        handleSave();
+      }
+    },
+    [handleSave]
+  );
+
+  const onButtonKeyDown = useCallback(
+    event => {
+      if (event.keyCode === 13 || event.keyCode === 32) {
+        setIsEditing(true);
+      }
+    },
+    [setIsEditing]
+  );
+
+  const onButtonClick = useCallback(
+    event => {
+      setIsEditing(true);
+      event.preventDefault();
+    },
+    [setIsEditing]
+  );
+
+  const onButtonMouseOver = useCallback(() => setIsHovering(true), []);
+  const onButtononMouseOut = useCallback(() => setIsHovering(false), []);
 
   const editableInputRef = useRef(null);
 
@@ -93,14 +117,14 @@ const EditableText = props => {
           size="small"
           value={editedValue}
           inputRef={editableInputRef}
-          onChange={event => setEditedValue(event.target.value)}
-          onKeyDown={onKeyDown}
+          onChange={handleInputChange}
+          onKeyDown={onInputKeyDown}
           sx={{ flexGrow: 1 }}
         />
         <LoadingButton
           variant="contained"
           loading={processing}
-          onClick={onSaveClick}
+          onClick={handleSave}
         >
           {t('common.editable_text_save')}
         </LoadingButton>
@@ -118,17 +142,10 @@ const EditableText = props => {
       direction="row"
       justifyContent="space-between"
       tabIndex="0"
-      onKeyDown={event => {
-        if (event.keyCode === 13 || event.keyCode === 32) {
-          setIsEditing(true);
-        }
-      }}
-      onClick={event => {
-        setIsEditing(true);
-        event.preventDefault();
-      }}
-      onMouseOver={() => setIsHovering(true)}
-      onMouseOut={() => setIsHovering(false)}
+      onKeyDown={onButtonKeyDown}
+      onClick={onButtonClick}
+      onMouseOver={onButtonMouseOver}
+      onMouseOut={onButtononMouseOut}
       {...viewProps}
       sx={{
         pt: 1,

--- a/src/group/components/GroupSharedDataUpload.js
+++ b/src/group/components/GroupSharedDataUpload.js
@@ -16,7 +16,7 @@
  */
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { usePermission } from 'permissions';
+import { usePermissionRedirect } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -38,10 +38,6 @@ const GroupSharedDataUpload = () => {
   const { slug } = useParams();
   const { fetching, group } = useSelector(
     state => state.group.sharedDataUpload
-  );
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'sharedData.add',
-    group
   );
 
   useDocumentTitle(
@@ -66,17 +62,13 @@ const GroupSharedDataUpload = () => {
     navigate(`/groups/${slug}`);
   }, [navigate, slug]);
 
-  useEffect(() => {
-    if (loadingPermissions) {
-      return;
-    }
+  usePermissionRedirect(
+    'sharedData.add',
+    group,
+    useMemo(() => `/groups/${group?.slug}`, [group?.slug])
+  );
 
-    if (!allowed && group.slug) {
-      navigate(`/groups/${group?.slug}`);
-    }
-  }, [allowed, loadingPermissions, navigate, group?.slug]);
-
-  if (fetching || loadingPermissions) {
+  if (fetching) {
     return <PageLoader />;
   }
 

--- a/src/group/components/GroupSharedDataUpload.js
+++ b/src/group/components/GroupSharedDataUpload.js
@@ -16,6 +16,7 @@
  */
 import React, { useCallback, useEffect, useMemo } from 'react';
 
+import { usePermission } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -37,6 +38,10 @@ const GroupSharedDataUpload = () => {
   const { slug } = useParams();
   const { fetching, group } = useSelector(
     state => state.group.sharedDataUpload
+  );
+  const { loading: loadingPermissions, allowed } = usePermission(
+    'sharedData.add',
+    group
   );
 
   useDocumentTitle(
@@ -61,7 +66,17 @@ const GroupSharedDataUpload = () => {
     navigate(`/groups/${slug}`);
   }, [navigate, slug]);
 
-  if (fetching) {
+  useEffect(() => {
+    if (loadingPermissions) {
+      return;
+    }
+
+    if (!allowed && group.slug) {
+      navigate(`/groups/${group?.slug}`);
+    }
+  }, [allowed, loadingPermissions, navigate, group?.slug]);
+
+  if (fetching || loadingPermissions) {
     return <PageLoader />;
   }
 

--- a/src/group/components/GroupSharedDataUpload.js
+++ b/src/group/components/GroupSharedDataUpload.js
@@ -62,13 +62,13 @@ const GroupSharedDataUpload = () => {
     navigate(`/groups/${slug}`);
   }, [navigate, slug]);
 
-  usePermissionRedirect(
+  const { loading } = usePermissionRedirect(
     'sharedData.add',
     group,
     useMemo(() => `/groups/${group?.slug}`, [group?.slug])
   );
 
-  if (fetching) {
+  if (fetching || loading) {
     return <PageLoader />;
   }
 

--- a/src/group/components/GroupSharedDataUploadFiles.test.js
+++ b/src/group/components/GroupSharedDataUploadFiles.test.js
@@ -39,6 +39,7 @@ const setup = async () => {
       'groups.edges[0].node',
       {
         id: 'group-id',
+        slug: 'slug-1',
         name: 'Group Name',
       },
       {}

--- a/src/group/components/GroupSharedDataUploadFiles.test.js
+++ b/src/group/components/GroupSharedDataUploadFiles.test.js
@@ -41,6 +41,10 @@ const setup = async () => {
         id: 'group-id',
         slug: 'slug-1',
         name: 'Group Name',
+        accountMembership: {
+          userRole: 'MEMBER',
+          membershipStatus: 'APPROVED',
+        },
       },
       {}
     )
@@ -189,6 +193,7 @@ test('GroupSharedDataUpload: Complete Success', async () => {
           new File(['content'], `test${index}.csv`, { type: 'text/csv' })
       )
   );
+  expect(navigate).toHaveBeenCalledTimes(0);
   const uploadButton = screen.getByRole('button', {
     name: 'Share Files and Links',
   });
@@ -204,6 +209,7 @@ test('GroupSharedDataUpload: PDF Success', async () => {
   await dropFiles([
     new File(['content'], 'test.pdf', { type: 'application/pdf' }),
   ]);
+  expect(navigate).toHaveBeenCalledTimes(0);
   const uploadButton = screen.getByRole('button', {
     name: 'Share Files and Links',
   });
@@ -244,6 +250,7 @@ test('GroupSharedDataUpload: MS Office Success', async () => {
           })
       )
   );
+  expect(navigate).toHaveBeenCalledTimes(0);
 
   const uploadButton = screen.getByRole('button', {
     name: 'Share Files and Links',
@@ -276,6 +283,7 @@ test('GroupSharedDataUpload: Gis files', async () => {
         })
     )
   );
+  expect(navigate).toHaveBeenCalledTimes(0);
 
   const uploadButton = screen.getByRole('button', {
     name: 'Share Files and Links',

--- a/src/group/groupService.js
+++ b/src/group/groupService.js
@@ -85,9 +85,9 @@ export const fetchGroupToView = slug => {
     }));
 };
 
-export const fetchGroupToUploadSharedData = (slug, currentUser) => {
+export const fetchGroupToUploadSharedData = slug => {
   const query = `
-    query group($slug: String!, $accountEmail: String!){
+    query group($slug: String!){
       groups(slug: $slug) {
         edges {
           node {
@@ -102,7 +102,7 @@ export const fetchGroupToUploadSharedData = (slug, currentUser) => {
     ${accountMembership}
   `;
   return terrasoApi
-    .requestGraphQL(query, { slug, accountEmail: currentUser.email })
+    .requestGraphQL(query, { slug })
     .then(_.get('groups.edges[0].node'))
     .then(group => group || Promise.reject('not_found'))
     .then(group => ({

--- a/src/group/groupService.js
+++ b/src/group/groupService.js
@@ -85,24 +85,30 @@ export const fetchGroupToView = slug => {
     }));
 };
 
-export const fetchGroupToUploadSharedData = slug => {
+export const fetchGroupToUploadSharedData = (slug, currentUser) => {
   const query = `
-    query group($slug: String!){
+    query group($slug: String!, $accountEmail: String!){
       groups(slug: $slug) {
         edges {
           node {
             id
             slug
             name
+            ...accountMembership
           }
         }
       }
     }
+    ${accountMembership}
   `;
   return terrasoApi
-    .requestGraphQL(query, { slug })
+    .requestGraphQL(query, { slug, accountEmail: currentUser.email })
     .then(_.get('groups.edges[0].node'))
-    .then(group => group || Promise.reject('not_found'));
+    .then(group => group || Promise.reject('not_found'))
+    .then(group => ({
+      ..._.omit(['memberships', 'accountMembership'], group),
+      membersInfo: extractMembersInfo(group),
+    }));
 };
 
 export const fetchGroups = () => {

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -14,13 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import _ from 'lodash/fp';
-import { usePermission } from 'permissions';
+import { usePermission, usePermissionRedirect } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { Typography } from '@mui/material';
 
@@ -48,7 +48,6 @@ const MemberLeaveButton = withProps(GroupMemberLeave, {
 const Header = props => {
   const { t } = useTranslation();
   const { group, fetching } = props;
-  const navigate = useNavigate();
 
   useDocumentTitle(
     t('group.members_document_title', {
@@ -64,25 +63,18 @@ const Header = props => {
     )
   );
 
-  const { loading: loadingViewPermissions, allowed: viewAllowed } =
-    usePermission('group.viewMembers', group);
-
   const { loading: loadingPermissions, allowed } = usePermission(
     'group.manageMembers',
     group
   );
 
-  useEffect(() => {
-    if (loadingViewPermissions) {
-      return;
-    }
+  usePermissionRedirect(
+    'group.viewMembers',
+    group,
+    useMemo(() => `/groups/${group?.slug}`, [group?.slug])
+  );
 
-    if (!viewAllowed && group.slug) {
-      navigate(`/groups/${group?.slug}`);
-    }
-  }, [viewAllowed, loadingViewPermissions, navigate, group?.slug]);
-
-  if (fetching || loadingPermissions || loadingViewPermissions) {
+  if (fetching || loadingPermissions) {
     return null;
   }
 

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -14,13 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
 import { usePermission } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Typography } from '@mui/material';
 
@@ -48,6 +48,7 @@ const MemberLeaveButton = withProps(GroupMemberLeave, {
 const Header = props => {
   const { t } = useTranslation();
   const { group, fetching } = props;
+  const navigate = useNavigate();
 
   useDocumentTitle(
     t('group.members_document_title', {
@@ -63,12 +64,25 @@ const Header = props => {
     )
   );
 
+  const { loading: loadingViewPermissions, allowed: viewAllowed } =
+    usePermission('group.viewMembers', group);
+
   const { loading: loadingPermissions, allowed } = usePermission(
     'group.manageMembers',
     group
   );
 
-  if (fetching || loadingPermissions) {
+  useEffect(() => {
+    if (loadingViewPermissions) {
+      return;
+    }
+
+    if (!viewAllowed && group.slug) {
+      navigate(`/groups/${group?.slug}`);
+    }
+  }, [viewAllowed, loadingViewPermissions, navigate, group?.slug]);
+
+  if (fetching || loadingPermissions || loadingViewPermissions) {
     return null;
   }
 

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -68,13 +68,13 @@ const Header = props => {
     group
   );
 
-  usePermissionRedirect(
+  const { loading } = usePermissionRedirect(
     'group.viewMembers',
     group,
     useMemo(() => `/groups/${group?.slug}`, [group?.slug])
   );
 
-  if (fetching || loadingPermissions) {
+  if (fetching || loading || loadingPermissions) {
     return null;
   }
 

--- a/src/group/membership/components/GroupMembers.test.js
+++ b/src/group/membership/components/GroupMembers.test.js
@@ -111,6 +111,7 @@ test('GroupMembers: Empty', async () => {
         'groups.edges[0].node',
         {
           name: 'Group Name',
+          membershipType: 'OPEN',
         },
         {}
       )
@@ -142,6 +143,7 @@ test('GroupMembers: Display list', async () => {
   const group = {
     slug: 'test-group-slug',
     name: 'Group Name',
+    membershipType: 'OPEN',
     memberships: generateMemberhips(3, 20),
   };
 
@@ -198,6 +200,7 @@ test('GroupMembers: Display list (small)', async () => {
   const group = {
     slug: 'test-group-slug',
     name: 'Group Name',
+    membershipType: 'OPEN',
     memberships: generateMemberhips(3, 20),
   };
 

--- a/src/group/membership/components/GroupMembers.test.js
+++ b/src/group/membership/components/GroupMembers.test.js
@@ -20,6 +20,8 @@ import React from 'react';
 
 import _ from 'lodash/fp';
 import { act } from 'react-dom/test-utils';
+import { useNavigate } from 'react-router-dom';
+import { GROUP_TYPES_WITH_REDIRECTS } from 'tests/constants';
 
 import useMediaQuery from '@mui/material/useMediaQuery';
 
@@ -32,6 +34,11 @@ global.console.error = jest.fn();
 jest.mock('terrasoBackend/api');
 
 jest.mock('@mui/material/useMediaQuery');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
 
 const setup = async initialState => {
   await render(<GroupMembers />, {
@@ -49,6 +56,39 @@ const setup = async initialState => {
     ...initialState,
   });
 };
+
+Object.keys(GROUP_TYPES_WITH_REDIRECTS).forEach(currentGroup =>
+  test(`GroupMembers: Redirection: ${currentGroup}`, async () => {
+    const navigate = jest.fn();
+    useNavigate.mockReturnValue(navigate);
+
+    terrasoApi.requestGraphQL.mockReturnValue(
+      Promise.resolve(
+        _.set(
+          'groups.edges[0].node',
+          {
+            id: 'group-id',
+            slug: 'slug-1',
+            name: 'Group Name',
+            membershipType:
+              GROUP_TYPES_WITH_REDIRECTS[currentGroup].membershipType,
+            accountMembership: {
+              userRole: GROUP_TYPES_WITH_REDIRECTS[currentGroup].userRole,
+              membershipStatus: 'APPROVED',
+            },
+          },
+          {}
+        )
+      )
+    );
+
+    await setup();
+
+    expect(navigate).toHaveBeenCalledTimes(
+      GROUP_TYPES_WITH_REDIRECTS[currentGroup].memberListRedirectCount
+    );
+  })
+);
 
 test('GroupMembers: Display error', async () => {
   terrasoApi.requestGraphQL.mockRejectedValue('Load error');

--- a/src/group/membership/components/GroupMembershipCard.test.js
+++ b/src/group/membership/components/GroupMembershipCard.test.js
@@ -68,6 +68,16 @@ const setup = async initialState => {
           },
         },
       },
+      group: {
+        memberships: {
+          'group-slug': {
+            fetching: false,
+            group: {
+              slug: 'group-slug',
+            },
+          },
+        },
+      },
       ...initialState,
     }
   );

--- a/src/group/membership/components/groupMembershipConstants.js
+++ b/src/group/membership/components/groupMembershipConstants.js
@@ -20,3 +20,6 @@ export const MEMBERSHIP_OPEN = 'OPEN';
 
 export const MEMBERSHIP_STATUS_PENDING = 'PENDING';
 export const MEMBERSHIP_STATUS_APPROVED = 'APPROVED';
+
+export const ROLE_MEMBER = 'MEMBER';
+export const ROLE_MANAGER = 'MANAGER';

--- a/src/landscape/components/LandscapeSharedDataUpload.js
+++ b/src/landscape/components/LandscapeSharedDataUpload.js
@@ -17,6 +17,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
+import { usePermission } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -38,6 +39,11 @@ const LandscapeSharedDataUpload = () => {
   const { slug } = useParams();
   const { fetching, landscape } = useSelector(
     state => state.landscape.sharedDataUpload
+  );
+
+  const { loading: loadingPermissions, allowed } = usePermission(
+    'sharedData.add',
+    landscape?.defaultGroup
   );
 
   useDocumentTitle(
@@ -65,7 +71,17 @@ const LandscapeSharedDataUpload = () => {
     });
   }, [navigate, slug]);
 
-  if (fetching) {
+  useEffect(() => {
+    if (loadingPermissions) {
+      return;
+    }
+
+    if (!allowed && landscape.slug) {
+      navigate(`/landscapes/${landscape?.slug}`);
+    }
+  }, [allowed, loadingPermissions, navigate, landscape?.slug]);
+
+  if (fetching || loadingPermissions) {
     return <PageLoader />;
   }
 

--- a/src/landscape/components/LandscapeSharedDataUpload.js
+++ b/src/landscape/components/LandscapeSharedDataUpload.js
@@ -68,7 +68,7 @@ const LandscapeSharedDataUpload = () => {
 
   const { loading } = usePermissionRedirect(
     'sharedData.add',
-    landscape,
+    landscape?.defaultGroup,
     useMemo(() => `/landscapes/${landscape?.slug}`, [landscape?.slug])
   );
 

--- a/src/landscape/components/LandscapeSharedDataUpload.js
+++ b/src/landscape/components/LandscapeSharedDataUpload.js
@@ -17,7 +17,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
-import { usePermission } from 'permissions';
+import { usePermissionRedirect } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -39,11 +39,6 @@ const LandscapeSharedDataUpload = () => {
   const { slug } = useParams();
   const { fetching, landscape } = useSelector(
     state => state.landscape.sharedDataUpload
-  );
-
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'sharedData.add',
-    landscape?.defaultGroup
   );
 
   useDocumentTitle(
@@ -71,17 +66,13 @@ const LandscapeSharedDataUpload = () => {
     });
   }, [navigate, slug]);
 
-  useEffect(() => {
-    if (loadingPermissions) {
-      return;
-    }
+  usePermissionRedirect(
+    'sharedData.add',
+    landscape,
+    useMemo(() => `/landscapes/${landscape?.slug}`, [landscape?.slug])
+  );
 
-    if (!allowed && landscape.slug) {
-      navigate(`/landscapes/${landscape?.slug}`);
-    }
-  }, [allowed, loadingPermissions, navigate, landscape?.slug]);
-
-  if (fetching || loadingPermissions) {
+  if (fetching) {
     return <PageLoader />;
   }
 

--- a/src/landscape/components/LandscapeSharedDataUpload.js
+++ b/src/landscape/components/LandscapeSharedDataUpload.js
@@ -66,13 +66,13 @@ const LandscapeSharedDataUpload = () => {
     });
   }, [navigate, slug]);
 
-  usePermissionRedirect(
+  const { loading } = usePermissionRedirect(
     'sharedData.add',
     landscape,
     useMemo(() => `/landscapes/${landscape?.slug}`, [landscape?.slug])
   );
 
-  if (fetching) {
+  if (fetching || loading) {
     return <PageLoader />;
   }
 

--- a/src/landscape/components/LandscapeSharedDataUploadLinks.test.js
+++ b/src/landscape/components/LandscapeSharedDataUploadLinks.test.js
@@ -39,14 +39,15 @@ const setup = async () => {
     {
       id: 'landscape-id',
       name: 'Landscape Name',
-      defaultGroup: _.set(
-        'edges[0].node',
-        {
-          id: 'group-id',
-          slug: 'group-slug',
+      slug: 'slug-1',
+      defaultGroup: {
+        id: 'group-id',
+        slug: 'group-slug',
+        accountMembership: {
+          userRole: 'MEMBER',
+          membershipStatus: 'APPROVED',
         },
-        {}
-      ),
+      },
     },
     {}
   );
@@ -192,6 +193,7 @@ test('LandscapeSharedDataUpload: Complete Success', async () => {
   const navigate = jest.fn();
   useNavigate.mockReturnValue(navigate);
   await setup();
+  expect(navigate).toHaveBeenCalledTimes(0);
   terrasoApi.requestGraphQL.mockResolvedValueOnce(
     _.set(
       'addDataEntry.dataEntry',

--- a/src/landscape/components/LandscapeSharedDataUploadLinks.test.js
+++ b/src/landscape/components/LandscapeSharedDataUploadLinks.test.js
@@ -20,6 +20,7 @@ import React from 'react';
 
 import _ from 'lodash/fp';
 import { useNavigate, useParams } from 'react-router-dom';
+import { LANDSCAPE_TYPES_WITH_REDIRECTS } from 'tests/constants';
 
 import * as terrasoApi from 'terrasoBackend/api';
 
@@ -33,7 +34,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
 }));
 
-const setup = async () => {
+const setup = async (userRole = 'MEMBER') => {
   const landscape = _.set(
     'landscapes.edges[0].node',
     {
@@ -44,7 +45,7 @@ const setup = async () => {
         id: 'group-id',
         slug: 'group-slug',
         accountMembership: {
-          userRole: 'MEMBER',
+          userRole,
           membershipStatus: 'APPROVED',
         },
       },
@@ -75,6 +76,19 @@ beforeEach(() => {
   });
   useNavigate.mockReturnValue(() => {});
 });
+
+Object.keys(LANDSCAPE_TYPES_WITH_REDIRECTS).forEach(currentLandscape =>
+  test(`LandscapeSharedDataUpload: Redirection: ${currentLandscape}`, async () => {
+    const navigate = jest.fn();
+    useNavigate.mockReturnValue(navigate);
+
+    await setup(LANDSCAPE_TYPES_WITH_REDIRECTS[currentLandscape].userRole);
+
+    expect(navigate).toHaveBeenCalledTimes(
+      LANDSCAPE_TYPES_WITH_REDIRECTS[currentLandscape].uploadRedirectCount
+    );
+  })
+);
 
 test('LandscapeSharedDataUpload: Error - Empty name', async () => {
   await setup();

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import { act, fireEvent, render, screen, within } from 'tests/utils';
+import { act, fireEvent, render, screen, waitFor, within } from 'tests/utils';
 
 import React from 'react';
 
@@ -270,6 +270,15 @@ test('LandscapeView: Update Shared Data', async () => {
   });
   expect(nameField).toBeInTheDocument();
   await act(async () => fireEvent.click(nameField));
+
+  await waitFor(() =>
+    expect(
+      within(items[3]).getByRole('textbox', {
+        name: 'Update name',
+      })
+    ).toBeInTheDocument()
+  );
+
   const name = within(items[3]).getByRole('textbox', {
     name: 'Update name',
   });

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -33,6 +33,10 @@ const Restricted = props => {
   } = props;
   const { loading, allowed } = usePermission(permission, resource);
 
+  if (!resource) {
+    return null;
+  }
+
   if (loading) {
     return LoadingComponent ? (
       <LoadingComponent />

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -18,6 +18,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 
 import _ from 'lodash/fp';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
 const defaultBehaviour = {
   isAllowedTo: () => Promise.resolve(false),
@@ -42,6 +43,22 @@ export const PermissionsProvider = ({ rules, children }) => {
       {children}
     </PermissionsContext.Provider>
   );
+};
+
+export const usePermissionRedirect = (permission, resource, path) => {
+  const navigate = useNavigate();
+
+  const { loading, allowed } = usePermission(permission, resource);
+
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+
+    if (!allowed && path) {
+      navigate(path);
+    }
+  }, [allowed, loading, navigate, path]);
 };
 
 export const usePermission = (permission, resource) => {

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -59,6 +59,8 @@ export const usePermissionRedirect = (permission, resource, path) => {
       navigate(path);
     }
   }, [allowed, loading, navigate, path]);
+
+  return { loading };
 };
 
 export const usePermission = (permission, resource) => {

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -53,7 +53,11 @@ export const usePermission = (permission, resource) => {
   const { isAllowedTo } = useContext(PermissionsContext);
 
   useEffect(() => {
+    if (!resource) {
+      return;
+    }
     isMounted.current = true;
+    setLoading(true);
     isAllowedTo(permission, user, resource).then(allowed => {
       if (isMounted.current) {
         setLoading(false);

--- a/src/permissions/rules.js
+++ b/src/permissions/rules.js
@@ -85,7 +85,12 @@ const isAllowedToChangeGroup = ({ resource: group }) => {
   return Promise.resolve(isManager);
 };
 
-const isAllowedToManagerGroupMembers = ({ resource: group }) => {
+const isAllowedToViewGroupMembers = ({ resource: group }) => {
+  const isMember = isApprovedMember(group);
+  return Promise.resolve(isMember);
+};
+
+const isAllowedToManageGroupMembers = ({ resource: group }) => {
   const isManager = hasRole({ group, role: 'MANAGER' });
   return Promise.resolve(isManager);
 };
@@ -107,7 +112,8 @@ const isAllowedToChangeStoryMap = ({ resource: storyMap, user }) => {
 
 const rules = {
   'group.change': isAllowedToChangeGroup,
-  'group.manageMembers': isAllowedToManagerGroupMembers,
+  'group.manageMembers': isAllowedToManageGroupMembers,
+  'group.viewMembers': isAllowedToViewGroupMembers,
   'group.viewFiles': isAllowedToViewGroupSharedData,
   'landscape.change': isAllowedToChangeLandscape,
   'sharedData.add': isAllowedToAddSharedData,

--- a/src/permissions/rules.js
+++ b/src/permissions/rules.js
@@ -16,7 +16,11 @@
  */
 import _ from 'lodash/fp';
 
-import { MEMBERSHIP_STATUS_APPROVED } from 'group/membership/components/groupMembershipConstants';
+import {
+  MEMBERSHIP_OPEN,
+  MEMBERSHIP_STATUS_APPROVED,
+  ROLE_MANAGER,
+} from 'group/membership/components/groupMembershipConstants';
 
 const getAccountMembership = group =>
   _.getOr(
@@ -51,7 +55,7 @@ const isAllowedToEditSharedData = ({
   resource: { group, dataEntry },
   user,
 }) => {
-  const isManager = hasRole({ group, role: 'MANAGER' });
+  const isManager = hasRole({ group, role: ROLE_MANAGER });
   const isOwner = _.get('createdBy.id', dataEntry) === _.get('id', user);
   return Promise.resolve(isManager || isOwner);
 };
@@ -64,7 +68,7 @@ const isAllowedToDeleteVisualization = ({
   resource: { group, visualizationConfig },
   user,
 }) => {
-  const isManager = hasRole({ group, role: 'MANAGER' });
+  const isManager = hasRole({ group, role: ROLE_MANAGER });
   const isOwner =
     _.get('createdBy.id', visualizationConfig) === _.get('id', user);
   return Promise.resolve(isManager || isOwner);
@@ -81,7 +85,7 @@ const isAllowedToAddSharedData = ({ resource: group }) => {
 };
 
 const isAllowedToChangeGroup = ({ resource: group }) => {
-  const isManager = hasRole({ group, role: 'MANAGER' });
+  const isManager = hasRole({ group, role: ROLE_MANAGER });
   return Promise.resolve(isManager);
 };
 
@@ -91,7 +95,7 @@ const isAllowedToViewGroupMembers = ({ resource: group }) => {
 };
 
 const isAllowedToManageGroupMembers = ({ resource: group }) => {
-  const isManager = hasRole({ group, role: 'MANAGER' });
+  const isManager = hasRole({ group, role: ROLE_MANAGER });
   return Promise.resolve(isManager);
 };
 
@@ -101,7 +105,10 @@ const isAllowedToViewGroupSharedData = ({ resource: group }) => {
 };
 
 const isAllowedToChangeLandscape = ({ resource: landscape }) => {
-  const isManager = hasRole({ group: landscape.defaultGroup, role: 'MANAGER' });
+  const isManager = hasRole({
+    group: landscape.defaultGroup,
+    role: ROLE_MANAGER,
+  });
   return Promise.resolve(isManager);
 };
 

--- a/src/permissions/rules.js
+++ b/src/permissions/rules.js
@@ -89,7 +89,13 @@ const isAllowedToChangeGroup = ({ resource: group }) => {
   return Promise.resolve(isManager);
 };
 
+// is open group or closed + you are a member
 const isAllowedToViewGroupMembers = ({ resource: group }) => {
+  const isOpenGroup = group.membershipType === MEMBERSHIP_OPEN;
+  if (isOpenGroup) {
+    return Promise.resolve(true);
+  }
+
   const isMember = isApprovedMember(group);
   return Promise.resolve(isMember);
 };

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
@@ -63,7 +63,7 @@ const SharedDataEntryBase = props => {
   const dispatch = useDispatch();
   const { trackEvent } = useAnalytics();
 
-  const onConfirm = () => {
+  const onConfirm = useCallback(() => {
     dispatch(deleteSharedData({ groupSlug: group.slug, dataEntry })).then(
       data => {
         const success = _.get('meta.requestStatus', data) === 'fulfilled';
@@ -74,27 +74,39 @@ const SharedDataEntryBase = props => {
         dispatch(resetProcessing(dataEntry.id));
       }
     );
-  };
+  }, [dataEntry, dispatch, group.slug, owner.slug, trackEvent, updateOwner]);
 
-  const onUpdate = field => value => {
-    dispatch(
-      updateSharedData({
-        dataEntry: {
-          ..._.pick(['id', 'name', 'description'], dataEntry),
-          [field]: value,
-        },
-      })
-    ).then(data => {
-      const success = _.get('meta.requestStatus', data) === 'fulfilled';
-      if (success) {
-        updateOwner();
-        trackEvent('dataEntry.edit', { props: { owner: owner.slug } });
-      }
-      dispatch(resetProcessing(dataEntry.id));
-    });
-  };
+  const onUpdate = useCallback(
+    field => value => {
+      dispatch(
+        updateSharedData({
+          dataEntry: {
+            ..._.pick(['id', 'name', 'description'], dataEntry),
+            [field]: value,
+          },
+        })
+      ).then(data => {
+        const success = _.get('meta.requestStatus', data) === 'fulfilled';
+        if (success) {
+          updateOwner();
+          trackEvent('dataEntry.edit', { props: { owner: owner.slug } });
+        }
+        dispatch(resetProcessing(dataEntry.id));
+      });
+    },
+    [dataEntry, dispatch, owner.slug, trackEvent, updateOwner]
+  );
 
-  const description = _.get('description', dataEntry);
+  const onUpdateName = useMemo(() => onUpdate('name'), [onUpdate]);
+  const onUpdateDescription = useMemo(
+    () => onUpdate('description'),
+    [onUpdate]
+  );
+
+  const description = useMemo(
+    () => _.get('description', dataEntry),
+    [dataEntry]
+  );
 
   return (
     <ListItem sx={{ p: 0, flexDirection: 'column' }}>
@@ -117,11 +129,12 @@ const SharedDataEntryBase = props => {
             resource={{ group, dataEntry }}
             FallbackComponent={() => <Typography>{dataEntry.name}</Typography>}
           >
+            {console.log({ isEditingName, processing })}
             <EditableText
               id={`name-${dataEntry.id}`}
               label={t('sharedData.name_update')}
               value={dataEntry.name}
-              onSave={onUpdate('name')}
+              onSave={onUpdateName}
               processing={processing}
               isEditing={isEditingName}
               setIsEditing={setIsEditingName}
@@ -222,7 +235,7 @@ const SharedDataEntryBase = props => {
                   ? 'sharedData.add_link_description_message'
                   : 'sharedData.add_file_description_message'
               )}
-              onSave={onUpdate('description')}
+              onSave={onUpdateDescription}
               viewProps={{ variant: 'body1' }}
             />
           </Restricted>

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -108,6 +108,11 @@ const SharedDataEntryBase = props => {
     [dataEntry]
   );
 
+  const permissionsResource = useMemo(
+    () => ({ group, dataEntry }),
+    [dataEntry, group]
+  );
+
   return (
     <ListItem sx={{ p: 0, flexDirection: 'column' }}>
       <Grid
@@ -126,10 +131,9 @@ const SharedDataEntryBase = props => {
           <EntryTypeIcon resourceType={dataEntry.resourceType} />
           <Restricted
             permission="sharedData.edit"
-            resource={{ group, dataEntry }}
+            resource={permissionsResource}
             FallbackComponent={() => <Typography>{dataEntry.name}</Typography>}
           >
-            {console.log({ isEditingName, processing })}
             <EditableText
               id={`name-${dataEntry.id}`}
               label={t('sharedData.name_update')}
@@ -168,7 +172,7 @@ const SharedDataEntryBase = props => {
         >
           <Restricted
             permission="sharedData.delete"
-            resource={{ group, dataEntry }}
+            resource={permissionsResource}
           >
             <ConfirmButton
               onConfirm={onConfirm}
@@ -218,7 +222,7 @@ const SharedDataEntryBase = props => {
         >
           <Restricted
             permission="sharedData.edit"
-            resource={{ group, dataEntry }}
+            resource={permissionsResource}
             FallbackComponent={() => (
               <Typography variant="body1">{dataEntry.description}</Typography>
             )}

--- a/src/tests/constants.js
+++ b/src/tests/constants.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+export const GROUP_TYPES_WITH_REDIRECTS = {
+  'Open member': {
+    membershipType: 'OPEN',
+    userRole: 'MEMBER',
+    uploadRedirectCount: 0,
+    memberListRedirectCount: 0,
+  },
+  'Open nonmember': {
+    membershipType: 'OPEN',
+    userRole: null,
+    uploadRedirectCount: 1,
+    memberListRedirectCount: 0,
+  },
+  'Open manager': {
+    membershipType: 'OPEN',
+    userRole: 'MANAGER',
+    uploadRedirectCount: 0,
+    memberListRedirectCount: 0,
+  },
+  'Closed member': {
+    membershipType: 'CLOSED',
+    userRole: 'MEMBER',
+    uploadRedirectCount: 0,
+    memberListRedirectCount: 0,
+  },
+  'Closed nonmember': {
+    membershipType: 'CLOSED',
+    userRole: null,
+    uploadRedirectCount: 1,
+    memberListRedirectCount: 1,
+  },
+  'Closed manager': {
+    membershipType: 'CLOSED',
+    userRole: 'MANAGER',
+    uploadRedirectCount: 0,
+    memberListRedirectCount: 0,
+  },
+};
+
+export const LANDSCAPE_TYPES_WITH_REDIRECTS = {
+  Member: {
+    userRole: 'MEMBER',
+    uploadRedirectCount: 0,
+  },
+  Manager: {
+    userRole: 'MANAGER',
+    uploadRedirectCount: 0,
+  },
+  Nonmember: {
+    userRole: null,
+    uploadRedirectCount: 1,
+  },
+};


### PR DESCRIPTION
## Description
Improve permission checks for file uploads and group member lists

Ensure users are redirected when the attempt to access `/members` or `/upload`

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #811
Backend: https://github.com/techmatters/terraso-backend/pull/419

Need to update query after https://github.com/techmatters/terraso-web-client/pull/857 is merged.