### PR TITLE
fix: revert assumption that landscape default groups are non-null in client

### DIFF
--- a/src/landscape/landscapeService.test.ts
+++ b/src/landscape/landscapeService.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2023 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+import * as terrasoApiToMock from 'terrasoApi/terrasoBackend/api';
+
+import * as landscapeService from 'landscape/landscapeService';
+
+jest.mock('terrasoApi/terrasoBackend/api');
+const terrasoApi = jest.mocked(terrasoApiToMock);
+
+test('LandscapeService: Fetch landscape with missing fields', async () => {
+  terrasoApi.requestGraphQL.mockReturnValue(
+    Promise.resolve({
+      landscapes: {
+        edges: [
+          {
+            node: {
+              name: 'Landscape name',
+              description: 'Landscape description',
+              website: 'https://www.landscape.org',
+            },
+          },
+        ],
+      },
+    })
+  );
+  const landscape = await landscapeService.fetchLandscapeToView('');
+  expect(landscape).toStrictEqual({
+    name: 'Landscape name',
+    description: 'Landscape description',
+    website: 'https://www.landscape.org',
+    areaPolygon: null,
+    defaultGroup: {
+      membersInfo: {
+        accountMembership: undefined,
+        membersSample: [],
+        pendingCount: undefined,
+        totalCount: undefined,
+      },
+    },
+    partnership: undefined,
+    partnershipStatus: undefined,
+  });
+});

--- a/src/terrasoApi/group/groupUtils.ts
+++ b/src/terrasoApi/group/groupUtils.ts
@@ -34,17 +34,21 @@ type GroupQuery = Partial<
     GroupFieldsFragment
 >;
 
-export const extractMembersInfo = (group: GroupQuery) => ({
-  totalCount: group.membershipsCount ?? group.memberships?.totalCount,
-  pendingCount: group.pending?.totalCount,
+export const extractMembersInfo = (group?: GroupQuery | null) => ({
+  totalCount: group?.membershipsCount ?? group?.memberships?.totalCount,
+  pendingCount: group?.pending?.totalCount,
   accountMembership: extractAccountMembership(group),
   membersSample: extractMembers(group),
 });
 
-export const extractMembers = (group: GroupQuery) =>
+export const extractMembers = (group?: GroupQuery | null) =>
   (
-    (group as Partial<GroupMembersFragment> & Partial<GroupMembersInfoFragment>)
-      .memberships?.edges || []
+    (
+      group as
+        | (Partial<GroupMembersFragment> & Partial<GroupMembersInfoFragment>)
+        | null
+        | undefined
+    )?.memberships?.edges || []
   ).map(edge => ({
     membershipId: edge.node.id,
     userRole: edge.node.userRole,
@@ -52,13 +56,13 @@ export const extractMembers = (group: GroupQuery) =>
     ...edge.node.user,
   }));
 
-export const extractAccountMembership = ({
-  accountMembership,
-}: AccountMembershipFragment) =>
-  accountMembership
+export const extractAccountMembership = (
+  group?: AccountMembershipFragment | null
+) =>
+  group?.accountMembership
     ? {
-        ..._.omit('id', accountMembership),
-        membershipId: accountMembership.id,
+        ..._.omit('id', group.accountMembership),
+        membershipId: group.accountMembership.id,
       }
     : undefined;
 
@@ -68,12 +72,14 @@ export const getMemberships = (groups: Group[]) =>
   );
 
 export const generateIndexedMembers = (memberships: Membership[]) =>
-  _.keyBy((member: Membership) => member.membershipId, memberships);
+  _.keyBy(member => member.membershipId, memberships);
 
-export const extractDataEntry = (dataEntry: GroupDataEntryFragment) => ({
+export const extractDataEntry = (
+  dataEntry?: GroupDataEntryFragment | null
+) => ({
   ...dataEntry,
-  visualizations: dataEntry.visualizations.edges.map(edge => edge.node),
+  visualizations: dataEntry?.visualizations.edges.map(edge => edge.node),
 });
 
-export const extractGroupDataEntries = (group: DataEntriesFragment) =>
-  group.dataEntries.edges.map(edge => extractDataEntry(edge.node));
+export const extractGroupDataEntries = (group?: DataEntriesFragment | null) =>
+  group?.dataEntries.edges.map(edge => extractDataEntry(edge.node));


### PR DESCRIPTION
## Description
Previous changes assumed that the groups passed into groupUtils would always be non-null. This is currently not the case, so this change undoes that assumption.

### Checklist
- [x] New tests added

### Verification steps
Should load landscapes page ok in environments where landscapes have no default group in DB.