### PR TITLE
fix: make nav blocker tool fully disable on form save

### DIFF
--- a/src/navigation/navigationContext.js
+++ b/src/navigation/navigationContext.js
@@ -20,6 +20,8 @@ import {
   useNavigate,
 } from 'react-router-dom';
 
+let originalPush;
+
 export const useNavigationBlocker = (when, message) => {
   const navigate = useNavigate();
   const { navigator } = useContext(NavigationContext);
@@ -31,8 +33,8 @@ export const useNavigationBlocker = (when, message) => {
    * so that we can be sure we're restoring the original when the blocker is
    * disabled or otherwised cleaned up.
    */
-  if (!navigator.originalPush) {
-    navigator.originalPush = navigator.push;
+  if (!originalPush) {
+    originalPush = navigator.push;
   }
 
   const proceed = useCallback(() => {
@@ -58,7 +60,7 @@ export const useNavigationBlocker = (when, message) => {
 
   const disable = useCallback(() => {
     window.removeEventListener('beforeunload', preventNavigation);
-    navigator.push = navigator.originalPush;
+    navigator.push = originalPush;
   }, [preventNavigation, navigator]);
 
   useEffect(() => {
@@ -71,7 +73,7 @@ export const useNavigationBlocker = (when, message) => {
     navigator.push = (...args) => {
       const options = args[2];
       if (options?.force) {
-        navigator.originalPush(...args);
+        originalPush(...args);
         return;
       }
 

--- a/src/navigation/navigationContext.js
+++ b/src/navigation/navigationContext.js
@@ -27,7 +27,7 @@ export const useNavigationBlocker = (when, message) => {
   const [blockedArgs, setBlockedArgs] = useState();
 
   /*
-   * we cache a reference to the original push method if we don't have one yet,
+   * We store a reference to the original push method (if we don't have one yet),
    * so that we can be sure we're restoring the original when the blocker is
    * disabled or otherwised cleaned up.
    */

--- a/src/navigation/navigationContext.test.js
+++ b/src/navigation/navigationContext.test.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import { render } from 'tests/utils';
+
+import { useNavigationBlocker } from './navigationContext';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+/*
+ * These tests do not cover all of the blocker system's behavior, but verifying that
+ * the event handler was added / removed was considered sufficient for an initial pass.
+ */
+
+test('Enable navigation blocker', async () => {
+  const Component = () => {
+    useNavigationBlocker(true, 'test');
+    return <div />;
+  };
+
+  window.addEventListener = jest.fn();
+
+  await render(<Component />);
+
+  expect(window.addEventListener).toHaveBeenCalledWith(
+    'beforeunload',
+    expect.any(Function)
+  );
+});
+
+test('Disable navigation blocker', async () => {
+  const Component = () => {
+    const { disable } = useNavigationBlocker(true, 'test');
+    disable();
+    return <div />;
+  };
+
+  window.removeEventListener = jest.fn();
+
+  await render(<Component />);
+
+  expect(window.removeEventListener).toHaveBeenCalledWith(
+    'beforeunload',
+    expect.any(Function)
+  );
+});

--- a/src/sharedData/visualization/components/VisualizationConfigForm/index.js
+++ b/src/sharedData/visualization/components/VisualizationConfigForm/index.js
@@ -151,7 +151,7 @@ const VisualizationConfigForm = props => {
     useState(INITIAL_CONFIG);
   const [isDirty, setIsDirty] = useState(false);
 
-  const { isBlocked, unblock, cancel } = useNavigationBlocker(
+  const { isBlocked, proceed, cancel, disable } = useNavigationBlocker(
     isDirty,
     t('sharedData.visualization_unsaved_changes_message')
   );
@@ -173,10 +173,11 @@ const VisualizationConfigForm = props => {
 
   const onCompleteSuccessWrapper = useCallback(
     mapSlug => {
-      onCompleteSuccess(mapSlug);
       setIsDirty(false);
+      disable();
+      onCompleteSuccess(mapSlug);
     },
-    [onCompleteSuccess]
+    [onCompleteSuccess, disable]
   );
 
   return (
@@ -185,7 +186,7 @@ const VisualizationConfigForm = props => {
         <NavigationBlockedDialog
           title={t('sharedData.visualization_unsaved_changes_title')}
           message={t('sharedData.visualization_unsaved_changes_message')}
-          onConfirm={unblock}
+          onConfirm={proceed}
           onCancel={cancel}
         />
       )}

--- a/src/storyMap/components/StoryMapForm/index.js
+++ b/src/storyMap/components/StoryMapForm/index.js
@@ -110,7 +110,7 @@ const StoryMapForm = props => {
     []
   );
 
-  const { isBlocked, unblock, cancel } = useNavigationBlocker(
+  const { isBlocked, proceed, cancel } = useNavigationBlocker(
     isDirty,
     t('storyMap.form_unsaved_changes_message')
   );
@@ -235,7 +235,7 @@ const StoryMapForm = props => {
         <NavigationBlockedDialog
           title={t('storyMap.form_unsaved_changes_title')}
           message={t('storyMap.form_unsaved_changes_message')}
-          onConfirm={unblock}
+          onConfirm={proceed}
           onCancel={cancel}
         />
       )}


### PR DESCRIPTION
## Description

The navigation blocker as implemented ran into an issue with saving on the map-creation workflow. The form was supposed to navigate to the user's newly-created map on save, but because of how react processes events and state changes, the navigation blocker was still active for the event cycle when the completion callback initiated the new navigation target. This introduces a new capability to the blocker which allows client code to disable the blocking behavior immediately, which allows the navigation to proceed as intended. Also does some minor name refactoring for clarity.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes [1400](https://github.com/techmatters/terraso-web-client/issues/1400)

### Verification steps

- Create a new landscape, upload a file, and begin creating a map from it ([as described in original report](https://github.com/techmatters/terraso-web-client/issues/1400))
- Verify that clicking to navigate away somewhere else still brings up the blocker
- Verify that saving the map navigates to the newly created map

- Verify that story map creation workflow is unchanged (it used the same navigation blocker hook)