### PR TITLE
fix: add pageSizeOptions to data grid to silence warning

### DIFF
--- a/src/common/components/Table.js
+++ b/src/common/components/Table.js
@@ -79,7 +79,7 @@ const Table = props => {
         pageSize: PAGE_SIZE,
         page: page || 0,
       }}
-      rowsPerPageOptions={[PAGE_SIZE]}
+      pageSizeOptions={[PAGE_SIZE]}
       sortModel={sortModel}
       onSortModelChange={model => {
         setSortModel(model);


### PR DESCRIPTION
## Description
* add `pageSizeOptions` to data grid to silence warning
```
    console.warn
      MUI: The page size `15` is not preset in the `pageSizeOptions`
      Add it to show the pagination select.
```
* remove unused `rowsPerPageOptions`
