### PR TITLE
fix: update cluster map color (new 1000L orange)

### DIFF
--- a/src/landscape/components/LandscapeListMap.css
+++ b/src/landscape/components/LandscapeListMap.css
@@ -15,9 +15,22 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+.landscape-list-map-cluster-icon div,
+.landscape-list-map-cluster-icon.leaflet-marker-icon.leaflet-interactive,
+.landscape-list-map-marker-icon.leaflet-marker-icon.leaflet-interactive {
+  background-color: #ff580d;
+}
+
+.landscape-marker-popup .leaflet-popup-content-wrapper {
+  border-color: #ff580d;
+}
+
+.landscape-marker-popup .leaflet-popup-tip {
+  border-right-color: #ff580d;
+}
+
 .landscape-list-map-cluster-icon div {
   background-clip: padding-box;
-  background-color: #985329;
   width: 30px;
   height: 25px;
   margin-left: 5px;
@@ -30,13 +43,11 @@
 
 .landscape-list-map-cluster-icon.leaflet-marker-icon.leaflet-interactive {
   background-clip: padding-box;
-  background: #98532999;
   border-radius: 20px;
 }
 
 .landscape-list-map-marker-icon.leaflet-marker-icon.leaflet-interactive {
   background-clip: padding-box;
-  background: #985329;
   border-radius: 30px;
 }
 
@@ -45,12 +56,15 @@
   font-size: 16px;
   line-height: 24px;
   border-radius: 3px;
-  border: 1px solid #985329;
+  border-width: 1px;
+  border-style: solid;
   box-shadow: none;
 }
+
 .landscape-marker-popup .leaflet-popup-tip {
   border: 1px solid transparent;
-  border-right: 1px solid #985329;
+  border-right-width: 1px;
+  border-right-style: solid;
   background-color: transparent;
   box-shadow: none;
 }

--- a/src/landscape/components/LandscapeListMap.css
+++ b/src/landscape/components/LandscapeListMap.css
@@ -38,7 +38,9 @@
   text-align: center;
   border-radius: 15px;
   padding-top: 5px;
-  color: #fff;
+  color: #000;
+  font-size: 14px;
+  font-weight: bold;
 }
 
 .landscape-list-map-cluster-icon.leaflet-marker-icon.leaflet-interactive {


### PR DESCRIPTION
## Description
Update the cluster map to use the new 1000L orange (`#ff580d`).

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues
Fixes #644.