### PR TITLE
fix: avoid crashing on maps without a source

### DIFF
--- a/src/gis/components/Map.js
+++ b/src/gis/components/Map.js
@@ -166,8 +166,13 @@ export const MapProvider = props => {
       if (!map) {
         return;
       }
+      let currentSource;
 
-      const currentSource = map.getSource(name);
+      try {
+        currentSource = map.getSource(name);
+      } catch (error) {
+        console.log('Error getting source', error);
+      }
 
       try {
         const isGeoJson = source.type === 'geojson';


### PR DESCRIPTION
## Description
Avoid crashing on maps without a source.

### Related Issues
Fixes #1336.