### PR TITLE
fix: update email notification strings

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -203,8 +203,8 @@
         "profile_document_title": "Account",
         "profile_form_label": "Manage profile",
         "form_language_label": "Language",
-        "form_notifications_section_label": "Notify me when",
-        "form_notifications_label": "A group I manage has pending requests or my request to join a closed group is approved",
+        "form_notifications_section_label": "Email notifications",
+        "form_notifications_label": "Notify me when a group I manage has pending requests or my request to join a closed group is approved",
         "unsubscribe_title": "Unsubscribe",
         "unsubscribe_success": "You have been unsubscribed from Terraso emails.",
         "unsubscribe_error": "Error unsubscribing from Terraso emails"

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -203,8 +203,8 @@
         "profile_document_title": "Cuenta",
         "profile_form_label": "Administrar perfil",
         "form_language_label": "Idioma",
-        "form_notifications_section_label": "Notifícame cuando",
-        "form_notifications_label": "Un grupo que administro tiene solicitudes pendientes o se aprobó mi solicitud para unirme a un grupo cerrado",
+        "form_notifications_section_label": "Notificaciónes de Correo Electrónico",
+        "form_notifications_label": "Notificarme cuando un grupo que administro tenga solicitudes pendientes o se apruebe mi solicitud para unirme a un grupo cerrado",
         "unsubscribe_title": "Darse de baja",
         "unsubscribe_success": "Has sido dado de baja de los correos electrónicos de Terraso.",
         "unsubscribe_error": "Error al darse de baja de los correos electrónicos de Terraso"


### PR DESCRIPTION
## Description
Update email notification strings on account profile page.

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [x] Strings are localized

### Related Issues
Fixes #839.