### PR TITLE
chore: bump client shared version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "slate-history": "^0.93.0",
         "slate-hyperscript": "^0.77.0",
         "slate-react": "^0.95.0",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#c759711",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#804f014",
         "use-debounce": "^9.0.4",
         "uuid": "^9.0.0",
         "web-vitals": "^3.3.2",
@@ -14659,9 +14659,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.2.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.2.3.tgz",
-      "integrity": "sha512-5spO7L0rNmW0jFuNhz+gfirlFt1anle4mTy4+gFkgsH0+T3R5++4oncBrzeKa7v8pweRyGBoGmOpboqlxovg6A==",
+      "version": "23.2.7",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.2.7.tgz",
+      "integrity": "sha512-EsbHHvF6b+p+B6Cht5fYWY7VE/WYOrqB1+DNwa1UpLTw6mG5g4tc8KCEjUUOSMUA2yqCsdYQP+PqVq5nBMtOtQ==",
       "funding": [
         {
           "type": "individual",
@@ -26232,11 +26232,11 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#d1a9923799f65d91cb6095b812767ef750bf3cfd"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#fe7708efbf55cb97a698e405c98e7f0ee93a6398"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#c7597119b0390226f54c168f96f55856b4acdbbe",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#804f014484982a30ab11b3796e5bc301dab8ed45",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "@rollbar/react": "^0.11.1",
@@ -26247,40 +26247,18 @@
         "filesize": "^10.0.7",
         "get-video-id": "^3.6.5",
         "history": "^5.3.0",
-        "i18next": "^22.4.15",
-        "i18next-browser-languagedetector": "^7.0.1",
+        "i18next": "^23.2.6",
+        "i18next-browser-languagedetector": "^7.1.0",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-redux": "^8.1.0",
-        "terraso-backend": "techmatters/terraso-backend#d1a9923",
+        "terraso-backend": "github:techmatters/terraso-backend#fe7708e",
         "use-debounce": "^9.0.4",
         "uuid": "^9.0.0",
         "web-vitals": "^3.3.1"
-      }
-    },
-    "node_modules/terraso-client-shared/node_modules/i18next": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.5.1.tgz",
-      "integrity": "sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "dependencies": {
-        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "slate-history": "^0.93.0",
     "slate-hyperscript": "^0.77.0",
     "slate-react": "^0.95.0",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#c759711",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#804f014",
     "use-debounce": "^9.0.4",
     "uuid": "^9.0.0",
     "web-vitals": "^3.3.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,9 @@ setAPIConfig({
   tokenStorage: {
     getToken: Cookies.get,
     removeToken: name => Cookies.remove(name, COOKIES_PARAMS),
-    setToken: (name, token) => Cookies.set(name, token, COOKIES_PARAMS),
+    setToken: (name, token) => {
+      Cookies.set(name, token, COOKIES_PARAMS);
+    },
   },
   logger: (severity: Severity, ...args) => rollbar[severity](...args),
 });


### PR DESCRIPTION
## Description
Just making sure the web client doesn't get too out of step with client shared changes, and that we aren't accidentally breaking the web client without noticing. In draft until https://github.com/techmatters/terraso-client-shared/pull/19 has been merged.

### Verification steps
Everything should work exactly the same.
