### PR TITLE
fix: rework tool and storymap cards on home page; color divider in app bar

### DIFF
--- a/src/layout/AppBar.js
+++ b/src/layout/AppBar.js
@@ -113,7 +113,7 @@ const AppBarComponent = () => {
             <Button
               color="inherit"
               sx={theme => ({
-                marginRight: theme.spacing(2),
+                marginRight: 2,
                 '&:hover': {
                   backgroundColor: 'transparent',
                   textDecoration: 'underline',
@@ -127,7 +127,7 @@ const AppBarComponent = () => {
         ) : (
           <Button
             color="primary"
-            sx={theme => ({ marginRight: theme.spacing(2) })}
+            sx={theme => ({ marginRight: 2 })}
             onClick={onSignIn}
           >
             {t('user.sign_in')}

--- a/src/layout/AppBar.js
+++ b/src/layout/AppBar.js
@@ -22,7 +22,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { signOut } from 'terrasoApi/account/accountSlice';
 
-import { AppBar, Box, Button, Toolbar } from '@mui/material';
+import { AppBar, Box, Button, Divider, Toolbar } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import ConditionalLink from 'common/components/ConditionalLink';
@@ -107,9 +107,13 @@ const AppBarComponent = () => {
             >
               {user.firstName} {user.lastName}
             </Button>
-            <span style={{ color: theme.palette.gray.mid2 }} aria-hidden="true">
-              |
-            </span>
+            <Divider
+              flexItem
+              variant="middle"
+              aria-hidden="true"
+              orientation="vertical"
+              sx={{ backgroundColor: 'gray.mid2', mt: 2, mb: 2 }}
+            />
             <Button
               color="inherit"
               sx={theme => ({

--- a/src/layout/AppBar.js
+++ b/src/layout/AppBar.js
@@ -107,7 +107,9 @@ const AppBarComponent = () => {
             >
               {user.firstName} {user.lastName}
             </Button>
-            <span aria-hidden="true">|</span>
+            <span style={{ color: theme.palette.gray.mid2 }} aria-hidden="true">
+              |
+            </span>
             <Button
               color="inherit"
               sx={theme => ({

--- a/src/storyMap/components/StoryMapsHomeCardDefault.js
+++ b/src/storyMap/components/StoryMapsHomeCardDefault.js
@@ -18,15 +18,13 @@ import React from 'react';
 
 import { useTranslation } from 'react-i18next';
 
-import { Box, CardHeader, Divider, Paper, Typography } from '@mui/material';
+import { Box, Divider, Link, Paper, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
 
 import CardActionRouterLink from 'common/components/CardActionRouterLink';
 import RouterLink from 'common/components/RouterLink';
 
 import HomeCard from 'home/components/HomeCard';
-
-import theme from 'theme';
 
 const StoryMapsHomeCardDefault = () => {
   const { t } = useTranslation();
@@ -37,33 +35,37 @@ const StoryMapsHomeCardDefault = () => {
       aria-labelledby="story-maps-default-title"
       sx={{ flexDirection: 'column' }}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          padding: theme.spacing(2),
-        }}
-      >
-        <Typography id="story-maps-default-title" variant="h2" sx={{ pt: 0 }}>
+      <Box sx={{ p: 2 }}>
+        <Typography
+          id="story-maps-default-title"
+          variant="h2"
+          sx={{ pt: 0, mb: 4 }}
+        >
           {t('storyMap.home_title')}
         </Typography>
-        <Stack direction="row" alignItems="start">
-          <Paper
-            variant="outlined"
-            component="img"
-            src={storyMapImage}
-            alt={t('tool.home_card_img_alt')}
-            height={64}
-            sx={{ mt: 2.5 }}
-          />
-          <CardHeader
-            title={
-              <RouterLink to="/tools/story-maps">
+
+        <Stack direction="row" spacing={3}>
+          <Link component={RouterLink} to="/tools">
+            <Paper
+              variant="outlined"
+              component="img"
+              src={storyMapImage}
+              alt={t('tool.home_card_img_alt')}
+              height={64}
+            />
+          </Link>
+
+          <Stack direction="column">
+            <Typography variant="h3" sx={{ pt: 0, mb: 2, fontSize: '1.3rem' }}>
+              <RouterLink to="/story-maps">
                 {t('storyMap.home_tools_link')}
               </RouterLink>
-            }
-            subheader={t('storyMap.home_default_description')}
-          />
+            </Typography>
+
+            <Typography variant="body2">
+              {t('storyMap.home_default_description')}
+            </Typography>
+          </Stack>
         </Stack>
       </Box>
       <Divider aria-hidden="true" />

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -17,11 +17,11 @@
 import React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { Box, Divider, Link, Paper, Stack, Typography } from '@mui/material';
 
 import CardActionRouterLink from 'common/components/CardActionRouterLink';
+import RouterLink from 'common/components/RouterLink';
 
 import HomeCard from 'home/components/HomeCard';
 

--- a/src/tool/components/ToolHomeCard.js
+++ b/src/tool/components/ToolHomeCard.js
@@ -19,58 +19,52 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
-import { Box, Divider, Link, Stack, Typography } from '@mui/material';
+import { Box, Divider, Link, Paper, Stack, Typography } from '@mui/material';
 
 import CardActionRouterLink from 'common/components/CardActionRouterLink';
 
 import HomeCard from 'home/components/HomeCard';
-
-import theme from 'theme';
 
 const ToolHomeCard = () => {
   const { t } = useTranslation();
   const koboImage = require(`assets/${t('tools.kobo.img.src')}`);
 
   return (
-    <HomeCard
-      aria-labelledby="tools-title"
-      sx={{
-        flexDirection: 'column',
-        padding: theme.spacing(2),
-        paddingBottom: 0,
-      }}
-    >
-      <Typography id="tools-title" variant="h2" sx={{ pt: 0 }}>
-        {t('tool.home_card_title')}
-      </Typography>
-      <Typography
-        variant="body1"
-        sx={{
-          marginTop: theme.spacing(2),
-          marginBottom: theme.spacing(2),
-        }}
-      ></Typography>
-      <Stack direction="row" spacing={3}>
-        <Link component={RouterLink} to="/tools">
-          <Box
-            component="img"
-            src={koboImage}
-            alt=""
-            width={t('tools.kobo.img.width')}
-            height={t('tools.kobo.img.height')}
-            sx={{
-              width: `${t('tools.kobo.img.width')}px`,
-              height: `${t('tools.kobo.img.height')}px`,
-            }}
-          />
-        </Link>
-        <Stack spacing={1}>
+    <HomeCard aria-labelledby="tools-title" sx={{ flexDirection: 'column' }}>
+      <Box sx={{ p: 2 }}>
+        <Typography id="tools-title" variant="h2" sx={{ pt: 0, mb: 4 }}>
+          {t('tool.home_card_title')}
+        </Typography>
+
+        <Stack direction="row" spacing={3}>
           <Link component={RouterLink} to="/tools">
-            <Typography>{t('tool.home_card_kobo_title')}</Typography>
+            <Paper
+              variant="outlined"
+              component="img"
+              src={koboImage}
+              alt=""
+              width={t('tools.kobo.img.width')}
+              height={t('tools.kobo.img.height')}
+              sx={{
+                width: `${t('tools.kobo.img.width')}px`,
+                height: `${t('tools.kobo.img.height')}px`,
+              }}
+            />
           </Link>
-          {t('tool.home_card_description')}
+
+          <Stack direction="column">
+            <Typography variant="h3" sx={{ pt: 0, mb: 2, fontSize: '1.3rem' }}>
+              <RouterLink to="/tools">
+                {t('tool.home_card_kobo_title')}
+              </RouterLink>
+            </Typography>
+
+            <Typography variant="body2">
+              {t('tool.home_card_description')}
+            </Typography>
+          </Stack>
         </Stack>
-      </Stack>
+      </Box>
       <Divider aria-hidden="true" />
       <CardActionRouterLink label={t('tool.home_explore_label')} to="/tools" />
     </HomeCard>


### PR DESCRIPTION
## Description
Rework tool and storymap cards on home page to match.

Make app bar divider gray.
