### PR TITLE
fix: Use correct prop to pass style for story maps

### DIFF
--- a/src/storyMap/components/StoryMap.js
+++ b/src/storyMap/components/StoryMap.js
@@ -517,7 +517,7 @@ const StoryMap = props => {
         <Map
           id="map"
           interactive={false}
-          style={config.style}
+          mapStyle={config.style}
           projection={config.projection}
           zoom={1}
           initialLocation={initialLocation}

--- a/src/storyMap/components/StoryMap.test.js
+++ b/src/storyMap/components/StoryMap.test.js
@@ -36,6 +36,7 @@ beforeEach(() => {
 });
 
 const CONFIG = {
+  "style": "mapbox://styles/terraso/test",
   title: 'Story Map Title',
   subtitle: 'Story Map Subtitle',
   byline: 'by User',
@@ -106,4 +107,14 @@ test('StoryMap: Renders title and chapters correctly', async () => {
     image: 'https://test.com/image.png',
   });
   testChapter({ title: 'Chapter 2', description: 'Chapter 2 description' });
+});
+
+test('StoryMap: Use config style', async () => {
+  await setup();
+
+  expect(mapboxgl.Map).toHaveBeenCalledWith(
+    expect.objectContaining({
+      style: CONFIG.style,
+    })
+  );
 });


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Fixed name property for mapbox style in Map component

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->