### PR TITLE
fix: Curried insert link function to keep selection before focus changes

### DIFF
--- a/src/common/components/RichTextEditor/index.js
+++ b/src/common/components/RichTextEditor/index.js
@@ -104,7 +104,7 @@ const withInlines = editor => {
 
   editor.insertText = text => {
     if (text && isUrl(text)) {
-      wrapLink(editor, transformURL(text), text);
+      wrapLinkPartial(editor)(transformURL(text), text);
     } else {
       insertText(text);
     }
@@ -126,11 +126,8 @@ const withInlines = editor => {
   return editor;
 };
 
-const insertLink = (editor, url) => {
-  if (editor.selection) {
-    wrapLink(editor, url);
-  }
-};
+const insertLinkPartial = editor =>
+  editor.selection ? wrapLinkPartial(editor) : () => {};
 
 const isLinkActive = editor => {
   const [link] = Editor.nodes(editor, {
@@ -147,25 +144,28 @@ const unwrapLink = editor => {
   });
 };
 
-const wrapLink = (editor, url, text) => {
+const wrapLinkPartial = editor => {
   if (isLinkActive(editor)) {
     unwrapLink(editor);
   }
 
   const { selection } = editor;
-  const isCollapsed = selection && Range.isCollapsed(selection);
-  const link = {
-    type: 'link',
-    url,
-    children: isCollapsed ? [{ text: text || url }] : [],
-  };
+  return (url, text) => {
+    Transforms.select(editor, selection);
+    const isCollapsed = selection && Range.isCollapsed(selection);
+    const link = {
+      type: 'link',
+      url,
+      children: isCollapsed ? [{ text: text || url }] : [],
+    };
 
-  if (isCollapsed) {
-    Transforms.insertNodes(editor, link);
-  } else {
-    Transforms.wrapNodes(editor, link, { split: true });
-    Transforms.collapse(editor, { edge: 'end' });
-  }
+    if (isCollapsed) {
+      Transforms.insertNodes(editor, link);
+    } else {
+      Transforms.wrapNodes(editor, link, { split: true });
+      Transforms.collapse(editor, { edge: 'end' });
+    }
+  };
 };
 
 // Put this at the start and end of an inline component to work around this Chromium bug:
@@ -278,12 +278,17 @@ const AddLinkButton = props => {
   const [open, setOpen] = useState(false);
   const [url, setUrl] = useState('');
   const [error, setError] = useState();
+  const [insertLink, setInsertLink] = useState();
 
-  const onButtonClick = useCallback(event => {
-    event.preventDefault();
-    setOpen(true);
-    setUrl('');
-  }, []);
+  const onButtonClick = useCallback(
+    event => {
+      event.preventDefault();
+      setInsertLink(() => insertLinkPartial(editor));
+      setOpen(true);
+      setUrl('');
+    },
+    [editor]
+  );
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -292,13 +297,13 @@ const AddLinkButton = props => {
   const handleAddLink = useCallback(() => {
     try {
       URL_SCHEMA.validateSync({ url });
-      insertLink(editor, transformURL(url));
+      insertLink(transformURL(url));
       setOpen(false);
     } catch (error) {
       setError(t(error.message.key, error.message.params));
       return;
     }
-  }, [editor, url, t]);
+  }, [insertLink, url, t]);
 
   const onInputChange = useCallback(event => setUrl(event.target.value), []);
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Curried insert link function to keep selection before focus changes

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #884 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
