### PR TITLE
fix: use anchor for map location dialog, compensate for padding issue

### DIFF
--- a/src/storyMap/components/StoryMapForm/MapLocationDialog.js
+++ b/src/storyMap/components/StoryMapForm/MapLocationDialog.js
@@ -56,57 +56,59 @@ const BearingIcon = () => {
 const SetMapHelperText = () => {
   const { t } = useTranslation();
   return (
-    <Stack spacing={3}>
-      <Box>
-        <Trans i18nKey="storyMap.form_location_helper_text_step_1">
-          <Typography gutterBottom variant="h3">
-            Title
-          </Typography>
-          <Typography gutterBottom>Paragraph 1</Typography>
-          <img
-            src="/storyMap/set-map-step-1.png"
-            alt={t('storyMap.form_location_helper_text_step_1_image_alt')}
-          />
-        </Trans>
-      </Box>
-      <Box>
-        <Trans i18nKey="storyMap.form_location_helper_text_step_2">
-          <Typography gutterBottom variant="h3">
-            Title
-          </Typography>
-          <Typography gutterBottom sx={{ mb: 2 }}>
-            Paragraph 1
-          </Typography>
-          <Typography gutterBottom>
-            Content
-            <BearingIcon />
-            content
-            <BearingIcon />
-            content
-          </Typography>
-          <img
-            src="/storyMap/set-map-step-2-1.png"
-            alt={t('storyMap.form_location_helper_text_step_2_1_image_alt')}
-          />
-          <img
-            src="/storyMap/set-map-step-2-2.png"
-            alt={t('storyMap.form_location_helper_text_step_2_2_image_alt')}
-          />
-        </Trans>
-      </Box>
-      <Box>
-        <Trans i18nKey="storyMap.form_location_helper_text_step_3">
-          <Typography gutterBottom variant="h3">
-            Title
-          </Typography>
-          <Typography gutterBottom>Paragraph 1</Typography>
-          <img
-            src={t('storyMap.form_location_helper_text_step_3_image_src')}
-            alt={t('storyMap.form_location_helper_text_step_3_image_alt')}
-          />
-        </Trans>
-      </Box>
-    </Stack>
+    <DialogContent>
+      <Stack spacing={3}>
+        <Box>
+          <Trans i18nKey="storyMap.form_location_helper_text_step_1">
+            <Typography gutterBottom variant="h3">
+              Title
+            </Typography>
+            <Typography gutterBottom>Paragraph 1</Typography>
+            <img
+              src="/storyMap/set-map-step-1.png"
+              alt={t('storyMap.form_location_helper_text_step_1_image_alt')}
+            />
+          </Trans>
+        </Box>
+        <Box>
+          <Trans i18nKey="storyMap.form_location_helper_text_step_2">
+            <Typography gutterBottom variant="h3">
+              Title
+            </Typography>
+            <Typography gutterBottom sx={{ mb: 2 }}>
+              Paragraph 1
+            </Typography>
+            <Typography gutterBottom>
+              Content
+              <BearingIcon />
+              content
+              <BearingIcon />
+              content
+            </Typography>
+            <img
+              src="/storyMap/set-map-step-2-1.png"
+              alt={t('storyMap.form_location_helper_text_step_2_1_image_alt')}
+            />
+            <img
+              src="/storyMap/set-map-step-2-2.png"
+              alt={t('storyMap.form_location_helper_text_step_2_2_image_alt')}
+            />
+          </Trans>
+        </Box>
+        <Box>
+          <Trans i18nKey="storyMap.form_location_helper_text_step_3">
+            <Typography gutterBottom variant="h3">
+              Title
+            </Typography>
+            <Typography gutterBottom>Paragraph 1</Typography>
+            <img
+              src={t('storyMap.form_location_helper_text_step_3_image_src')}
+              alt={t('storyMap.form_location_helper_text_step_3_image_alt')}
+            />
+          </Trans>
+        </Box>
+      </Stack>
+    </DialogContent>
   );
 };
 
@@ -226,7 +228,6 @@ const MapLocationDialog = props => {
           <DialogContent sx={{ pb: 0 }}>
             <HelperText
               showLabel
-              useAnchor={false}
               maxWidth={586}
               label={t('storyMap.form_location_dialog_helper_text_label')}
               Component={SetMapHelperText}


### PR DESCRIPTION
## Description
The dialog box was set to not use an 'anchor' for its help icon, which caused it to show in the middle of the screen. I set the component to use default anchor element behavior. This caused a styling issue as a side-effect because non-anchored help boxes are styled differently than anchored ones. I compensated by changing the content to use equivalent styling.

### Checklist
- [x] Corresponding issue has been opened
- [x] Verified on desktop

### Related Issues
Fixes #1477

### Verification steps
Begin creating a new story map. Click 'set map location' and verify that the info dialog is displayed at the expected position with the expected spacing.
