### PR TITLE
Fix: clean up routerlink code

### DIFF
--- a/src/landscape/components/LandscapeListMap.js
+++ b/src/landscape/components/LandscapeListMap.js
@@ -33,10 +33,10 @@ import { getLandscapePin } from 'landscape/landscapeUtils';
 import './LandscapeListMap.css';
 
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { Link, Typography } from '@mui/material';
 
+import RouterLink from 'common/components/RouterLink';
 import { countryNameForCode } from 'common/utils';
 
 import { LAYER_ESRI } from 'gis/components/Map';

--- a/src/landscape/components/LandscapeProfile/AffiliationCard.js
+++ b/src/landscape/components/LandscapeProfile/AffiliationCard.js
@@ -18,7 +18,6 @@ import React, { useEffect, useMemo } from 'react';
 
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import {
   Button,
@@ -31,6 +30,7 @@ import {
   Typography,
 } from '@mui/material';
 
+import RouterLink from 'common/components/RouterLink';
 import Restricted from 'permissions/components/Restricted';
 
 import { PARTNERSHIP_STATUS_NO } from 'landscape/landscapeConstants';

--- a/src/landscape/components/LandscapeProfile/DevelopmentStrategyCard.js
+++ b/src/landscape/components/LandscapeProfile/DevelopmentStrategyCard.js
@@ -19,7 +19,6 @@ import React, { useEffect, useMemo } from 'react';
 import _ from 'lodash/fp';
 import { Trans } from 'react-i18next';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import {
   Button,
@@ -30,6 +29,7 @@ import {
 } from '@mui/material';
 
 import ExternalLink from 'common/components/ExternalLink';
+import RouterLink from 'common/components/RouterLink';
 import Restricted from 'permissions/components/Restricted';
 
 const FIELDS = [

--- a/src/landscape/components/LandscapeProfile/KeyInfoCard.js
+++ b/src/landscape/components/LandscapeProfile/KeyInfoCard.js
@@ -17,7 +17,6 @@
 import React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import EmailIcon from '@mui/icons-material/Email';
 import PublicIcon from '@mui/icons-material/Public';
@@ -31,6 +30,7 @@ import {
   Typography,
 } from '@mui/material';
 
+import RouterLink from 'common/components/RouterLink';
 import Restricted from 'permissions/components/Restricted';
 
 const KeyInfoCard = ({ landscape }) => {

--- a/src/landscape/components/LandscapeProfile/ProfileCard.js
+++ b/src/landscape/components/LandscapeProfile/ProfileCard.js
@@ -20,7 +20,6 @@ import _ from 'lodash/fp';
 import { usePermission } from 'permissions';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link as RouterLink } from 'react-router-dom';
 
 import DeleteIcon from '@mui/icons-material/Delete';
 import {
@@ -34,6 +33,7 @@ import {
 } from '@mui/material';
 
 import ConfirmButton from 'common/components/ConfirmButton';
+import RouterLink from 'common/components/RouterLink';
 import { countryNameForCode } from 'common/utils';
 import Restricted from 'permissions/components/Restricted';
 

--- a/src/landscape/components/LandscapesHomeCard.js
+++ b/src/landscape/components/LandscapesHomeCard.js
@@ -18,11 +18,11 @@ import React from 'react';
 
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { Box, Divider, Link, List, ListItem, Typography } from '@mui/material';
 
 import CardActionRouterLink from 'common/components/CardActionRouterLink';
+import RouterLink from 'common/components/RouterLink';
 
 import HomeCard from 'home/components/HomeCard';
 

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -17,11 +17,12 @@
 import React from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { Grid, Link, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { visuallyHidden } from '@mui/utils';
+
+import RouterLink from 'common/components/RouterLink';
 
 import theme from 'theme';
 

--- a/src/navigation/components/Breadcrumbs.js
+++ b/src/navigation/components/Breadcrumbs.js
@@ -18,10 +18,11 @@ import React from 'react';
 
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { Link, Breadcrumbs as MuiBreadcrumbs, Typography } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
+
+import RouterLink from 'common/components/RouterLink';
 
 import { useBreadcrumbsContext } from '../breadcrumbsContext';
 import { useBreadcrumbs } from './Routes';

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -19,7 +19,6 @@ import React from 'react';
 import { filesize } from 'filesize';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { Link as RouterLink } from 'react-router-dom';
 
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import MapIcon from '@mui/icons-material/Map';
@@ -32,6 +31,7 @@ import {
   Stack,
 } from '@mui/material';
 
+import RouterLink from 'common/components/RouterLink';
 import { formatDate } from 'localization/utils';
 
 import { useGroupContext } from 'group/groupContext';


### PR DESCRIPTION
## Description
Replace this old code:
```
import { Link as RouterLink } from 'react-router-dom';
```

With this new code:
```
import RouterLink from 'common/components/RouterLink';
```

### Checklist
- [X] Clean up ReactRouterLink import

### Related Issues
Fixes #930 
