### PR TITLE
fix: update editable embedded text

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -909,6 +909,7 @@
         "form_media_audio_delete_confirm_button": "Delete audio",
         "form_media_video_delete_confirm_title": "Remove video?",
         "form_media_video_delete_confirm_button": "Remove video",
+        "form_media_video_delete_confirm_message": "Are you sure you want to delete this video? This action cannot be undone.",
         "form_media_add_dialog_title": "Add media",
         "form_media_add_dialog_add": "Add media",
         "form_media_add_dialog_close": "Cancel",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -907,6 +907,8 @@
         "form_media_audio_delete_confirm_title": "Delete audio?",
         "form_media_audio_delete_confirm_message": "Are you sure you want to delete this audio? This action cannot be undone.",
         "form_media_audio_delete_confirm_button": "Delete audio",
+        "form_media_video_delete_confirm_title": "Remove video?",
+        "form_media_video_delete_confirm_button": "Remove video",
         "form_media_add_dialog_title": "Add media",
         "form_media_add_dialog_add": "Add media",
         "form_media_add_dialog_close": "Cancel",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -914,6 +914,7 @@
         "form_media_audio_delete_confirm_button": "Eliminar audio",
         "form_media_video_delete_confirm_title": "Quitar vídeo?",
         "form_media_video_delete_confirm_button": "Quitar vídeo",
+        "form_media_video_delete_confirm_message": "¿Seguro que quieres eliminar este vídeo? Esta acción no se puede deshacer.",
         "form_media_add_dialog_title": "Agregar multimedia",
         "form_media_add_dialog_add": "Agregar multimedia",
         "form_media_add_dialog_close": "Cancelar",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -912,6 +912,8 @@
         "form_media_audio_delete_confirm_title": "¿Eliminar audio?",
         "form_media_audio_delete_confirm_message": "¿Seguro que quieres eliminar este audio? Esta acción no se puede deshacer.",
         "form_media_audio_delete_confirm_button": "Eliminar audio",
+        "form_media_video_delete_confirm_title": "Quitar vídeo?",
+        "form_media_video_delete_confirm_button": "Quitar vídeo",
         "form_media_add_dialog_title": "Agregar multimedia",
         "form_media_add_dialog_add": "Agregar multimedia",
         "form_media_add_dialog_close": "Cancelar",

--- a/src/storyMap/components/StoryMapForm/EditableMedia.js
+++ b/src/storyMap/components/StoryMapForm/EditableMedia.js
@@ -488,7 +488,7 @@ const EditableEmbedded = props => {
             },
           }}
           confirmTitle={t('storyMap.form_media_video_delete_confirm_title')}
-          confirmMessage={t('storyMap.form_media_audio_delete_confirm_message')}
+          confirmMessage={t('storyMap.form_media_video_delete_confirm_message')}
           confirmButton={t('storyMap.form_media_video_delete_confirm_button')}
         >
           <DeleteIcon sx={{ color: 'white' }} />

--- a/src/storyMap/components/StoryMapForm/EditableMedia.js
+++ b/src/storyMap/components/StoryMapForm/EditableMedia.js
@@ -487,9 +487,9 @@ const EditableEmbedded = props => {
               minWidth: 'auto',
             },
           }}
-          confirmTitle={t('storyMap.form_media_audio_delete_confirm_title')}
+          confirmTitle={t('storyMap.form_media_video_delete_confirm_title')}
           confirmMessage={t('storyMap.form_media_audio_delete_confirm_message')}
-          confirmButton={t('storyMap.form_media_audio_delete_confirm_button')}
+          confirmButton={t('storyMap.form_media_video_delete_confirm_button')}
         >
           <DeleteIcon sx={{ color: 'white' }} />
         </ConfirmButton>


### PR DESCRIPTION
## Description
Change editable embedded title and button text from "Delete audio" to "Remove video"

### Related Issues
Fixes https://github.com/techmatters/terraso-web-client/issues/993

### Verification steps
1. Create a story map
2. add a chapter
3. associate chapter with a youtube video, EG: https://youtu.be/cNQQUWDVtfo
4. Delete media for video
5. See the error

<img width="655" alt="Screen Shot 2023-06-13 at 3 20 37 PM" src="https://github.com/techmatters/terraso-web-client/assets/82774370/0fb734ef-a0c9-4c7b-bfe1-23c1472f0d73">
