### PR TITLE
fix: Cast website value before saving

### DIFF
--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -140,6 +140,10 @@ const InfoStep = props => {
     [isNew, landscape, user.email]
   );
 
+  const formattedValues = useMemo(() =>
+    updatedValues ? VALIDATION_SCHEMA.cast(updatedValues) : null
+  , [updatedValues]);
+
   return (
     <>
       <PageHeader
@@ -154,7 +158,6 @@ const InfoStep = props => {
         {t('landscape.form_new_description')}
       </Typography>
       <Form
-        mode="onChange"
         aria-labelledby="landscape-form-page-title"
         prefix="landscape"
         localizationPrefix="landscape.form_key_info"
@@ -168,7 +171,7 @@ const InfoStep = props => {
         isForm
         isNew={isNew}
         onCancel={() => navigate(-1)}
-        updatedValues={updatedValues}
+        updatedValues={formattedValues}
         onNext={setUpdatedLandscape}
         nextLabel={t('landscape.form_add_landscape_label')}
         updateLabel={t('landscape.form_save_label')}

--- a/src/landscape/components/LandscapeForm/KeyInfoUpdate.test.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoUpdate.test.js
@@ -289,7 +289,7 @@ test('KeyInfoUpdate: Save form', async () => {
     target: { value: 'new@other.org' },
   });
   fireEvent.change(inputs.website, {
-    target: { value: 'https://www.other.org' },
+    target: { value: 'www.other.org' },
   });
   await inputs.changeLocation('Argentina');
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Added yup cast to transform website before saving

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #666 
