### PR TITLE
fix: Correct alt text and links on story maps home card

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -154,7 +154,6 @@
         "description": "Use this tool to",
         "actions_bookmark": "Bookmark",
         "actions_recommend": "Recommend this to my team",
-        "home_card_img_alt": "KoboToolbox",
         "list_document_title": "Tools",
         "list_document_description": "A list of tools useful to Terraso users"
     },

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -154,7 +154,6 @@
         "description": "Utiliza esta herramienta para",
         "actions_bookmark": "Marcar como favorito",
         "actions_recommend": "Recomendar esto a mi equipo",
-        "home_card_img_alt": "Imagen de KoboToolbox",
         "list_document_title": "Herramientas",
         "list_document_description": "Lista de herramientas utiles para los usuarios de Terraso"
     },

--- a/src/storyMap/components/StoryMapsHomeCardDefault.js
+++ b/src/storyMap/components/StoryMapsHomeCardDefault.js
@@ -35,7 +35,7 @@ const StoryMapsHomeCardDefault = () => {
       image={{
         src: storyMapImage,
         to: '/tools',
-        alt: t('tool.home_card_img_alt'),
+        alt: t('tools.storyMap.img.caption'),
         caption: t('tools.storyMap.img.caption'),
       }}
     >

--- a/src/storyMap/components/StoryMapsHomeCardDefault.js
+++ b/src/storyMap/components/StoryMapsHomeCardDefault.js
@@ -34,7 +34,7 @@ const StoryMapsHomeCardDefault = () => {
       }}
       image={{
         src: storyMapImage,
-        to: '/tools',
+        to: '/tools/story-maps',
         alt: t('tools.storyMap.img.caption'),
         caption: t('tools.storyMap.img.caption'),
       }}


### PR DESCRIPTION
## Description
Correct alt text and links on story maps home card
* alt text was Kobo; is now a description of the image
* link now goes to story maps page, not tools page