### PR TITLE
fix: add alt text to tool images

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -164,7 +164,8 @@
             "img": {
                 "height": "140",
                 "width": "250",
-                "src": "tools/kobotoolbox-screenshot.png"
+                "src": "tools/kobotoolbox-screenshot.png",
+                "alt": "A phone, a laptop, and a tablet, each displaying a data collection form. The tool’s logo is in the foreground."
             },
             "description": [
                 "Design and build forms quickly",
@@ -181,7 +182,8 @@
             "img": {
                 "height": "140",
                 "width": "250",
-                "src": "tools/landscale-screenshot.png"
+                "src": "tools/landscale-screenshot.png",
+                "alt": "A dashboard containing charts and graphs about a landscape. The tool’s logo is in the foreground."
             },
             "description": [
                 "Assess landscape sustainability performance",
@@ -198,6 +200,7 @@
                 "height": "188",
                 "width": "250",
                 "src": "tools/story-maps.png",
+                "alt": "A satellite map of a bend in a river, overlayed by a window containing a picture and a block of text.",
                 "caption": "Rocky Hill’s Story Map"
             },
             "description": ["Create beautiful map-based stories"],

--- a/src/tool/components/ToolCard.js
+++ b/src/tool/components/ToolCard.js
@@ -42,7 +42,7 @@ const ToolIconAndLink = ({ tool, title, external }) => {
       <Box
         component="img"
         src={toolImage}
-        alt=""
+        alt={t(`tools.${tool}.img.alt`)}
         width={t(`tools.${tool}.img.width`)}
         height={t(`tools.${tool}.img.height`)}
         sx={{


### PR DESCRIPTION
## Description
Add alt text to Terraso tools images

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [ ] Strings are localized

### Related Issues
Fixes #1335.
