### PR TITLE
fix: correct typo in form_profile_image_description_helper_text key

### DIFF
--- a/src/landscape/components/LandscapeForm/ProfileImageStep.js
+++ b/src/landscape/components/LandscapeForm/ProfileImageStep.js
@@ -60,7 +60,7 @@ const FORM_FIELDS = [
     name: 'profileImageDescription',
     label: 'landscape.form_profile_image_description_label',
     helperText: {
-      i18nKey: 'landscape.orm_profile_image_description_helper_text',
+      i18nKey: 'landscape.form_profile_image_description_helper_text',
     },
     placeholder: 'landscape.form_profile_image_description_placeholder',
   },


### PR DESCRIPTION
## Description
Correct typo in `form_profile_image_description_helper_text` key.

### Checklist
- [X] Corresponding issue has been opened

### Related Issues
Fixes #887.