### PR TITLE
fix: add alpha/transparency to outer ring on map

### DIFF
--- a/src/landscape/components/LandscapeListMap.css
+++ b/src/landscape/components/LandscapeListMap.css
@@ -21,7 +21,7 @@
 }
 
 .landscape-list-map-cluster-icon.leaflet-marker-icon.leaflet-interactive {
-  background-color: #985329;
+  background-color: #ff580d99;
 }
 
 .landscape-marker-popup .leaflet-popup-content-wrapper {


### PR DESCRIPTION
## Description
Restore alpha/transparency to outer ring on map.