### PR TITLE
fix: Plausible update, analytics updates for the Share Public Link feature #533

### DIFF
--- a/src/common/components/SocialShare.js
+++ b/src/common/components/SocialShare.js
@@ -36,7 +36,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { useCopy } from 'custom-hooks';
 
-import { useAnalytics } from 'monitoring/analytics';
+import { useShareEvent } from 'monitoring/events';
 
 import CopyLink from './CopyLink';
 
@@ -261,7 +261,7 @@ const PostToService = props => {
 const SocialShare = props => {
   const { buttonProps } = props;
   const { t } = useTranslation();
-  const { trackEvent } = useAnalytics();
+  const { onShare } = useShareEvent();
   const { socialShareProps } = useContext(SocialShareContext);
   const { name } = socialShareProps;
   const [open, setOpen] = useState(false);
@@ -278,10 +278,6 @@ const SocialShare = props => {
     if (ref) {
       ref.focus();
     }
-  };
-
-  const onShare = method => {
-    trackEvent('share', { props: { url: pageUrl.toString(), method } });
   };
 
   if (!name) {

--- a/src/monitoring/events.js
+++ b/src/monitoring/events.js
@@ -41,7 +41,7 @@ export const useDownloadEvent = () => {
       trackEvent('dataEntry.file.download', {
         props: {
           [entityType]: ownerSlug,
-          'download location': location,
+          downloadLocation: location,
         },
       });
     },

--- a/src/monitoring/events.js
+++ b/src/monitoring/events.js
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useAnalytics } from 'monitoring/analytics';
 
@@ -23,9 +23,30 @@ export const useShareEvent = () => {
   const { trackEvent } = useAnalytics();
   const pageUrl = useMemo(() => window.location, []);
 
-  const onShare = method => {
-    trackEvent('share', { props: { url: pageUrl.toString(), method } });
-  };
+  const onShare = useCallback(
+    method => {
+      trackEvent('share', { props: { url: pageUrl.toString(), method } });
+    },
+    [trackEvent, pageUrl]
+  );
 
   return { onShare };
+};
+
+export const useDownloadEvent = () => {
+  const { trackEvent } = useAnalytics();
+
+  const onDownload = useCallback(
+    (entityType, ownerSlug, location) => {
+      trackEvent('dataEntry.file.download', {
+        props: {
+          [entityType]: ownerSlug,
+          'download location': location,
+        },
+      });
+    },
+    [trackEvent]
+  );
+
+  return { onDownload };
 };

--- a/src/monitoring/events.js
+++ b/src/monitoring/events.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021-2024 Technology Matters
+ * Copyright © 2024 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/monitoring/events.js
+++ b/src/monitoring/events.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021-2023 Technology Matters
+ * Copyright © 2021-2024 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,26 +14,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-import { useCallback } from 'react';
 
-import { useCollaborationContext } from 'collaboration/collaborationContext';
+import { useMemo } from 'react';
+
 import { useAnalytics } from 'monitoring/analytics';
 
-export const useSharedData = () => {
+export const useShareEvent = () => {
   const { trackEvent } = useAnalytics();
-  const { owner, entityType } = useCollaborationContext();
+  const pageUrl = useMemo(() => window.location, []);
 
-  const downloadFile = useCallback(
-    file => {
-      trackEvent('dataEntry.file.download', {
-        props: {
-          [entityType]: owner.slug,
-        },
-      });
-      window.open(file.url, '_blank');
-    },
-    [trackEvent, owner, entityType]
-  );
+  const onShare = method => {
+    trackEvent('share', { props: { url: pageUrl.toString(), method } });
+  };
 
-  return { downloadFile };
+  return { onShare };
 };

--- a/src/monitoring/events.test.js
+++ b/src/monitoring/events.test.js
@@ -17,21 +17,20 @@
 import { render } from 'tests/utils';
 
 import { useAnalytics } from 'monitoring/analytics';
-import { useShareEvent } from 'monitoring/events';
+import { useDownloadEvent, useShareEvent } from 'monitoring/events';
 
 jest.mock('monitoring/analytics', () => ({
   ...jest.requireActual('monitoring/analytics'),
   useAnalytics: jest.fn(),
 }));
 
-const Component = () => {
-  const { onShare } = useShareEvent();
-
-  onShare('test');
-  return <div></div>;
-};
-
 test('Events: onShare', async () => {
+  const Component = () => {
+    const { onShare } = useShareEvent();
+    onShare('test');
+    return <div></div>;
+  };
+
   const trackEvent = jest.fn();
   useAnalytics.mockReturnValue({
     trackEvent,
@@ -47,6 +46,30 @@ test('Events: onShare', async () => {
     props: {
       method: 'test',
       url: expectedUrl,
+    },
+  });
+});
+
+test('Events: onDownload', async () => {
+  const Component = () => {
+    const { onDownload } = useDownloadEvent();
+    onDownload('group', 'abc', 'test');
+    return <div></div>;
+  };
+
+  const trackEvent = jest.fn();
+  useAnalytics.mockReturnValue({
+    trackEvent,
+  });
+
+  await render(<Component />);
+
+  const eventCall = trackEvent.mock.calls[0];
+  expect(eventCall[0]).toStrictEqual('dataEntry.file.download');
+  expect(eventCall[1]).toStrictEqual({
+    props: {
+      group: 'abc',
+      'download location': 'test',
     },
   });
 });

--- a/src/monitoring/events.test.js
+++ b/src/monitoring/events.test.js
@@ -69,7 +69,7 @@ test('Events: onDownload', async () => {
   expect(eventCall[1]).toStrictEqual({
     props: {
       group: 'abc',
-      'download location': 'test',
+      downloadLocation: 'test',
     },
   });
 });

--- a/src/monitoring/events.test.js
+++ b/src/monitoring/events.test.js
@@ -54,7 +54,7 @@ test('Events: onDownload', async () => {
   const Component = () => {
     const { onDownload } = useDownloadEvent();
     onDownload('group', 'abc', 'test');
-    return <div></div>;
+    return <div />;
   };
 
   const trackEvent = jest.fn();

--- a/src/monitoring/events.test.js
+++ b/src/monitoring/events.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021-2023 Technology Matters
+ * Copyright © 2024 Technology Matters
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published

--- a/src/navigation/components/Routes.js
+++ b/src/navigation/components/Routes.js
@@ -17,6 +17,8 @@
 import React, { useMemo } from 'react';
 import { matchPath, Route, Routes, useLocation } from 'react-router-dom';
 
+import { withProps } from 'react-hoc';
+
 import NotFound from 'layout/NotFound';
 import AccountLogin from 'account/components/AccountLogin';
 import AccountProfile from 'account/components/AccountProfile';
@@ -108,13 +110,17 @@ const paths = [
     showBreadcrumbs: true,
     breadcrumbsLabel: 'group.breadcrumbs_visualization',
   }),
-  path('/groups/:groupSlug/download/:shareUuid', SharedResourceDownload, {
-    optionalAuth: {
-      enabled: true,
-      topMessage:
-        'sharedData.shared_resource_download_optional_auth_top_message',
-    },
-  }),
+  path(
+    '/groups/:groupSlug/download/:shareUuid',
+    withProps(SharedResourceDownload, { entityType: 'group' }),
+    {
+      optionalAuth: {
+        enabled: true,
+        topMessage:
+          'sharedData.shared_resource_download_optional_auth_top_message',
+      },
+    }
+  ),
   path('/landscapes/map', LandscapeMapEmbed, {
     optionalAuth: {
       enabled: true,
@@ -167,7 +173,7 @@ const paths = [
   ),
   path(
     '/landscapes/:landscapeSlug/download/:shareUuid',
-    SharedResourceDownload,
+    withProps(SharedResourceDownload, { entityType: 'landscape' }),
     {
       optionalAuth: {
         enabled: true,

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -49,6 +49,7 @@ import { useCollaborationContext } from 'collaboration/collaborationContext';
 import CopyLink from 'common/components/CopyLink';
 import RouterLink from 'common/components/RouterLink';
 import { formatDate } from 'localization/utils';
+import { useShareEvent } from 'monitoring/events';
 import {
   SHARE_ACCESS_ALL,
   SHARE_ACCESS_TYPES,
@@ -161,6 +162,8 @@ const ShareDialog = props => {
       ref.focus();
     }
   };
+
+  const { onShare } = useShareEvent();
 
   const onChange = useCallback(
     event => {
@@ -280,7 +283,7 @@ const ShareDialog = props => {
             </Typography>
           </Stack>
         )}
-        <CopyLink pageUrl={sharedResource.shareUrl} />
+        <CopyLink pageUrl={sharedResource.shareUrl} onShare={onShare} />
       </DialogContent>
       <DialogActions
         sx={{

--- a/src/sharedData/components/SharedResourceDownload.js
+++ b/src/sharedData/components/SharedResourceDownload.js
@@ -25,17 +25,23 @@ import { Button, Paper, Stack, Typography } from '@mui/material';
 import NotFound from 'layout/NotFound';
 import PageContainer from 'layout/PageContainer';
 import PageLoader from 'layout/PageLoader';
+import { useDownloadEvent } from 'monitoring/events';
 import { generateReferrerPath } from 'navigation/navigationUtils';
 import { fetchSharedResource } from 'sharedData/sharedDataSlice';
 
-const SharedResourceDownload = () => {
+const SharedResourceDownload = props => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const { shareUuid } = useParams();
+  const { shareUuid, ...params } = useParams();
   const { data: sharedResource, fetching: fetchingSharedResource } =
     useSelector(state => state.sharedData.sharedResource);
   const hasToken = useSelector(state => state.account.hasToken);
+
+  const { entityType } = props;
+  const ownerSlug =
+    entityType === 'group' ? params.groupSlug : params.landscapeSlug;
+  const { onDownload } = useDownloadEvent();
 
   useFetchData(
     useCallback(() => fetchSharedResource({ shareUuid }), [shareUuid])
@@ -59,8 +65,9 @@ const SharedResourceDownload = () => {
   }, [fetchingSharedResource, location, sharedResource, hasToken, navigate]);
 
   const downloadFile = useCallback(() => {
+    onDownload(entityType, ownerSlug, 'download page');
     window.open(sharedResource.downloadUrl, '_blank');
-  }, [sharedResource]);
+  }, [onDownload, entityType, ownerSlug, sharedResource]);
 
   if (fetchingSharedResource) {
     return <PageLoader />;

--- a/src/sharedData/sharedDataHooks.js
+++ b/src/sharedData/sharedDataHooks.js
@@ -17,22 +17,18 @@
 import { useCallback } from 'react';
 
 import { useCollaborationContext } from 'collaboration/collaborationContext';
-import { useAnalytics } from 'monitoring/analytics';
+import { useDownloadEvent } from 'monitoring/events';
 
 export const useSharedData = () => {
-  const { trackEvent } = useAnalytics();
+  const { onDownload } = useDownloadEvent();
   const { owner, entityType } = useCollaborationContext();
 
   const downloadFile = useCallback(
     file => {
-      trackEvent('dataEntry.file.download', {
-        props: {
-          [entityType]: owner.slug,
-        },
-      });
+      onDownload(entityType, owner.slug, 'landscape/group page');
       window.open(file.url, '_blank');
     },
-    [trackEvent, owner, entityType]
+    [onDownload, owner, entityType]
   );
 
   return { downloadFile };


### PR DESCRIPTION
## Description

Address requests from [Plausible update, analytics updates for the Share Public Link feature #533](https://github.com/techmatters/terraso-product/issues/533). Both download buttons now generate an event, with common code ensuring consistency between the two. Additionally, 'share public link' functionality now uses standardized events as well. Both updated plausible events now live in a common `events.js` file so we can begin centralizing Plausible-related logic with an eye towards having centralized control over all events.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #533 

### Verification steps

Run unit tests where added. Go to downloads for both a group and landscape, press the download button, and verify in the network inspector that the outgoing plausible event calls have the expected parameters.