### PR TITLE
fix: allow empty checks for custom url validation

### DIFF
--- a/src/forms/yup.js
+++ b/src/forms/yup.js
@@ -21,6 +21,9 @@ const ARRAY_INDEX_REGEX = /\[([^)]+)\]/;
 
 const hasValidTLD = urlString => {
   try {
+    if (!urlString) {
+      return true;
+    }
     const TLD_REGEX = /\.[a-z]{2,}$/i;
     const url = new URL(urlString);
     const match = url.hostname.match(TLD_REGEX);

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -63,7 +63,8 @@ const VALIDATION_SCHEMA = yup
       .ensure()
       .transform(transformURL)
       .validTld()
-      .url(),
+      .url()
+      .notRequired(),
     membershipType: yup.string(),
   })
   .required();

--- a/src/group/components/GroupForm.js
+++ b/src/group/components/GroupForm.js
@@ -63,8 +63,7 @@ const VALIDATION_SCHEMA = yup
       .ensure()
       .transform(transformURL)
       .validTld()
-      .url()
-      .notRequired(),
+      .url(),
     membershipType: yup.string(),
   })
   .required();


### PR DESCRIPTION
## Description
add a notRequired() check for group website form and allow empty input for custom url validation

## Steps to Reproduce:
1. Go to URL: http://127.0.0.1:3000/groups/new
2. Fill out Name and Description but not website
3. Groups should be successful
