### PR TITLE
fix: ensure Navigation doesn't exceed 1200px

### DIFF
--- a/src/navigation/components/Navigation.js
+++ b/src/navigation/components/Navigation.js
@@ -128,6 +128,11 @@ const Navigation = React.forwardRef((props, ref) => {
         ref={ref}
         value={value}
         aria-label={t('navigation.nav_label_short')}
+        sx={{
+          maxWidth: {
+            md: 1200,
+          },
+        }}
       >
         <Typography sx={visuallyHidden} variant="h2">
           {t('navigation.nav_label')}


### PR DESCRIPTION
## Description
Ensure Navigation doesn't exceed 1200px on story maps page.

### Related Issues
Fixes #1284.