### PR TITLE
fix: inconsistent text validating account profile changes

### DIFF
--- a/src/account/components/AccountProfile.js
+++ b/src/account/components/AccountProfile.js
@@ -39,7 +39,11 @@ import AccountAvatar from './AccountAvatar';
 
 const VALIDATION_SCHEMA = yup
   .object({
-    firstName: yup.string().trim().required(),
+    firstName: yup
+      .string()
+      .trim()
+      .required()
+      .label('account.form_first_name_label_singular'),
   })
   .required();
 

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -700,7 +700,7 @@
         "validation_field_invalid": "$t({{path}}) must be valid",
         "validation_field_invalid_unexpected": "Field must be valid",
         "validation_email_invalid": "Enter a valid email address.",
-        "validation_field_required": "Enter a given name.",
+        "validation_field_required": "Enter a {{path, lowercase}}.",
         "validation_url_required": "Enter a web address.",
         "validation_url_invalid": "Enter a valid web address.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} is required",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -191,6 +191,7 @@
         }
     },
     "account": {
+        "test": "test",
         "profile": "Account Profile",
         "disclaimer": "If you don’t already have a Terraso account, signing in will create one in accordance with our <1>privacy policy</1>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",
@@ -700,7 +701,7 @@
         "validation_field_invalid": "$t({{path}}) must be valid",
         "validation_field_invalid_unexpected": "Field must be valid",
         "validation_email_invalid": "Enter a valid email address.",
-        "validation_field_required": "Enter a {{path, lowercase}}.",
+        "validation_field_required": "Enter a given name.",
         "validation_url_required": "Enter a web address.",
         "validation_url_invalid": "Enter a valid web address.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} is required",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -191,7 +191,6 @@
         }
     },
     "account": {
-        "test": "test",
         "profile": "Account Profile",
         "disclaimer": "If you don’t already have a Terraso account, signing in will create one in accordance with our <1>privacy policy</1>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -195,6 +195,7 @@
         "disclaimer": "If you don’t already have a Terraso account, signing in will create one in accordance with our <1>privacy policy</1>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",
         "unauthenticated_message": "Your Terraso session has expired. Please log in again.",
+        "form_first_name_label_singular": "Given name",
         "form_first_name_label": "Given names",
         "form_last_name_label": "Family names",
         "form_email_label": "Email address",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -705,7 +705,7 @@
         "validation_field_invalid": "$t({{path}}) debe ser válido",
         "validation_field_invalid_unexpected": "El campo debe ser válido",
         "validation_email_invalid": "Introduce una dirección de correo electrónico válida.",
-        "validation_field_required": "Introduce un(a) {{path, lowercase}}.",
+        "validation_field_required": "Introduce un(a) nombre de pila.",
         "validation_url_required": "Introduce una dirección web.",
         "validation_url_invalid": "Introduce una dirección web válida.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} es obligatorio",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -705,7 +705,7 @@
         "validation_field_invalid": "$t({{path}}) debe ser válido",
         "validation_field_invalid_unexpected": "El campo debe ser válido",
         "validation_email_invalid": "Introduce una dirección de correo electrónico válida.",
-        "validation_field_required": "Introduce un(a) nombre de pila.",
+        "validation_field_required": "Introduce un(a) {{path, lowercase}}.",
         "validation_url_required": "Introduce una dirección web.",
         "validation_url_invalid": "Introduce una dirección web válida.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} es obligatorio",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -195,6 +195,7 @@
         "disclaimer": "Si aún no tiene una cuenta de Terraso, al iniciar sesión se creará una de acuerdo con nuestros <1>política de privacidad</1>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",
         "unauthenticated_message": "Su sesión de Terraso ha caducado. Vuelva a iniciar sesión.",
+        "form_first_name_label_singular": "Nombre",
         "form_first_name_label": "Nombres",
         "form_last_name_label": "Apellidos",
         "form_email_label": "Dirección de correo electrónico",


### PR DESCRIPTION
## Description
Inconsistent text when validating account profile changes

## Expected behaviour
- [X] The text should say "Enter a given name."
- [X] Spanish text changed to corresponding text ("given name" instead of "firstname")

## Verification steps
1. Go to URL: https://app.terraso.org/account/profile
2. Clear the given name field
3. Press save profile
4. Observe text
![Screen Shot 2023-05-10 at 12 20 56 PM](https://github.com/techmatters/terraso-web-client/assets/82774370/9c45f9d7-ba95-49c6-adcc-95474a763be5)
![Screen Shot 2023-05-10 at 1 40 21 PM](https://github.com/techmatters/terraso-web-client/assets/82774370/ea166cb4-4c68-4ad8-84f2-73311a28d547)

