### PR TITLE
fix: mount tsconfig instead of jsconfig in Docker

### DIFF
--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -5,7 +5,7 @@ COMMAND="$2"
 
 # Define specific folders and files to mount from local dev
 # to improve start performance
-toMount="locales public scripts src .eslintrc .prettierrc .stylelintrc jsconfig.json package.json package-lock.json"
+toMount="locales public scripts src .eslintrc .prettierrc .stylelintrc tsconfig.json package.json package-lock.json"
 volumes=""
 for entry in $toMount
 do


### PR DESCRIPTION
Forgot to remove a reference to jsconfig when migrating to Typescript!

