### PR TITLE
fix: hide 'no preview' text; update strings

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -559,7 +559,7 @@
         "share_file_dialog_share_access_type_ALL": "Anyone with link",
         "share_file_dialog_share_access_type_MEMBERS": "Members",
         "share_file_dialog_share_access_suffix": "can view and download this file",
-        "share_file_dialog_share_access_all_warning": "Anyone with the link can access this file.",
+        "share_file_dialog_share_access_all_warning": "Anyone on the internet with the link can access this file",
         "share_file_dialog_share_access_not_allowed": "Only group managers and file owners can change this setting.",
         "share_file_dialog_share_access_updated": "Access updated",
         "share_file_dialog_share_access_done": "Done",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -561,7 +561,7 @@
         "share_file_dialog_share_access_suffix": "can view and download this file",
         "share_file_dialog_share_access_all_warning": "Anyone with the link can access this file.",
         "share_file_dialog_share_access_not_allowed": "Only group managers and file owners can change this setting.",
-        "share_file_dialog_share_access_updated": "Access updated.",
+        "share_file_dialog_share_access_updated": "Access updated",
         "share_file_dialog_share_access_done": "Done",
         "invalid_extension": "The file extension ({{file.resourceType}}) does not match the file’s contents",
         "invalid_extension_zip": "The file {{file.name}}{{file.resourceType}} is a not a valid zip.",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -602,7 +602,7 @@
         "share_file_dialog_share_access_type_ALL": "Cualquier persona con el enlace",
         "share_file_dialog_share_access_type_MEMBERS": "Miembros",
         "share_file_dialog_share_access_suffix": "pueden ver y descargar este archivo",
-        "share_file_dialog_share_access_all_warning": "Cualquiera que tenga el enlace puede acceder a este archivo.",
+        "share_file_dialog_share_access_all_warning": "Cualquier persona en el internet con el enlace puede acceder a este archivo",
         "share_file_dialog_share_access_not_allowed": "Sólo los administradores de grupos y propietarios de archivos pueden cambiar esta configuración.",
         "share_file_dialog_share_access_updated": "Acceso actualizado",
         "share_file_dialog_share_access_done": "Hecho",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -604,7 +604,7 @@
         "share_file_dialog_share_access_suffix": "pueden ver y descargar este archivo",
         "share_file_dialog_share_access_all_warning": "Cualquiera que tenga el enlace puede acceder a este archivo.",
         "share_file_dialog_share_access_not_allowed": "Sólo los administradores de grupos y propietarios de archivos pueden cambiar esta configuración.",
-        "share_file_dialog_share_access_updated": "Acceso actualizado.",
+        "share_file_dialog_share_access_updated": "Acceso actualizado",
         "share_file_dialog_share_access_done": "Hecho",
         "invalid_extension": "La extensión del archivo ({{file.resourceType}}) no coincide con el contenido del archivo",
         "invalid_extension_zip": "El archivo {{file.name}}{{file.resourceType}} no es un zip válido.",

--- a/src/sharedData/components/SharedResourceDownload.js
+++ b/src/sharedData/components/SharedResourceDownload.js
@@ -85,9 +85,6 @@ const SharedResourceDownload = () => {
         sx={{ p: 4, mt: 6 }}
       >
         <Typography variant="h1">{`${sharedResource.dataEntry?.name}.${sharedResource.dataEntry?.resourceType}`}</Typography>
-        <Typography>
-          {t('sharedData.shared_resource_download_no_preview')}
-        </Typography>
         <Button variant="contained" onClick={downloadFile}>
           {t('sharedData.shared_resource_download_button')}
         </Button>


### PR DESCRIPTION
## Description
For the [file sharing feature](https://github.com/techmatters/terraso-web-client/pull/1451):
* remove extra warning
* updated some strings