### PR TITLE
fix: properly generate nested graphql fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
             "config": {
               "documentMode": "string",
               "skipTypename": true,
-              "enumsAsTypes": true
+              "enumsAsTypes": true,
+              "dedupeFragments": true
             },
             "presetConfig": {
               "fragmentMasking": false


### PR DESCRIPTION
## Description
The graphql codegen was not including nested fragments in the generated GraphQL documents. This adds a config option to ensure that fragments are included properly. See https://github.com/dotansimha/graphql-code-generator/issues/4684 for context.

### Verification steps
Previously broken GraphQL queries should now work (e.g. on logging in).