### PR TITLE
fix: check empty bounds when fitting map to landscape list

### DIFF
--- a/src/landscape/components/LandscapeListMap.js
+++ b/src/landscape/components/LandscapeListMap.js
@@ -203,9 +203,12 @@ const Clusters = props => {
       new mapboxgl.LngLatBounds()
     );
 
-    map.fitBounds(bounds, {
-      padding: 50,
-    });
+    if (!bounds.isEmpty()) {
+      map.fitBounds(bounds, {
+        padding: 50,
+      });
+    }
+
     return () => {
       map.off('click', 'clusters', onClusterClick);
       map.off('click', 'unclustered-point', onUnclusteredPointClick);


### PR DESCRIPTION
## Description
Opening the landscape list without any existing landscapes caused an error when the map fit to the bounds of all available landscapes. This is because a newly-initialized `LngLatBounds` object is empty and has no defined latitude or longitude. Fix the issue by checking that the bounds is non-empty before passing it to the `fitBounds` method.

### Checklist
- [x] Verified on mobile
- [x] Verified on desktop

### Verification steps
Open the landscapes view for an account with no current landscapes. Verify that the page opens successfully without displaying an error.
