### PR TITLE
test: mock useIsMounted to prevent intermittently failing tests

### DIFF
--- a/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
@@ -24,7 +24,9 @@ import mapboxgl from 'gis/mapbox';
 import LandscapeNew from 'landscape/components/LandscapeForm/New';
 
 jest.mock('custom-hooks', () => ({
-  useIsMounted: () => { current: false },
+  useIsMounted: () => {
+    false;
+  },
 }));
 
 jest.mock('terraso-client-shared/terrasoApi/api');

--- a/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
@@ -24,7 +24,7 @@ import mapboxgl from 'gis/mapbox';
 import LandscapeNew from 'landscape/components/LandscapeForm/New';
 
 jest.mock('custom-hooks', () => ({
-  useIsMounted: () => false,
+  useIsMounted: () => { current: false },
 }));
 
 jest.mock('terraso-client-shared/terrasoApi/api');

--- a/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
@@ -23,11 +23,13 @@ import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import mapboxgl from 'gis/mapbox';
 import LandscapeNew from 'landscape/components/LandscapeForm/New';
 
-jest.mock('custom-hooks', () => ({
-  useIsMounted: () => {
-    false;
-  },
-}));
+jest.mock('custom-hooks', () => {
+  return {
+    useIsMounted: () => {
+      return { current: false };
+    },
+  };
+});
 
 jest.mock('terraso-client-shared/terrasoApi/api');
 

--- a/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
@@ -23,10 +23,9 @@ import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import mapboxgl from 'gis/mapbox';
 import LandscapeNew from 'landscape/components/LandscapeForm/New';
 
-import { useIsMounted } from 'custom-hooks';
-jest.mock("custom-hooks", () => ({
-  useIsMounted: () => false
-}))
+jest.mock('custom-hooks', () => ({
+  useIsMounted: () => false,
+}));
 
 jest.mock('terraso-client-shared/terrasoApi/api');
 

--- a/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
+++ b/src/landscape/components/LandscapeForm/BoundaryStepNewBoundariesFile.test.js
@@ -23,6 +23,11 @@ import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
 import mapboxgl from 'gis/mapbox';
 import LandscapeNew from 'landscape/components/LandscapeForm/New';
 
+import { useIsMounted } from 'custom-hooks';
+jest.mock("custom-hooks", () => ({
+  useIsMounted: () => false
+}))
+
 jest.mock('terraso-client-shared/terrasoApi/api');
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
## Description

When determining the place information by name, [`useIsMounted`](https://github.com/techmatters/terraso-web-client/blob/main/src/landscape/components/LandscapeForm/BoundaryStep/index.js#L158) is called to determine if the boundingBox must be set.
See: [src/landscape/components/LandscapeForm/BoundaryStep/index.js](https://github.com/techmatters/terraso-web-client/blob/main/src/landscape/components/LandscapeForm/BoundaryStep/index.js)

During tests, it was found that `useIsMounted` returns sometimes true, sometimes false. This causes tests to sometimes uses the response from [`getPlaceInfoByName`](https://github.com/techmatters/terraso-web-client/blob/main/src/landscape/components/LandscapeForm/BoundaryStep/index.js#L178-L180), and sometimes to not.

During tests, it seemed that the response should always be the non-mounted one. Mocking `useIsMounted` enforces this for all tests.

I could confirm locally that sometimes the test fails. After the update, it never failed again; hopefully it won't fail on CI. 