### PR TITLE
fix: increase timeout on slow test to avoid flakes

### DIFF
--- a/src/landscape/components/LandscapeSharedDataVisualizationConfig.test.js
+++ b/src/landscape/components/LandscapeSharedDataVisualizationConfig.test.js
@@ -329,4 +329,4 @@ test('LandscapeSharedDataVisualizationConfig: Create visualization', async () =>
       dataEntryId: 'f00c5564-cf93-471a-94c2-b930cbb0a4f8',
     },
   });
-});
+}, 30000);


### PR DESCRIPTION
## Description
Increases timeout on the "Create visualization" test of "LandscapeSharedDataVisualizationConfig"

### Checklist
- [x] Corresponding issue has been opened

### Related Issues
Fixes #992 

### Verification steps
Hard to verify for sure because it's an intermittent test flake, but I will re-run the test action in CI several times and hope it succeeds consistently :shrug: 