### PR TITLE
fix: add fallback page title when first name is missing

### DIFF
--- a/src/home/components/Home.js
+++ b/src/home/components/Home.js
@@ -93,7 +93,13 @@ const Home = () => {
 
   return (
     <PageContainer>
-      <PageHeader header={t('home.page_title', { name: user.firstName })} />
+      <PageHeader
+        header={
+          user.firstName
+            ? t('home.page_title', { name: user.firstName })
+            : t('home.document_title')
+        }
+      />
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
           <Stack spacing={3}>

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -249,3 +249,33 @@ test('Home: Display defaults', async () => {
     )
   ).toBeInTheDocument();
 });
+
+test('Home: Display title', async () => {
+  fetchHomeData.mockReturnValue(
+    Promise.resolve({
+      groups: [],
+      landscapes: [],
+    })
+  );
+  await setup();
+  expect(screen.getByText(/First’s Terraso/i)).toBeInTheDocument();
+});
+
+test('Home: Display title (default)', async () => {
+  terrasoApi.requestGraphQL.mockReturnValue(
+    Promise.resolve(
+      _.set(
+        'users.edges[0].node',
+        {
+          firstName: undefined,
+          lastName: undefined,
+          profileImage: 'test.com',
+          preferences: { edges: [] },
+        },
+        {}
+      )
+    )
+  );
+  await setup();
+  expect(screen.getByText(/Terraso Home/i)).toBeInTheDocument();
+});

--- a/src/home/components/Home.test.js
+++ b/src/home/components/Home.test.js
@@ -29,16 +29,15 @@ jest.mock('home/homeService', () => ({
   fetchHomeData: jest.fn(),
 }));
 
-const setup = async () => {
+const setup = async (
+  currentUserData = { firstName: 'First', lastName: 'Last' }
+) => {
   await render(<Home />, {
     account: {
       hasToken: true,
       currentUser: {
         fetching: false,
-        data: {
-          firstName: 'First',
-          lastName: 'Last',
-        },
+        data: currentUserData,
       },
     },
   });
@@ -262,20 +261,12 @@ test('Home: Display title', async () => {
 });
 
 test('Home: Display title (default)', async () => {
-  terrasoApi.requestGraphQL.mockReturnValue(
-    Promise.resolve(
-      _.set(
-        'users.edges[0].node',
-        {
-          firstName: undefined,
-          lastName: undefined,
-          profileImage: 'test.com',
-          preferences: { edges: [] },
-        },
-        {}
-      )
-    )
+  fetchHomeData.mockReturnValue(
+    Promise.resolve({
+      groups: [],
+      landscapes: [],
+    })
   );
-  await setup();
+  await setup({ firstName: undefined, lastName: undefined });
   expect(screen.getByText(/Terraso Home/i)).toBeInTheDocument();
 });

--- a/src/tool/components/ToolCard.js
+++ b/src/tool/components/ToolCard.js
@@ -153,7 +153,11 @@ const ToolCard = ({ tool }) => {
           </section>
 
           <section>
-            <ToolIconAndLink tool={tool} title={toolTitle} external />
+            <ToolIconAndLink
+              tool={tool}
+              title={toolTitle}
+              external={external}
+            />
           </section>
         </Stack>
       </Card>


### PR DESCRIPTION
## Description
Add fallback page title to Terraso home page when first name is missing.