### PR TITLE
fix: Renamed state fields and service function names

### DIFF
--- a/src/group/groupSlice.ts
+++ b/src/group/groupSlice.ts
@@ -25,7 +25,7 @@ import type { Message } from 'terraso-client-shared/notifications/notificationsS
 import { createAsyncThunk } from 'terraso-client-shared/store/utils';
 
 import * as groupService from 'group/groupService';
-import { setList } from 'sharedData/sharedDataSlice';
+import { setSharedResourcesList } from 'sharedData/sharedDataSlice';
 
 export type Group = {
   slug: string;
@@ -46,7 +46,7 @@ export const fetchGroupView = createAsyncThunk(
   'group/fetchGroupView',
   async (slug: string, user, { dispatch }) => {
     const group = await groupService.fetchGroupToView(slug, user);
-    dispatch(setList(group.sharedResources));
+    dispatch(setSharedResourcesList(group.sharedResources));
     return group;
   }
 );

--- a/src/landscape/landscapeSlice.js
+++ b/src/landscape/landscapeSlice.js
@@ -19,7 +19,7 @@ import _ from 'lodash/fp';
 import { createAsyncThunk } from 'terraso-client-shared/store/utils';
 
 import * as landscapeService from 'landscape/landscapeService';
-import { setList } from 'sharedData/sharedDataSlice';
+import { setSharedResourcesList } from 'sharedData/sharedDataSlice';
 
 const initialState = {
   list: {
@@ -73,7 +73,7 @@ export const fetchLandscapeView = createAsyncThunk(
       params,
       currentUser
     );
-    dispatch(setList(landscape.sharedResources));
+    dispatch(setSharedResourcesList(landscape.sharedResources));
     return landscape;
   }
 );

--- a/src/sharedData/components/SharedDataCard.js
+++ b/src/sharedData/components/SharedDataCard.js
@@ -42,7 +42,7 @@ const SharedDataCard = props => {
   const { owner, entityTypeLocalized } = useCollaborationContext();
   const { allowed } = usePermission(`sharedData.viewFiles`, owner);
   const { data: sharedResources, fetching } = useSelector(
-    _.get('sharedData.list')
+    _.get('sharedData.sharedResources')
   );
   const hasSharedData = !_.isEmpty(sharedResources);
 

--- a/src/sharedData/sharedDataService.js
+++ b/src/sharedData/sharedDataService.js
@@ -118,7 +118,7 @@ export const updateSharedData = ({ dataEntry }) => {
     .then(extractDataEntry);
 };
 
-export const fetchSharedData = ({
+export const fetchDataEntries = ({
   targetSlug,
   targetType,
   resourceTypes = ALL_RESOURCE_TYPES,
@@ -153,7 +153,7 @@ export const fetchSharedData = ({
     .then(edges => edges.map(edge => extractDataEntry(edge.node)));
 };
 
-export const fetchSharedDataWithGeojson = ({ id }) => {
+export const fetchDataEntriesWithGeojson = ({ id }) => {
   const query = graphql(`
     query dataEntryWithGeojson($id: ID!) {
       dataEntry(id: $id) {

--- a/src/sharedData/sharedDataSlice.js
+++ b/src/sharedData/sharedDataSlice.js
@@ -30,7 +30,11 @@ const initialState = {
     links: {},
   },
   processing: {},
-  list: {
+  sharedResources: {
+    fetching: true,
+    data: null,
+  },
+  dataEntries: {
     fetching: true,
     data: null,
   },
@@ -78,9 +82,9 @@ export const updateSharedData = createAsyncThunk(
     params: { name: dataEntry.name },
   })
 );
-export const fetchSharedData = createAsyncThunk(
-  'sharedData/fetchSharedData',
-  sharedDataService.fetchSharedData
+export const fetchDataEntries = createAsyncThunk(
+  'sharedData/fetchDataEntries',
+  sharedDataService.fetchDataEntries
 );
 
 export const addVisualizationConfig = createAsyncThunk(
@@ -134,9 +138,9 @@ const sharedDataSlice = createSlice({
       ...state,
       processing: _.omit(action.payload, state.processing),
     }),
-    setList: (state, action) => ({
+    setSharedResourcesList: (state, action) => ({
       ...state,
-      list: {
+      sharedResources: {
         data: action.payload,
         fetching: false,
       },
@@ -160,9 +164,9 @@ const sharedDataSlice = createSlice({
     );
     builder.addCase(updateSharedData.fulfilled, (state, action) => ({
       ...state,
-      list: {
-        ...state.list,
-        data: state.list.data.map(item =>
+      sharedResources: {
+        ...state.sharedResources,
+        data: state.sharedResources.data.map(item =>
           item.id === action.meta.arg.sharedResource.id
             ? { ...item, dataEntry: action.payload }
             : item
@@ -190,9 +194,9 @@ const sharedDataSlice = createSlice({
         processing: _.omit(action.meta.arg.sharedResource.id, {
           ...state.processing,
         }),
-        list: {
-          ...state.list,
-          data: state.list.data.map(item =>
+        sharedResources: {
+          ...state.sharedResources,
+          data: state.sharedResources.data.map(item =>
             item.id === action.meta.arg.sharedResource.id
               ? action.payload
               : item
@@ -218,9 +222,9 @@ const sharedDataSlice = createSlice({
 
     builder.addCase(deleteSharedData.fulfilled, (state, action) => ({
       ...state,
-      list: {
-        ...state.list,
-        data: state.list.data.filter(
+      sharedResources: {
+        ...state.sharedResources,
+        data: state.sharedResources.data.filter(
           item => item.id !== action.meta.arg.sharedResource.id
         ),
       },
@@ -292,17 +296,17 @@ const sharedDataSlice = createSlice({
       )
     );
 
-    builder.addCase(fetchSharedData.pending, (state, action) => ({
+    builder.addCase(fetchDataEntries.pending, (state, action) => ({
       ...state,
-      list: {
+      dataEntries: {
         fetching: true,
         data: null,
       },
     }));
 
-    builder.addCase(fetchSharedData.fulfilled, (state, action) => ({
+    builder.addCase(fetchDataEntries.fulfilled, (state, action) => ({
       ...state,
-      list: {
+      dataEntries: {
         fetching: false,
         data: action.payload,
       },
@@ -368,7 +372,7 @@ const sharedDataSlice = createSlice({
   },
 });
 
-export const { resetUploads, resetProcessing, setList } =
+export const { resetUploads, resetProcessing, setSharedResourcesList } =
   sharedDataSlice.actions;
 
 export default sharedDataSlice.reducer;

--- a/src/sharedData/visualization/components/VisualizationConfigForm/SelectDataFileStep.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/SelectDataFileStep.js
@@ -37,7 +37,7 @@ import StepperStep from 'common/components/StepperStep';
 import PageLoader from 'layout/PageLoader';
 import { formatDate } from 'localization/utils';
 import SharedFileIcon from 'sharedData/components/SharedFileIcon';
-import { fetchSharedData } from 'sharedData/sharedDataSlice';
+import { fetchDataEntries } from 'sharedData/sharedDataSlice';
 import { useVisualizationContext } from 'sharedData/visualization/visualizationContext';
 
 import {
@@ -77,7 +77,9 @@ const SelectDataFileStep = props => {
   const { visualizationConfig } = useVisualizationContext();
   const { onNext, onBack } = props;
   const { owner, entityType } = useCollaborationContext();
-  const { data: sharedFiles, fetching } = useSelector(_.get('sharedData.list'));
+  const { data: sharedFiles, fetching } = useSelector(
+    _.get('sharedData.dataEntries')
+  );
   const [selected, setSelected] = useState();
 
   useEffect(() => {
@@ -88,7 +90,7 @@ const SelectDataFileStep = props => {
 
   useEffect(() => {
     dispatch(
-      fetchSharedData({
+      fetchDataEntries({
         targetSlug: owner.slug,
         targetType: entityType,
         resourceTypes: ACCEPTED_RESOURCE_TYPES,

--- a/src/sharedData/visualization/visualizationUtils.js
+++ b/src/sharedData/visualization/visualizationUtils.js
@@ -20,7 +20,7 @@ import * as yup from 'yup';
 
 import { normalizeLongitude } from 'gis/gisUtils';
 import mapboxgl from 'gis/mapbox';
-import { fetchSharedDataWithGeojson } from 'sharedData/sharedDataService';
+import { fetchDataEntriesWithGeojson } from 'sharedData/sharedDataService';
 
 export const readFile = async file => {
   const response = await fetch(file.url);
@@ -61,7 +61,7 @@ export const readDataSetFile = async file => {
 };
 
 export const readMapFile = async dataEntry => {
-  const response = await fetchSharedDataWithGeojson({ id: dataEntry.id });
+  const response = await fetchDataEntriesWithGeojson({ id: dataEntry.id });
   const geojson = JSON.parse(response.geojson);
   return { geojson };
 };


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Renamed sharedData state fields and service functions to avoid confusion between fetching dataEntries and fetching sharedResources

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1575

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
