### PR TITLE
Fix: customize message for blank select values

### DIFF
--- a/src/forms/yup.js
+++ b/src/forms/yup.js
@@ -19,16 +19,19 @@ import * as yup from 'yup';
 
 const ARRAY_INDEX_REGEX = /\[([^)]+)\]/;
 
+yup.addMethod(yup.string, 'selected', function () {
+  return this.required(params => ({
+    key: 'form.validation_select_field_required',
+    params,
+  }));
+});
+
 // Localization codes form Yup schema validation
 // Check: https://github.com/jquense/yup#api to know the format to add more codes here
 yup.setLocale({
   mixed: {
     default: params => ({ key: 'form.validation_field_invalid', params }),
-    required: params => {
-      return params.path === 'location'
-        ? { key: 'form.validation_select_field_required', params }
-        : { key: 'form.validation_field_required', params };
-    },
+    required: params => ({ key: 'form.validation_field_required', params }),
     notType: params => ({ key: 'form.validation_field_noType', params }),
   },
   string: {

--- a/src/forms/yup.js
+++ b/src/forms/yup.js
@@ -24,7 +24,11 @@ const ARRAY_INDEX_REGEX = /\[([^)]+)\]/;
 yup.setLocale({
   mixed: {
     default: params => ({ key: 'form.validation_field_invalid', params }),
-    required: params => ({ key: 'form.validation_field_required', params }),
+    required: params => {
+      return params.path === 'location'
+        ? { key: 'form.validation_select_field_required', params }
+        : { key: 'form.validation_field_required', params };
+    },
     notType: params => ({ key: 'form.validation_field_noType', params }),
   },
   string: {

--- a/src/landscape/components/LandscapeForm/KeyInfoStep.js
+++ b/src/landscape/components/LandscapeForm/KeyInfoStep.js
@@ -38,7 +38,7 @@ const VALIDATION_SCHEMA = yup
   .object({
     name: yup.string().trim().required(),
     description: yup.string().max(MAX_DESCRIPTION_LENGTH).trim().required(),
-    location: yup.string().trim().required(),
+    location: yup.string().trim().selected(),
     email: yup.string().trim().email(),
     website: yup.string().trim().ensure().transform(transformURL).url(),
   })

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -702,6 +702,7 @@
         "validation_field_invalid_unexpected": "Field must be valid",
         "validation_email_invalid": "Enter a valid email address.",
         "validation_field_required": "Enter a {{path, lowercase}}.",
+        "validation_select_field_required": "Select a {{path, lowercase}}.",
         "validation_url_required": "Enter a web address.",
         "validation_url_invalid": "Enter a valid web address.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} is required",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -707,6 +707,7 @@
         "validation_field_invalid_unexpected": "El campo debe ser válido",
         "validation_email_invalid": "Introduce una dirección de correo electrónico válida.",
         "validation_field_required": "Introduce un(a) {{path, lowercase}}.",
+        "validation_select_field_required": "Seleccione un(a) {{path, lowercase}}.",
         "validation_url_required": "Introduce una dirección web.",
         "validation_url_invalid": "Introduce una dirección web válida.",
         "validation_field_required_array": "$t({{path}}) {{arrayIndex}} es obligatorio",


### PR DESCRIPTION
## Description
yup.setLocale section is modified to include a condition based on the path parameter in the required method

### Checklist
- [X] Customize message for blank select values in Forms

### Related Issues
Fixes #638 

### Verification steps
1. Go to URL: https://app.staging.terraso.net/landscapes/[landscape slug]/edit
2. Clear value in country select
3. Watch error message
