### PR TITLE
feat: Block navigation in visualization form

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -654,7 +654,9 @@
         "upload_link_form.description": "$t(sharedData.upload_description_label)",
         "addSharedDataLink.terraso_api.invalid": "Invalid $t(sharedData.upload_{{field}}_label)",
         "link_delete_tooltip": "Remove link “{{name}}”.",
-        "file_delete_tooltip": "Remove file “{{name}}”."
+        "file_delete_tooltip": "Remove file “{{name}}”.",
+        "visualization_unsaved_changes_title": "Leave Map?",
+        "visualization_unsaved_changes_message": "You have unsaved changes that will be lost if you leave the page. Finish map before you leave."
     },
     "common": {
         "dialog_cancel_label": "Cancel",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -656,7 +656,7 @@
         "link_delete_tooltip": "Remove link “{{name}}”.",
         "file_delete_tooltip": "Remove file “{{name}}”.",
         "visualization_unsaved_changes_title": "Leave Map?",
-        "visualization_unsaved_changes_message": "You have unsaved changes that will be lost if you leave the page. Finish map before you leave."
+        "visualization_unsaved_changes_message": "You have unsaved changes that will be lost if you leave the page."
     },
     "common": {
         "dialog_cancel_label": "Cancel",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -697,7 +697,9 @@
         "upload_link_form.description": "$t(sharedData.upload_description_label)",
         "addSharedDataLink.terraso_api.invalid": "$t(sharedData.upload_{{field}}_label) inválido",
         "link_delete_tooltip": "Eliminar enlace “{{name}}”.",
-        "file_delete_tooltip": "Eliminar archivo “{{name}}”."
+        "file_delete_tooltip": "Eliminar archivo “{{name}}”.",
+        "visualization_unsaved_changes_title": "¿Dejar el mapa?",
+        "visualization_unsaved_changes_message": "Tienes cambios no guardados que se perderán si abandonas la página."
     },
     "share": {
         "button": "Comparte",

--- a/src/sharedData/visualization/components/VisualizationConfigForm.test.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm.test.js
@@ -697,7 +697,15 @@ test.each([
 ])(
   'VisualizationConfigForm: Create %s visualization',
   async (caseDescription, testParams) => {
+    const preventDefault = jest.fn();
+    window.onbeforeunload = jest.fn(event => {
+      event.preventDefault = preventDefault;
+    });
     const { map, events } = await setup(testParams);
+
+    // Navigation is not blocked in the first step
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(preventDefault).toHaveBeenCalledTimes(0);
 
     await testSelectDataFileStep(testParams);
     await testStepper(testParams);
@@ -714,6 +722,10 @@ test.each([
       testParams.expectedDataEntriesFetchInput
     );
 
+    // Block navigation if there are unsaved changes
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+
     // Save
     await act(async () =>
       fireEvent.click(screen.getByRole('button', { name: 'Publish' }))
@@ -728,6 +740,10 @@ test.each([
     expect(JSON.parse(saveCall[1].input.configuration)).toStrictEqual(
       testParams.expectedConfiguration
     );
+
+    // Navigation is not blocked after saving
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(preventDefault).toHaveBeenCalledTimes(1);
   },
   30000
 );

--- a/src/sharedData/visualization/components/VisualizationConfigForm.test.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm.test.js
@@ -722,7 +722,7 @@ test.each([
       testParams.expectedDataEntriesFetchInput
     );
 
-    // Block navigation if there are unsaved changes
+    // Blocked navigation
     window.dispatchEvent(new Event('beforeunload'));
     expect(preventDefault).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Block navigation after step 1 and unblock after save

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1231
