### PR TITLE
fix: set English and Spanish localization for date and author of shared files

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -523,6 +523,7 @@
         "title": "Shared files and Links",
         "description_with_files": "Only members of your {{entityType}} can download these files or create a map with them.",
         "card_description": "Upload documents and share links with other members. Make maps with data files (latitude and longitude required) and map files (GeoJSON, KML, KMZ, ESRI shapefiles).",
+        "file_date_and_author": "{{date}}, by $t(user.full_name)",
         "upload_button": "Share Files and Links",
         "delete_confirm_title": "Delete “{{name}}”?",
         "delete_file_confirm_message": "Are you sure you wish to delete the file “{{name}}”?",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -570,6 +570,7 @@
         "title": "Archivos y enlaces compartidos",
         "description_with_files": "Solo los miembros de tu {{entityType}} pueden descargar estos archivos o crear un mapa con ellos.",
         "card_description": "Carga documentos y comparte enlaces con otros miembros. Crea mapas con archivos de datos (se requieren latitud y longitud) y archivos de mapas (GeoJSON, KML, KMZ, Shapefiles de ESRI).",
+        "file_date_and_author": "{{date}}, por $t(user.full_name)",
         "upload_button": "Compartir archivos y enlaces",
         "delete_confirm_title": "Eliminar “{{name}}”?",
         "delete_file_confirm_message": "¿Estás segura(o) de que deseas eliminar el archivo “{{name}}”?",

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -226,9 +226,11 @@ const SharedDataEntryBase = props => {
         </Grid>
         <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
-        <Grid item xs={11} md={3} order={{ xs: 8, md: 6 }}>
-          {formatDate(i18n.resolvedLanguage, dataEntry.createdAt)}, by{' '}
-          {t('user.full_name', { user: dataEntry.createdBy })}
+        <Grid item xs={11} md={3} order={{ xs: 8, md: 4 }}>
+          {t('sharedData.file_date_and_author', {
+            date: formatDate(i18n.resolvedLanguage, dataEntry.createdAt),
+            user: dataEntry.createdBy,
+          })}
         </Grid>
 
         <Grid


### PR DESCRIPTION
## Description
Sets localization properly for the date and author string that was hard-coded into the SharedDataEntryBase component (e.g., "Mar 22, 2024, by Carissa Knipe" in English; "22 mar 2024, por Carissa Knipe" in Spanish) 

### Checklist
- [x] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes #1662 

### Verification steps
See #1662 