### PR TITLE
fix: add margin around disclaimer

### DIFF
--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -138,7 +138,7 @@ const AccountForm = () => {
           )}
         </Stack>
 
-        <Typography sx={{ mb: 4 }}>
+        <Typography sx={{ m: 2.5 }}>
           <Trans i18nKey="account.disclaimer">
             prefix
             <ExternalLink href={t('account.disclaimer_url')}>text</ExternalLink>


### PR DESCRIPTION
## Description
Add margin around disclaimer. Aligns text with footer on mobile.

### Checklist
- [X] Verified on mobile
- [X] Verified on desktop