### PR TITLE
fix: more GraphQL migration bugs

### DIFF
--- a/src/group/membership/components/GroupMembersList.js
+++ b/src/group/membership/components/GroupMembersList.js
@@ -228,14 +228,14 @@ const GroupMembersList = () => {
 
   const onMemberRoleChange = (member, newRole) => {
     onUpdateMember({
-      id: member.membershipId,
+      membershipId: member.membershipId,
       userRole: newRole,
     });
   };
 
   const onMemberApprove = member => {
     onUpdateMember({
-      id: member.membershipId,
+      membershipId: member.membershipId,
       membershipStatus: MEMBERSHIP_STATUS_APPROVED,
     });
   };

--- a/src/group/membership/components/GroupMembershipJoinLeaveButton.js
+++ b/src/group/membership/components/GroupMembershipJoinLeaveButton.js
@@ -70,7 +70,7 @@ const GroupMembershipJoinLeaveButton = props => {
     dispatch(
       leaveGroup({
         groupSlug,
-        membershipId: userMembership.id,
+        membershipId: userMembership.membershipId,
         ownerName: owner.name,
         successMessage,
       })

--- a/src/home/homeService.js
+++ b/src/home/homeService.js
@@ -15,24 +15,18 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import _ from 'lodash/fp';
-import {
-  groupFields,
-  groupMembersPending,
-} from 'terrasoApi/group/groupFragments';
+import { graphql } from 'terrasoApi/gql';
 import {
   extractAccountMembership,
   extractMembersInfo,
 } from 'terrasoApi/group/groupUtils';
 import * as terrasoApi from 'terrasoApi/terrasoBackend/api';
 
-import { defaultGroup, landscapeFields } from 'landscape/landscapeFragments';
-import { storyMapMetadataFields } from 'storyMap/storyMapFragments';
-
 export const fetchHomeData = email => {
-  const query = `
+  const query = graphql(`
     query home($accountEmail: String!) {
       landscapeGroups: groups(
-        memberships_Email: $accountEmail,
+        memberships_Email: $accountEmail
         associatedLandscapes_IsDefaultLandscapeGroup: true
       ) {
         edges {
@@ -51,7 +45,7 @@ export const fetchHomeData = email => {
         }
       }
       userIndependentGroups: groups(
-        memberships_Email: $accountEmail,
+        memberships_Email: $accountEmail
         associatedLandscapes_Isnull: true
       ) {
         edges {
@@ -63,7 +57,7 @@ export const fetchHomeData = email => {
         }
       }
       userLandscapeGroups: groups(
-        memberships_Email: $accountEmail,
+        memberships_Email: $accountEmail
         associatedLandscapes_IsDefaultLandscapeGroup: false
       ) {
         edges {
@@ -82,12 +76,7 @@ export const fetchHomeData = email => {
         }
       }
     }
-    ${groupFields}
-    ${groupMembersPending}
-    ${landscapeFields}
-    ${defaultGroup}
-    ${storyMapMetadataFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { accountEmail: email })
     .then(response => ({

--- a/src/landscape/landscapeFragments.js
+++ b/src/landscape/landscapeFragments.js
@@ -14,14 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import {
-  accountMembership,
-  groupMembersInfo,
-} from 'terrasoApi/group/groupFragments';
 
-import { taxonomyTermLanguages } from 'taxonomies/taxonomiesFragments';
-
-export const landscapeFields = `
+export const landscapeFields = /* GraphQL */ `
   fragment landscapeFields on LandscapeNode {
     id
     slug
@@ -34,7 +28,7 @@ export const landscapeFields = `
   }
 `;
 
-export const landscapeProfileFields = `
+export const landscapeProfileFields = /* GraphQL */ `
   fragment landscapeProfileFields on LandscapeNode {
     id
     slug
@@ -81,13 +75,12 @@ export const landscapeProfileFields = `
       }
     }
   }
-  ${taxonomyTermLanguages}
 `;
 
-export const landscapePartnershipField = `
+export const landscapePartnershipField = /* GraphQL */ `
   fragment landscapePartnershipField on LandscapeNode {
     partnershipStatus
-    associatedGroups(isPartnership:true) {
+    associatedGroups(isPartnership: true) {
       edges {
         node {
           isPartnership
@@ -102,7 +95,7 @@ export const landscapePartnershipField = `
   }
 `;
 
-export const defaultGroup = `
+export const defaultGroup = /* GraphQL */ `
   fragment defaultGroup on LandscapeNode {
     defaultGroup {
       id
@@ -111,10 +104,9 @@ export const defaultGroup = `
       ...accountMembership
     }
   }
-  ${accountMembership}
 `;
 
-export const defaultGroupWithMembersSample = `
+export const defaultGroupWithMembersSample = /* GraphQL */ `
   fragment defaultGroupWithMembersSample on LandscapeNode {
     defaultGroup {
       id
@@ -123,6 +115,4 @@ export const defaultGroupWithMembersSample = `
       ...accountMembership
     }
   }
-  ${accountMembership}
-  ${groupMembersInfo}
 `;

--- a/src/landscape/landscapeService.js
+++ b/src/landscape/landscapeService.js
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import _ from 'lodash/fp';
-import { accountMembership } from 'terrasoApi/group/groupFragments';
+import { graphql } from 'terrasoApi/gql';
 import {
   extractAccountMembership,
   extractMembersInfo,
@@ -23,13 +23,6 @@ import {
 import * as terrasoApi from 'terrasoApi/terrasoBackend/api';
 
 import * as gisService from 'gis/gisService';
-import {
-  defaultGroup,
-  defaultGroupWithMembersSample,
-  landscapeFields,
-  landscapePartnershipField,
-  landscapeProfileFields,
-} from 'landscape/landscapeFragments';
 import { extractTerms } from 'taxonomies/taxonomiesUtils';
 
 import { ALL_PARTNERSHIP_STATUS } from './landscapeConstants';
@@ -109,8 +102,8 @@ const cleanLandscape = landscape =>
   )(landscape);
 
 export const fetchLandscapeToUpdate = slug => {
-  const query = `
-    query landscapes($slug: String!){
+  const query = graphql(`
+    query landscapesToUpdate($slug: String!) {
       landscapes(slug: $slug) {
         edges {
           node {
@@ -119,8 +112,7 @@ export const fetchLandscapeToUpdate = slug => {
         }
       }
     }
-    ${landscapeProfileFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug })
     .then(_.get('landscapes.edges[0].node'))
@@ -147,8 +139,8 @@ const getDefaultGroup = landscape => {
 };
 
 export const fetchLandscapeToView = slug => {
-  const query = `
-    query landscapes($slug: String!){
+  const query = graphql(`
+    query landscapesToView($slug: String!) {
       landscapes(slug: $slug) {
         edges {
           node {
@@ -160,10 +152,7 @@ export const fetchLandscapeToView = slug => {
         }
       }
     }
-    ${landscapeFields}
-    ${landscapePartnershipField}
-    ${defaultGroupWithMembersSample}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug })
     .then(_.get('landscapes.edges[0].node'))
@@ -197,8 +186,8 @@ export const fetchLandscapeToView = slug => {
 };
 
 export const fetchLandscapeProfile = slug => {
-  const query = `
-    query landscapes($slug: String!){
+  const query = graphql(`
+    query landscapesProfiles($slug: String!) {
       landscapes(slug: $slug) {
         edges {
           node {
@@ -208,9 +197,7 @@ export const fetchLandscapeProfile = slug => {
         }
       }
     }
-    ${landscapeProfileFields}
-    ${defaultGroup}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug })
     .then(_.get('landscapes.edges[0].node'))
@@ -227,8 +214,8 @@ export const fetchLandscapeProfile = slug => {
 };
 
 export const fetchLandscapeToUploadSharedData = slug => {
-  const query = `
-    query landscapes($slug: String!){
+  const query = graphql(`
+    query landscapesToUploadSharedData($slug: String!) {
       landscapes(slug: $slug) {
         edges {
           node {
@@ -238,9 +225,7 @@ export const fetchLandscapeToUploadSharedData = slug => {
         }
       }
     }
-    ${landscapeFields}
-    ${defaultGroup}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug })
     .then(_.get('landscapes.edges[0].node'))
@@ -252,7 +237,7 @@ export const fetchLandscapeToUploadSharedData = slug => {
 };
 
 export const fetchLandscapes = () => {
-  const query = `
+  const query = graphql(`
     query landscapes {
       landscapes {
         edges {
@@ -267,9 +252,7 @@ export const fetchLandscapes = () => {
         }
       }
     }
-    ${landscapeFields}
-    ${defaultGroup}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query)
     .then(response => response.landscapes)
@@ -288,8 +271,8 @@ export const fetchLandscapes = () => {
 };
 
 export const fetchLandscapeForMembers = slug => {
-  const query = `
-    query landscapes($slug: String!){
+  const query = graphql(`
+    query landscapesForMembers($slug: String!) {
       landscapes(slug: $slug) {
         edges {
           node {
@@ -302,9 +285,7 @@ export const fetchLandscapeForMembers = slug => {
         }
       }
     }
-    ${landscapeFields}
-    ${accountMembership}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug })
     .then(_.get('landscapes.edges[0].node'))
@@ -320,7 +301,7 @@ export const fetchLandscapeForMembers = slug => {
 };
 
 const updateLandscape = landscape => {
-  const query = `
+  const query = graphql(`
     mutation updateLandscape($input: LandscapeUpdateMutationInput!) {
       updateLandscape(input: $input) {
         landscape {
@@ -329,8 +310,7 @@ const updateLandscape = landscape => {
         errors
       }
     }
-    ${landscapeProfileFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { input: cleanLandscape(landscape) })
     .then(response => ({ new: false, ...response.updateLandscape.landscape }))
@@ -341,8 +321,8 @@ const updateLandscape = landscape => {
 };
 
 const addLandscape = landscape => {
-  const query = `
-    mutation addLandscape($input: LandscapeAddMutationInput!){
+  const query = graphql(`
+    mutation addLandscape($input: LandscapeAddMutationInput!) {
       addLandscape(input: $input) {
         landscape {
           ...landscapeProfileFields
@@ -350,8 +330,7 @@ const addLandscape = landscape => {
         errors
       }
     }
-    ${landscapeProfileFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { input: cleanLandscape(landscape) })
     .then(response => ({ new: true, ...response.addLandscape.landscape }))

--- a/src/sharedData/sharedDataFragments.js
+++ b/src/sharedData/sharedDataFragments.js
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-export const dataEntry = `
+export const dataEntry = /* GraphQL */ `
   fragment dataEntry on DataEntryNode {
     id
     name
@@ -47,10 +47,9 @@ export const visualizationConfig = /* GraphQL */ `
   }
 `;
 
-export const visualizationConfigWithConfiguration = `
+export const visualizationConfigWithConfiguration = /* GraphQL */ `
   fragment visualizationConfigWithConfiguration on VisualizationConfigNode {
     ...visualizationConfig
     configuration
   }
-  ${visualizationConfig}
 `;

--- a/src/storyMap/storyMapFragments.js
+++ b/src/storyMap/storyMapFragments.js
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-export const storyMapFields = `
+export const storyMapFields = /* GraphQL */ `
   fragment storyMapFields on StoryMapNode {
     id
     slug
@@ -33,7 +33,7 @@ export const storyMapFields = `
   }
 `;
 
-export const storyMapMetadataFields = `
+export const storyMapMetadataFields = /* GraphQL */ `
   fragment storyMapMetadataFields on StoryMapNode {
     id
     slug

--- a/src/storyMap/storyMapService.js
+++ b/src/storyMap/storyMapService.js
@@ -15,13 +15,12 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import _ from 'lodash/fp';
+import { graphql } from 'terrasoApi/gql';
 import * as terrasoApi from 'terrasoApi/terrasoBackend/api';
 
-import { storyMapFields, storyMapMetadataFields } from './storyMapFragments';
-
 export const fetchSamples = (params, currentUser) => {
-  const query = `
-    query home($accountEmail: String!) {
+  const query = graphql(`
+    query storyMapsHome($accountEmail: String!) {
       storyMaps(createdBy_Email_Not: $accountEmail) {
         edges {
           node {
@@ -30,8 +29,7 @@ export const fetchSamples = (params, currentUser) => {
         }
       }
     }
-    ${storyMapMetadataFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { accountEmail: currentUser.email })
     .then(response => ({
@@ -40,8 +38,8 @@ export const fetchSamples = (params, currentUser) => {
 };
 
 export const fetchStoryMap = ({ slug, storyMapId }) => {
-  const query = `
-    query fetchStoryMap($slug: String!, $storyMapId: String!){
+  const query = graphql(`
+    query fetchStoryMap($slug: String!, $storyMapId: String!) {
       storyMaps(slug: $slug, storyMapId: $storyMapId) {
         edges {
           node {
@@ -50,8 +48,7 @@ export const fetchStoryMap = ({ slug, storyMapId }) => {
         }
       }
     }
-    ${storyMapFields}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { slug, storyMapId })
     .then(_.get('storyMaps.edges[0].node'))
@@ -105,7 +102,7 @@ export const updateStoryMap = async ({ storyMap, files }) => {
 };
 
 export const deleteStoryMap = ({ storyMap }) => {
-  const query = `
+  const query = graphql(`
     mutation deleteStoryMap($id: ID!) {
       deleteStoryMap(input: { id: $id }) {
         storyMap {
@@ -114,7 +111,7 @@ export const deleteStoryMap = ({ storyMap }) => {
         errors
       }
     }
-  `;
+  `);
   return terrasoApi.requestGraphQL(query, {
     id: storyMap.id,
   });

--- a/src/taxonomies/taxonomiesFragments.js
+++ b/src/taxonomies/taxonomiesFragments.js
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-export const taxonomyTermLanguages = `
+export const taxonomyTermLanguages = /* GraphQL */ `
   fragment taxonomyTermLanguages on TaxonomyTermNode {
     valueEn
     valueEs

--- a/src/taxonomies/taxonomiesService.js
+++ b/src/taxonomies/taxonomiesService.js
@@ -15,14 +15,14 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 import _ from 'lodash/fp';
+import { graphql } from 'terrasoApi/gql';
 import * as terrasoApi from 'terrasoApi/terrasoBackend/api';
 
-import { taxonomyTermLanguages } from './taxonomiesFragments';
 import { extractTerms } from './taxonomiesUtils';
 
 export const fetchTermsForTypes = ({ types }) => {
-  const query = `
-    query taxonomyTerms($types: [CoreTaxonomyTermTypeChoices]!){
+  const query = graphql(`
+    query taxonomyTerms($types: [CoreTaxonomyTermTypeChoices]!) {
       taxonomyTerms(type_In: $types) {
         edges {
           node {
@@ -34,8 +34,7 @@ export const fetchTermsForTypes = ({ types }) => {
         }
       }
     }
-    ${taxonomyTermLanguages}
-  `;
+  `);
   return terrasoApi
     .requestGraphQL(query, { types })
     .then(_.get('taxonomyTerms.edges'))

--- a/src/terrasoApi/group/groupFragments.ts
+++ b/src/terrasoApi/group/groupFragments.ts
@@ -16,7 +16,7 @@
  */
 
 export const dataEntry = /* GraphQL */ `
-  fragment dataEntry on DataEntryNode {
+  fragment groupDataEntry on DataEntryNode {
     id
     name
     description
@@ -45,7 +45,7 @@ export const dataEntries = /* GraphQL */ `
     dataEntries(resourceType_In: $resourceTypes) {
       edges {
         node {
-          ...dataEntry
+          ...groupDataEntry
         }
       }
     }

--- a/src/terrasoApi/group/groupService.ts
+++ b/src/terrasoApi/group/groupService.ts
@@ -259,7 +259,7 @@ export const updateMember = ({ member }: { member: Membership }) => {
   `);
   return terrasoApi
     .requestGraphQL(query, {
-      input: { ...member, id: member.membershipId },
+      input: { ..._.omit('membershipId', member), id: member.membershipId },
     })
     .then(resp => resp.updateMembership.membership!.group)
     .then(group => ({

--- a/src/terrasoApi/group/groupSlice.ts
+++ b/src/terrasoApi/group/groupSlice.ts
@@ -16,6 +16,7 @@
  */
 import { createSlice } from '@reduxjs/toolkit';
 import _ from 'lodash/fp';
+import { User } from 'terrasoApi/account/accountSlice';
 import * as groupService from 'terrasoApi/group/groupService';
 import * as groupUtils from 'terrasoApi/group/groupUtils';
 import {
@@ -30,7 +31,7 @@ export type Group = {
     totalCount?: number;
     pendingCount?: number;
     accountMembership?: Membership;
-    membersSample?: Membership[];
+    membersSample?: (Membership & Omit<User, 'preferences'>)[];
   };
   slug: string;
   id: string;

--- a/src/terrasoApi/group/groupUtils.ts
+++ b/src/terrasoApi/group/groupUtils.ts
@@ -57,7 +57,7 @@ export const extractAccountMembership = ({
 }: AccountMembershipFragment) =>
   accountMembership
     ? {
-        ...accountMembership,
+        ..._.omit('id', accountMembership),
         membershipId: accountMembership.id,
       }
     : undefined;

--- a/src/terrasoApi/group/groupUtils.ts
+++ b/src/terrasoApi/group/groupUtils.ts
@@ -18,7 +18,7 @@ import _ from 'lodash/fp';
 import type {
   AccountMembershipFragment,
   DataEntriesFragment,
-  DataEntryFragment,
+  GroupDataEntryFragment,
   GroupFieldsFragment,
   GroupMembersFragment,
   GroupMembersInfoFragment,
@@ -70,7 +70,7 @@ export const getMemberships = (groups: Group[]) =>
 export const generateIndexedMembers = (memberships: Membership[]) =>
   _.keyBy((member: Membership) => member.membershipId, memberships);
 
-export const extractDataEntry = (dataEntry: DataEntryFragment) => ({
+export const extractDataEntry = (dataEntry: GroupDataEntryFragment) => ({
   ...dataEntry,
   visualizations: dataEntry.visualizations.edges.map(edge => edge.node),
 });


### PR DESCRIPTION
## Description
We are getting GraphQL errors in the frontend because the mixed format of partially hand-written, partially generated GraphQL operations didn't work properly when inlining nested fragments between the two modes. This PR migrates the remaining GraphQL queries to codegen.

Since we didn't have any tests that caught this, we will need to manually verify the fix works. I'm not sure what would be a good stopgap way to test for this until integration tests are set up (which would definitely have caught this).

### Verification steps
Navigate to landscape page, there should be no error.
