### PR TITLE
fix: pass correct value to user.full_name strings

### DIFF
--- a/src/collaboration/components/MembershipsList.js
+++ b/src/collaboration/components/MembershipsList.js
@@ -51,12 +51,12 @@ const MembershipsList = props => {
         valueGetter: ({ row: membership }) =>
           membership.pendingEmail
             ? membership.pendingEmail
-            : t('user.full_name', { user: membership.user }),
+            : t('user.full_name', { user: membership }),
         cardRender: ({ row: membership }) => (
           <Typography noWrap>
             {membership.pendingEmail
               ? membership.pendingEmail
-              : t('user.full_name', { user: membership.user })}
+              : t('user.full_name', { user: membership })}
           </Typography>
         ),
         renderCell: ({ row: membership }) => (


### PR DESCRIPTION
## Description
Pass correct value to user.full_name strings

membership looks like
```
{
    "id": "ecfbc181-a000-480d-a5c9-c8b3b719f7a5",
    "email": "john@example.com",
    "firstName": "John",
    "lastName": "Doe",
    "profileImage": "https://images.dev.terraso.org/ecfbc181-a000-480d-a5c9-c8b3b719f7a5/profile-image_31",
    "userRole": "owner"
}
```
there is no `membership.user`.

### Related Issues
Fixes #1366.