### PR TITLE
feat: Add file extension type column to shared data card for files

### DIFF
--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -122,6 +122,7 @@ const baseViewTest = async (
             description: `Description ${index}`,
             size: 3456,
             entryType: 'FILE',
+            resourceType: 'txt',
             visualizations: { edges: [] },
           },
         },
@@ -233,6 +234,9 @@ test('LandscapeView: Display data', async () => {
   const entriesList = within(sharedDataRegion.getByRole('list'));
   const items = entriesList.getAllByRole('listitem');
   expect(items.length).toBe(6);
+  const firstEntry = within(items[0]);
+  expect(firstEntry.getByText('Data Entry 0')).toBeInTheDocument();
+  expect(firstEntry.getByText('txt')).toBeInTheDocument();
 
   // Boundary
   expect(

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -54,7 +54,8 @@ const SharedDataEntryBase = props => {
     EntryTypeIcon,
     DownloadComponent,
     ShareComponent,
-    info,
+    fileSize,
+    resourceType,
     deleteTooltip,
   } = props;
   const [isEditingName, setIsEditingName] = useState(false);
@@ -203,26 +204,28 @@ const SharedDataEntryBase = props => {
             />
           </Restricted>
         </Grid>
-        <Grid item xs={1} order={{ xs: 5 }} display={{ md: 'none' }} />
-        <Grid
-          item
-          xs={11}
-          md={1}
-          order={{ xs: 6, md: 4 }}
-          sx={{ wordWrap: 'break-word' }}
-        >
-          {info}
+
+        <Grid item xs={12} md={4} order={{ xs: 5, md: 3 }}>
+          <Grid container>
+            <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
+              {resourceType}
+            </Grid>
+            <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
+              {fileSize}
+            </Grid>
+            <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
+            <Grid item xs={11} md={8}>
+              {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
+              {t('user.full_name', { user: dataEntry.createdBy })}
+            </Grid>
+          </Grid>
         </Grid>
-        <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
-        <Grid item xs={11} md={3} order={{ xs: 8, md: 4 }}>
-          {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
-          {t('user.full_name', { user: dataEntry.createdBy })}
-        </Grid>
+
         <Grid
           item
           xs={4}
           md={2}
-          order={{ xs: 3, md: 4 }}
+          order={{ xs: 3, md: 6 }}
           component={StackRow}
           justifyContent="flex-end"
           display={isEditingName ? 'none' : 'inherit'}

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -231,25 +231,6 @@ const SharedDataEntryBase = props => {
           {t('user.full_name', { user: dataEntry.createdBy })}
         </Grid>
 
-        {/* 
-        <Grid item xs={10} order={{ xs: 4 }} display={{ md: 'none' }} />
-        <Grid item xs={12} md={4} order={{ xs: 5, md: 3 }}>
-          <Grid container>
-            <Grid item xs={1} order={{ xs: 1 }} display={{ md: 'none' }} />
-            <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
-              {resourceType}
-            </Grid>
-            <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
-              {fileSize}
-            </Grid>
-            <Grid item xs={11} md={8}>
-              {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
-              {t('user.full_name', { user: dataEntry.createdBy })}
-            </Grid>
-          </Grid>
-        </Grid>
-*/}
-
         <Grid
           item
           xs={4}

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -174,7 +174,7 @@ const SharedDataEntryBase = props => {
         <Grid
           item
           xs={isEditingName ? 12 : 8}
-          md={6}
+          md={5}
           order={{ xs: 2, md: 2 }}
           component={StackRow}
         >
@@ -205,21 +205,50 @@ const SharedDataEntryBase = props => {
           </Restricted>
         </Grid>
 
+        <Grid item xs={1} order={{ xs: 4 }} display={{ md: 'none' }} />
+        <Grid
+          item
+          xs={2}
+          md={1}
+          order={{ xs: 5, md: 4 }}
+          sx={{ wordWrap: 'break-word' }}
+        >
+          {resourceType}
+        </Grid>
+        <Grid
+          item
+          xs={2}
+          md={1}
+          order={{ xs: 6, md: 5 }}
+          sx={{ wordWrap: 'break-word' }}
+        >
+          {fileSize}
+        </Grid>
+        <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
+        <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
+        <Grid item xs={11} md={3} order={{ xs: 8, md: 6 }}>
+          {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
+          {t('user.full_name', { user: dataEntry.createdBy })}
+        </Grid>
+
+        {/* 
+        <Grid item xs={10} order={{ xs: 4 }} display={{ md: 'none' }} />
         <Grid item xs={12} md={4} order={{ xs: 5, md: 3 }}>
           <Grid container>
+            <Grid item xs={1} order={{ xs: 1 }} display={{ md: 'none' }} />
             <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
               {resourceType}
             </Grid>
             <Grid item xs={11} md={2} sx={{ wordWrap: 'break-word' }}>
               {fileSize}
             </Grid>
-            <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
             <Grid item xs={11} md={8}>
               {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
               {t('user.full_name', { user: dataEntry.createdBy })}
             </Grid>
           </Grid>
         </Grid>
+*/}
 
         <Grid
           item

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -211,7 +211,7 @@ const SharedDataEntryBase = props => {
           xs={2}
           md={1}
           order={{ xs: 5, md: 4 }}
-          sx={{ wordWrap: 'break-word' }}
+          sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
         >
           {resourceType}
         </Grid>

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -360,7 +360,7 @@ const SharedDataEntryFile = props => {
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
       fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}
-      resourceType={sharedResource.dataEntry.resourceType.toUpperCase()}
+      resourceType={sharedResource.dataEntry.resourceType}
     >
       <Visualizations file={sharedResource.dataEntry} />
     </SharedDataEntryBase>

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -359,7 +359,13 @@ const SharedDataEntryFile = props => {
       EntryTypeIcon={SharedFileIcon}
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
-      info={filesize(sharedResource.dataEntry.size, { round: 0 })}
+      fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}
+      resourceType={sharedResource.dataEntry.resourceType.toUpperCase()}
+      // TODO-cknipe: Just add resourceType to info, maybe?
+      // Hmm but Base does have to know about info regardless I guess
+      // we want it to be another
+      // Could just be info1 and info2 I guess
+      // but iono
     >
       <Visualizations file={sharedResource.dataEntry} />
     </SharedDataEntryBase>

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -361,11 +361,6 @@ const SharedDataEntryFile = props => {
       ShareComponent={ShareComponent}
       fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}
       resourceType={sharedResource.dataEntry.resourceType.toUpperCase()}
-      // TODO-cknipe: Just add resourceType to info, maybe?
-      // Hmm but Base does have to know about info regardless I guess
-      // we want it to be another
-      // Could just be info1 and info2 I guess
-      // but iono
     >
       <Visualizations file={sharedResource.dataEntry} />
     </SharedDataEntryBase>


### PR DESCRIPTION
## Description
In the "Shared Files and Links" section, shared files now display a column with the file extension type.
This addresses GitHub Issue #1551.

### Checklist
- [x] New tests added
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Will file some other issues found in the process of looking at this, but not directly related. One on grid layout particulars, one on localization, and one on edit description save button.

### Verification steps
1. Go to a landscape and scroll down to the "Shared Files and Links" card
2. Add files if there aren't any already
3. Confirm there is a column for the file extension type, that it displays the correct file extension, that it looks ok on different size screens

### Aside
- The fileSize and resourceType props are only relevant for SharedDataEntryFile, but the concepts exist in SharedDataEntryBase (previously, there was just one prop that was also only relevant for SharedDataEntryFile, but was more generally named 'info')