### PR TITLE
fix: use RouterButton instead of RouterLink for Update Maps button

### DIFF
--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -360,8 +360,9 @@ const LandscapeView = () => {
                 <CardActions sx={{ paddingTop: 0 }}>
                   <Button
                     variant="outlined"
-                    component={RouterLink}
-                    to={`/landscapes/${landscape.slug}/boundaries`}
+                    onClick={() =>
+                      navigate(`/landscapes/${landscape.slug}/boundaries`)
+                    }
                   >
                     {t('landscape.view_map_boundaries_update')}
                   </Button>

--- a/src/landscape/components/LandscapeView.js
+++ b/src/landscape/components/LandscapeView.js
@@ -41,6 +41,7 @@ import {
 
 import ExternalLink from 'common/components/ExternalLink';
 import InlineHelp from 'common/components/InlineHelp';
+import RouterButton from 'common/components/RouterButton';
 import RouterLink from 'common/components/RouterLink';
 import { useSocialShareContext } from 'common/components/SocialShare';
 import { useDocumentDescription, useDocumentTitle } from 'common/document';
@@ -358,14 +359,12 @@ const LandscapeView = () => {
               </CardContent>
               <Restricted permission="landscape.change" resource={landscape}>
                 <CardActions sx={{ paddingTop: 0 }}>
-                  <Button
+                  <RouterButton
                     variant="outlined"
-                    onClick={() =>
-                      navigate(`/landscapes/${landscape.slug}/boundaries`)
-                    }
+                    to={`/landscapes/${landscape.slug}/boundaries`}
                   >
                     {t('landscape.view_map_boundaries_update')}
-                  </Button>
+                  </RouterButton>
                 </CardActions>
               </Restricted>
             </Card>


### PR DESCRIPTION
## Description
The Update Map button had underline on focus because it was also a RouterLink. I removed the RouterLink component and added an onClick handler (which matches other buttons in the app).