### PR TITLE
fix: center story map title/subtitle placeholders

### DIFF
--- a/src/storyMap/components/StoryMapForm/TitleForm.js
+++ b/src/storyMap/components/StoryMapForm/TitleForm.js
@@ -120,6 +120,9 @@ const TitleForm = props => {
             ...inputProps,
             inputProps: {
               'aria-label': t('storyMap.form_title_aria_label'),
+              sx: {
+                textAlign: 'center',
+              },
             },
           }}
         />
@@ -132,6 +135,9 @@ const TitleForm = props => {
             ...inputProps,
             inputProps: {
               'aria-label': t('storyMap.form_subtitle_aria_label'),
+              sx: {
+                textAlign: 'center',
+              },
             },
           }}
         />


### PR DESCRIPTION
## Description
Center story map title/subtitle placeholders

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on desktop

### Related Issues
Fixes #761.