### PR TITLE
fix: Set user field for owner membership in story map

### DIFF
--- a/src/storyMap/components/StoryMapForm/ShareDialog.js
+++ b/src/storyMap/components/StoryMapForm/ShareDialog.js
@@ -218,7 +218,7 @@ const ShareDialog = props => {
   const memberships = useMemo(
     () => [
       {
-        ...storyMap.createdBy,
+        user: storyMap.createdBy,
         userRole: MEMBERSHIP_ROLE_OWNER,
       },
       ...storyMap.memberships,

--- a/src/storyMap/components/StoryMapUpdate.test.js
+++ b/src/storyMap/components/StoryMapUpdate.test.js
@@ -194,6 +194,11 @@ test('StoryMapUpdate: Show Share Dialog', async () => {
     ).toBeInTheDocument();
   });
 
+  // Show owner
+  expect(
+    within(membersList).getByRole('listitem', { name: 'Pedro Paez' })
+  ).toBeInTheDocument();
+
   // Show cancel button
   const cancelButton = screen.getByRole('button', { name: 'Cancel' });
   expect(cancelButton).toBeInTheDocument();


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Fixed owner membership to have separate user field

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1366
