### PR TITLE
fix: correct link to story maps

### DIFF
--- a/src/storyMap/components/StoryMapsHomeCardDefault.js
+++ b/src/storyMap/components/StoryMapsHomeCardDefault.js
@@ -57,7 +57,7 @@ const StoryMapsHomeCardDefault = () => {
 
           <Stack direction="column">
             <Typography variant="h3" sx={{ pt: 0, mb: 2, fontSize: '1.3rem' }}>
-              <RouterLink to="/story-maps">
+              <RouterLink to="/tools/story-maps">
                 {t('storyMap.home_tools_link')}
               </RouterLink>
             </Typography>


### PR DESCRIPTION
## Description
Correct link to story maps (on story maps home card).

### Related Issues
Fixes #953.