### PR TITLE
fis: Plausible story map events update

### DIFF
--- a/src/monitoring/analytics.js
+++ b/src/monitoring/analytics.js
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
+import { useCallback } from 'react';
+
 import Plausible from 'plausible-tracker';
 import { useTranslation } from 'react-i18next';
 
@@ -29,16 +31,19 @@ plausible.enableAutoPageviews();
 export const useAnalytics = () => {
   const { i18n } = useTranslation();
 
-  const trackEvent = (name, options = {}) => {
-    const extendedOptions = {
-      ...options,
-      props: {
-        ...(options.props || {}),
-        language: i18n.resolvedLanguage,
-      },
-    };
-    plausible.trackEvent(name, extendedOptions);
-  };
+  const trackEvent = useCallback(
+    (name, options = {}) => {
+      const extendedOptions = {
+        ...options,
+        props: {
+          ...(options.props || {}),
+          language: i18n.resolvedLanguage,
+        },
+      };
+      plausible.trackEvent(name, extendedOptions);
+    },
+    [i18n.resolvedLanguage]
+  );
 
   return { trackEvent };
 };

--- a/src/storyMap/components/StoryMapNew.js
+++ b/src/storyMap/components/StoryMapNew.js
@@ -103,19 +103,28 @@ const StoryMapNew = () => {
   useDocumentTitle(t('storyMap.new_document_title'));
 
   useEffect(() => {
+    trackEvent('storymap.start', {
+      props: {
+        [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,
+      },
+    });
+  }, [trackEvent]);
+
+  useEffect(() => {
     if (!saved) {
       return;
     }
-    const { slug, storyMapId, published } = saved;
     setSaved(null);
+    const { slug, storyMapId, published } = saved;
+    const url = generateStoryMapUrl({ slug, storyMapId });
+    const event = published ? 'storymap.publish' : 'storymap.saveDraft';
+    trackEvent(event, {
+      props: {
+        url: `${window.location.origin}${url}`,
+        [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,
+      },
+    });
     if (published) {
-      const url = generateStoryMapUrl({ slug, storyMapId });
-      trackEvent('storymap.publish', {
-        props: {
-          url: `${window.location.origin}${url}`,
-          [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,
-        },
-      });
       navigate(url);
       return;
     }

--- a/src/storyMap/components/StoryMapUpdate.js
+++ b/src/storyMap/components/StoryMapUpdate.js
@@ -64,14 +64,22 @@ const StoryMapUpdate = props => {
 
     const { title, slug, storyMapId, published } = saved;
     setSaved(null);
+    const url = generateStoryMapUrl({ slug, storyMapId });
+
+    console.log({ published, storyMap });
+    const event = published
+      ? storyMap.isPublished
+        ? 'storymap.save'
+        : 'storymap.publish'
+      : 'storymap.saveDraft';
+
+    trackEvent(event, {
+      props: {
+        url: `${window.location.origin}${url}`,
+        [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,
+      },
+    });
     if (published) {
-      const url = generateStoryMapUrl({ slug, storyMapId });
-      trackEvent('storymap.publish', {
-        props: {
-          url: `${window.location.origin}${url}`,
-          [ILM_OUTPUT_PROP]: LANDSCAPE_NARRATIVES,
-        },
-      });
       navigate(url);
       return;
     }


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Story map events added and updated:
- `storymap.start`: Added when a user enters `/tools/story-maps/new`
- `storymap.publish`: When a story map changes from draft to published
- `storymap.save`: When a story map is updated after it gets published
- `storymap.saveDraft`: When a story map gets saved and it is not published

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes https://github.com/techmatters/terraso-product/issues/94
