### PR TITLE
fix: Clear url when link dialog opens in richtext editor

### DIFF
--- a/src/common/components/RichTextEditor/index.js
+++ b/src/common/components/RichTextEditor/index.js
@@ -283,6 +283,7 @@ const AddLinkButton = props => {
   const onButtonClick = useCallback(event => {
     event.preventDefault();
     setOpen(true);
+    setUrl('');
   }, []);
 
   const handleClose = useCallback(() => {

--- a/src/common/components/RichTextEditor/index.js
+++ b/src/common/components/RichTextEditor/index.js
@@ -315,7 +315,16 @@ const AddLinkButton = props => {
           {t('common.rich_text_editor_link_add_dialog_title')}
         </DialogTitle>
         <DialogContent>
-          <OutlinedInput fullWidth value={url} onChange={onInputChange} />
+          <OutlinedInput
+            fullWidth
+            value={url}
+            onChange={onInputChange}
+            inputProps={{
+              'aria-label': t(
+                'common.rich_text_editor_link_add_dialog_input_label'
+              ),
+            }}
+          />
           {error && <FormHelperText error>{error}</FormHelperText>}
         </DialogContent>
         <DialogActions>

--- a/src/common/components/RichTextEditor/index.js
+++ b/src/common/components/RichTextEditor/index.js
@@ -420,9 +420,10 @@ const RichTextEditor = props => {
     onChange,
     placeholder,
     addContainer,
+    initialFocused = false,
   } = props;
 
-  const [focused, setFocused] = useState(false);
+  const [focused, setFocused] = useState(initialFocused);
 
   const editor = useMemo(
     () => withInlines(withHistory(withReact(createEditor()))),

--- a/src/common/components/RichTextEditor/index.test.js
+++ b/src/common/components/RichTextEditor/index.test.js
@@ -28,7 +28,7 @@ const setup = async () => {
               text: 'asdasd asd asd ',
             },
             {
-              url: 'https://test.com',
+              url: 'https://example.com',
               type: 'link',
               children: [
                 {

--- a/src/common/components/RichTextEditor/index.test.js
+++ b/src/common/components/RichTextEditor/index.test.js
@@ -1,0 +1,82 @@
+import { act, fireEvent, render, screen, waitFor, within } from 'tests/utils';
+
+import { Editor } from 'slate';
+
+import RichTextEditor from '.';
+
+jest.mock('slate', () => ({
+  ...jest.requireActual('slate'),
+  Editor: {
+    ...jest.requireActual('slate').Editor,
+    nodes: jest.fn(),
+  },
+}));
+
+beforeEach(() => {
+  global.window.open = jest.fn();
+});
+
+const setup = async () => {
+  await render(
+    <RichTextEditor
+      initialFocused
+      value={[
+        {
+          type: 'paragraph',
+          children: [
+            {
+              text: 'asdasd asd asd ',
+            },
+            {
+              url: 'https://test.com',
+              type: 'link',
+              children: [
+                {
+                  text: 'link',
+                },
+              ],
+            },
+            {
+              text: ' asd as',
+            },
+          ],
+        },
+      ]}
+    />
+  );
+};
+
+test('RichTextEditor: Link dialog input should be empty', async () => {
+  Editor.nodes.mockReturnValue([null]);
+  await setup();
+
+  const addLink = async () => {
+    const linkButton = screen.getByRole('button', { name: 'Link' });
+    expect(linkButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.mouseDown(linkButton);
+    });
+
+    const dialog = screen.getByRole('dialog', { name: 'Add Link' });
+
+    const urlInput = within(dialog).getByRole('textbox', { name: 'Link' });
+    await act(async () => {
+      fireEvent.change(urlInput, { target: { value: 'test.com' } });
+    });
+
+    const addButton = within(dialog).getByRole('button', { name: 'Add Link' });
+    await act(async () => {
+      fireEvent.click(addButton);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Add Link' })
+      ).not.toBeInTheDocument()
+    );
+  };
+
+  await addLink();
+  await addLink();
+});

--- a/src/common/components/RichTextEditor/index.test.js
+++ b/src/common/components/RichTextEditor/index.test.js
@@ -62,7 +62,7 @@ test('RichTextEditor: Link dialog input should be empty', async () => {
 
     const urlInput = within(dialog).getByRole('textbox', { name: 'Link' });
     await act(async () => {
-      fireEvent.change(urlInput, { target: { value: 'test.com' } });
+      fireEvent.change(urlInput, { target: { value: 'example.com' } });
     });
 
     const addButton = within(dialog).getByRole('button', { name: 'Add Link' });

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -649,6 +649,7 @@
         "rich_text_editor_link_add_dialog_title": "Add Link",
         "rich_text_editor_link_add_dialog_cancel": "Cancel",
         "rich_text_editor_link_add_dialog_add": "Add Link",
+        "rich_text_editor_link_add_dialog_input_label": "Link",
         "rich_text_editor_toolbar_link_add": "Link",
         "rich_text_editor_toolbar_link_remove": "Unlink",
         "rich_text_editor_toolbar_bold": "Bold",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -522,6 +522,7 @@
         "rich_text_editor_link_add_dialog_title": "Añadir enlace",
         "rich_text_editor_link_add_dialog_cancel": "Cancelar",
         "rich_text_editor_link_add_dialog_add": "Añadir enlace",
+        "rich_text_editor_link_add_dialog_input_label": "Enlace",
         "rich_text_editor_toolbar_link_add": "Enlace",
         "rich_text_editor_toolbar_link_remove": "Desvincular enlace",
         "rich_text_editor_toolbar_bold": "Negrita",


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Clear url when link dialog opens in richtext editor

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #800 
