### PR TITLE
fix: Removed feature to allow async permissions resolution

### DIFF
--- a/src/group/components/GroupSharedDataUpload.js
+++ b/src/group/components/GroupSharedDataUpload.js
@@ -60,13 +60,13 @@ const GroupSharedDataUpload = () => {
     navigate(`/groups/${slug}`);
   }, [navigate, slug]);
 
-  const { loading } = usePermissionRedirect(
+  usePermissionRedirect(
     'sharedData.add',
     group,
     useMemo(() => `/groups/${group?.slug}`, [group?.slug])
   );
 
-  if (fetching || loading) {
+  if (fetching) {
     return <PageLoader />;
   }
 

--- a/src/group/membership/components/GroupMembers.js
+++ b/src/group/membership/components/GroupMembers.js
@@ -65,18 +65,15 @@ const Header = props => {
     )
   );
 
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'group.manageMembers',
-    group
-  );
+  const { allowed } = usePermission('group.manageMembers', group);
 
-  const { loading } = usePermissionRedirect(
+  usePermissionRedirect(
     'group.viewMembers',
     group,
     useMemo(() => `/groups/${group?.slug}`, [group?.slug])
   );
 
-  if (fetching || loading || loadingPermissions) {
+  if (fetching) {
     return null;
   }
 

--- a/src/landscape/components/LandscapeProfile/index.js
+++ b/src/landscape/components/LandscapeProfile/index.js
@@ -61,10 +61,7 @@ const LandscapeProfile = () => {
   const dispatch = useDispatch();
   const { landscape, fetching } = useSelector(state => state.landscape.profile);
   const { slug } = useParams();
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'landscape.change',
-    landscape
-  );
+  const { allowed } = usePermission('landscape.change', landscape);
 
   const [isEmptySections, setIsEmptySections] = useState({
     developmentStrategy: false,
@@ -117,7 +114,7 @@ const LandscapeProfile = () => {
     dispatch(refreshLandscapeView(slug));
   }, [dispatch, slug]);
 
-  if (fetching || loadingPermissions) {
+  if (fetching) {
     return <PageLoader />;
   }
 

--- a/src/landscape/components/LandscapeSharedDataUpload.js
+++ b/src/landscape/components/LandscapeSharedDataUpload.js
@@ -64,13 +64,13 @@ const LandscapeSharedDataUpload = () => {
     });
   }, [navigate, slug]);
 
-  const { loading } = usePermissionRedirect(
+  usePermissionRedirect(
     'sharedData.add',
     landscape?.defaultGroup,
     useMemo(() => `/landscapes/${landscape?.slug}`, [landscape?.slug])
   );
 
-  if (fetching || loading) {
+  if (fetching) {
     return <PageLoader />;
   }
 

--- a/src/landscape/membership/components/LandscapeMembers.js
+++ b/src/landscape/membership/components/LandscapeMembers.js
@@ -43,10 +43,7 @@ const MemberLeaveButton = withProps(LandscapeMemberLeave, {
 
 const Header = ({ landscape, fetching }) => {
   const { t } = useTranslation();
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'group.manageMembers',
-    landscape
-  );
+  const { allowed } = usePermission('group.manageMembers', landscape);
 
   useDocumentTitle(
     t('landscape.members_document_title', {
@@ -68,10 +65,6 @@ const Header = ({ landscape, fetching }) => {
       [landscape?.name]
     )
   );
-
-  if (loadingPermissions) {
-    return null;
-  }
 
   return (
     <>

--- a/src/permissions/components/Restricted.js
+++ b/src/permissions/components/Restricted.js
@@ -16,31 +16,19 @@
  */
 import React from 'react';
 import { usePermission } from 'permissions';
-import { useTranslation } from 'react-i18next';
-import { CircularProgress } from '@mui/material';
 
 const Restricted = props => {
-  const { t } = useTranslation();
   const {
     permission,
     resource,
     toDisallowedUsers = false,
     FallbackComponent,
-    LoadingComponent,
     children,
   } = props;
-  const { loading, allowed } = usePermission(permission, resource);
+  const { allowed } = usePermission(permission, resource);
 
   if (!resource) {
     return null;
-  }
-
-  if (loading) {
-    return LoadingComponent ? (
-      <LoadingComponent />
-    ) : (
-      <CircularProgress aria-label={t('common.loader_label')} />
-    );
   }
 
   if (toDisallowedUsers ? !allowed : allowed) {

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -62,7 +62,6 @@ test('Restricted: Display custom loader', async () => {
     {
       resource: {},
       permission: 'resource.action',
-      LoadingComponent: () => <div>Loading...</div>,
       children: <div>Restricted content</div>,
     },
     rules

--- a/src/permissions/components/Restricted.test.js
+++ b/src/permissions/components/Restricted.test.js
@@ -39,40 +39,9 @@ const setup = async (props, rules) => {
   );
 };
 
-test('Restricted: Display default loader', async () => {
-  const rules = {
-    'resource.action': () => new Promise(() => {}),
-  };
-  await setup(
-    {
-      resource: {},
-      permission: 'resource.action',
-      children: <div>Restricted content</div>,
-    },
-    rules
-  );
-  expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
-  expect(screen.getByRole('progressbar')).toBeInTheDocument();
-});
-test('Restricted: Display custom loader', async () => {
-  const rules = {
-    'resource.action': () => new Promise(() => {}),
-  };
-  await setup(
-    {
-      resource: {},
-      permission: 'resource.action',
-      children: <div>Restricted content</div>,
-    },
-    rules
-  );
-  expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
-  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-  expect(screen.getByText('Loading...')).toBeInTheDocument();
-});
 test('Restricted: Display allowed component', async () => {
   const rules = {
-    'resource.action': () => Promise.resolve(true),
+    'resource.action': () => true,
   };
   await setup(
     {
@@ -86,7 +55,7 @@ test('Restricted: Display allowed component', async () => {
 });
 test('Restricted: Hide denied component', async () => {
   const rules = {
-    'resource.action': () => Promise.resolve(false),
+    'resource.action': () => false,
   };
   await setup(
     {
@@ -97,11 +66,10 @@ test('Restricted: Hide denied component', async () => {
     rules
   );
   expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
-  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
 });
 test('Restricted: Display component for unallowed users', async () => {
   const rules = {
-    'resource.action': () => Promise.resolve(false),
+    'resource.action': () => false,
   };
   await setup(
     {
@@ -116,7 +84,7 @@ test('Restricted: Display component for unallowed users', async () => {
 });
 test('Restricted: Hide component for allowed users', async () => {
   const rules = {
-    'resource.action': () => Promise.resolve(true),
+    'resource.action': () => true,
   };
   await setup(
     {
@@ -128,7 +96,6 @@ test('Restricted: Hide component for allowed users', async () => {
     rules
   );
   expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
-  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
 });
 test('Restricted: Display fallback component', async () => {
   await setup({
@@ -138,6 +105,5 @@ test('Restricted: Display fallback component', async () => {
     children: <div>Restricted content</div>,
   });
   expect(screen.queryByText('Restricted content')).not.toBeInTheDocument();
-  expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   expect(screen.getByText('Fallback content')).toBeInTheDocument();
 });

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -26,16 +26,17 @@ const defaultBehaviour = {
 export const PermissionsContext = React.createContext(defaultBehaviour);
 
 export const PermissionsProvider = ({ rules, children }) => {
-  const isAllowedTo = useCallback((permission, user, resource) => {
-    const ruleResolver = _.getOr(
-      defaultBehaviour.isAllowedTo,
-      permission,
-      rules
-    );
-    return !resource
-      ? false
-      : ruleResolver({ user, resource });
-  }, []);
+  const isAllowedTo = useCallback(
+    (permission, user, resource) => {
+      const ruleResolver = _.getOr(
+        defaultBehaviour.isAllowedTo,
+        permission,
+        rules
+      );
+      return !resource ? false : ruleResolver({ user, resource });
+    },
+    [rules]
+  );
 
   return (
     <PermissionsContext.Provider value={isAllowedTo}>

--- a/src/permissions/rules.js
+++ b/src/permissions/rules.js
@@ -57,7 +57,7 @@ const isAllowedToEditSharedData = ({
 }) => {
   const isManager = hasRole({ group, role: ROLE_MANAGER });
   const isOwner = _.get('createdBy.id', dataEntry) === _.get('id', user);
-  return Promise.resolve(isManager || isOwner);
+  return isManager || isOwner;
 };
 
 const isAllowedToDeleteSharedData = ({ resource, user }) => {
@@ -71,43 +71,43 @@ const isAllowedToDeleteVisualization = ({
   const isManager = hasRole({ group, role: ROLE_MANAGER });
   const isOwner =
     _.get('createdBy.id', visualizationConfig) === _.get('id', user);
-  return Promise.resolve(isManager || isOwner);
+  return isManager || isOwner;
 };
 
 const isAllowedToDownloadSharedData = ({ resource: group }) => {
   const isMember = isApprovedMember(group);
-  return Promise.resolve(isMember);
+  return isMember;
 };
 
 const isAllowedToAddSharedData = ({ resource: group }) => {
   const isMember = isApprovedMember(group);
-  return Promise.resolve(isMember);
+  return isMember;
 };
 
 const isAllowedToChangeGroup = ({ resource: group }) => {
   const isManager = hasRole({ group, role: ROLE_MANAGER });
-  return Promise.resolve(isManager);
+  return isManager;
 };
 
 // is open group or closed + you are a member
 const isAllowedToViewGroupMembers = ({ resource: group }) => {
   const isOpenGroup = group.membershipType === MEMBERSHIP_OPEN;
   if (isOpenGroup) {
-    return Promise.resolve(true);
+    return true;
   }
 
   const isMember = isApprovedMember(group);
-  return Promise.resolve(isMember);
+  return isMember;
 };
 
 const isAllowedToManageGroupMembers = ({ resource: group }) => {
   const isManager = hasRole({ group, role: ROLE_MANAGER });
-  return Promise.resolve(isManager);
+  return isManager;
 };
 
 const isAllowedToViewGroupSharedData = ({ resource: group }) => {
   const isMember = isApprovedMember(group);
-  return Promise.resolve(isMember);
+  return isMember;
 };
 
 const isAllowedToChangeLandscape = ({ resource: landscape }) => {
@@ -115,12 +115,12 @@ const isAllowedToChangeLandscape = ({ resource: landscape }) => {
     group: landscape.defaultGroup,
     role: ROLE_MANAGER,
   });
-  return Promise.resolve(isManager);
+  return isManager;
 };
 
 const isAllowedToChangeStoryMap = ({ resource: storyMap, user }) => {
   const isOwner = _.get('createdBy.id', storyMap) === _.get('id', user);
-  return Promise.resolve(isOwner);
+  return isOwner;
 };
 
 const rules = {

--- a/src/storyMap/components/StoryMapUpdate.js
+++ b/src/storyMap/components/StoryMapUpdate.js
@@ -131,10 +131,7 @@ const ContextWrapper = props => {
   const { slug, storyMapId } = useParams();
   const dispatch = useDispatch();
   const { fetching, data: storyMap } = useSelector(_.get('storyMap.form'));
-  const { loading: loadingPermissions, allowed } = usePermission(
-    'storyMap.change',
-    storyMap
-  );
+  const { allowed } = usePermission('storyMap.change', storyMap);
 
   useEffect(() => {
     dispatch(resetForm());
@@ -147,7 +144,7 @@ const ContextWrapper = props => {
     )
   );
 
-  if (fetching || loadingPermissions) {
+  if (fetching) {
     return <PageLoader />;
   }
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->

When permissions were implemented there was an assumption that permissions resolution could be a async process, but it is not and it is making the logic to handle loding them unnecesary so I will remove them until the need for something like this arises