### PR TITLE
fix: minor text label typo/inconsistencies

### DIFF
--- a/src/group/membership/components/GroupMemberLeave.js
+++ b/src/group/membership/components/GroupMemberLeave.js
@@ -34,7 +34,7 @@ const GroupMemberLeave = props => {
       })}
       confirmButton={t('group.membership_leave_confirm_button')}
       buttonLabel={t(label)}
-      ariaLabel={t('landscape.list_leave_label', {
+      ariaLabel={t('group.list_leave_label', {
         name: _.get('name', owner),
       })}
       buttonProps={buttonProps}

--- a/src/landscape/components/LandscapeList.test.js
+++ b/src/landscape/components/LandscapeList.test.js
@@ -221,7 +221,7 @@ test('LandscapeList: Display list', async () => {
   );
   expect(
     within(rows[2])
-      .getByRole('button', { name: 'Connect: Landscape Name 1' })
+      .getByRole('button', { name: 'Join: Landscape Name 1' })
       .closest('[role="cell"]')
   ).toHaveAttribute('data-field', 'actions');
   expect(

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -276,7 +276,7 @@
         "view_update_button": "Update Description",
         "list_join_button": "Join",
         "list_leave_button": "Leave",
-        "list_join_label": "Connect: {{name}}",
+        "list_join_label": "Join: {{name}}",
         "list_leave_label": "Leave: {{name}}",
         "list_new_button": "Add Landscape",
         "members_remove_confirmation_button": "Remove Member",


### PR DESCRIPTION
## Description
Just a bit of tidying in the code. I can't actually find the word "Connect" anywhere on the site so it might be unused? But would require digging into the group UI code a bit more so just submitting this quick PR because it is faster than opening an issue.