### PR TITLE
fix: shared files layout improvements

### DIFF
--- a/src/common/components/ConfirmationDialog.js
+++ b/src/common/components/ConfirmationDialog.js
@@ -57,7 +57,7 @@ const ConfirmationDialog = props => {
       aria-labelledby="confirmation-dialog-title"
       aria-describedby="confirmation-dialog-content-text"
     >
-      <DialogTitle component="h1" id="confirmation-dialog-title">
+      <DialogTitle component="h1" id="confirmation-dialog-title" sx={{ mt: 2 }}>
         {title}
       </DialogTitle>
       <DialogContent>

--- a/src/common/components/ConfirmationDialog.js
+++ b/src/common/components/ConfirmationDialog.js
@@ -57,7 +57,11 @@ const ConfirmationDialog = props => {
       aria-labelledby="confirmation-dialog-title"
       aria-describedby="confirmation-dialog-content-text"
     >
-      <DialogTitle component="h1" id="confirmation-dialog-title" sx={{ mt: 2 }}>
+      <DialogTitle
+        component="h1"
+        id="confirmation-dialog-title"
+        sx={{ marginTop: { xs: 2, md: 0 } }}
+      >
         {title}
       </DialogTitle>
       <DialogContent>

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Grid, ListItem, Stack, Typography } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { daysSince } from 'timeUtils';
 
@@ -69,6 +70,7 @@ const SharedDataEntryBase = props => {
   );
   const dispatch = useDispatch();
   const { trackEvent } = useAnalytics();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const onConfirm = useCallback(() => {
     dispatch(deleteSharedData({ dataEntry, sharedResource })).then(data => {
@@ -182,7 +184,10 @@ const SharedDataEntryBase = props => {
           order={{ xs: 2, md: 2 }}
           component={StackRow}
         >
-          <EntryTypeIcon resourceType={dataEntry.resourceType} />
+          <EntryTypeIcon
+            resourceType={dataEntry.resourceType}
+            style={isSmall ? { marginTop: '-1em', paddingRight: '5px' } : {}}
+          />
           <Restricted
             permission="sharedData.edit"
             resource={permissionsResource}

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -20,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Grid, ListItem, Stack, Typography } from '@mui/material';
-import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { daysSince } from 'timeUtils';
 
@@ -70,7 +69,6 @@ const SharedDataEntryBase = props => {
   );
   const dispatch = useDispatch();
   const { trackEvent } = useAnalytics();
-  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const onConfirm = useCallback(() => {
     dispatch(deleteSharedData({ dataEntry, sharedResource })).then(data => {
@@ -183,10 +181,20 @@ const SharedDataEntryBase = props => {
           md={5}
           order={{ xs: 2, md: 2 }}
           component={StackRow}
+          sx={{
+            alignItems: {
+              xs: 'flex-start',
+              md: 'inherit',
+            },
+          }}
         >
           <EntryTypeIcon
             resourceType={dataEntry.resourceType}
-            style={isSmall ? { marginTop: '-1em', paddingRight: '5px' } : {}}
+            styleProps={{
+              marginTop: { xs: '1em', md: 'inherit' },
+              marginLeft: { xs: '-5px', md: 'inherit' },
+              paddingRight: { xs: '5px', md: 'inherit' },
+            }}
           />
           <Restricted
             permission="sharedData.edit"

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -42,7 +42,7 @@ import theme from 'theme';
 export const ICON_SIZE = 24;
 
 const StackRow = props => (
-  <Stack direction="row" alignItems="center" spacing={1} {...props} />
+  <Stack direction="row" alignItems="center" {...props} />
 );
 
 const SharedDataEntryBase = props => {
@@ -169,11 +169,15 @@ const SharedDataEntryBase = props => {
         container
         spacing={1}
         alignItems="center"
-        sx={{ fontSize: 14, color: 'gray.dark1', p: 1 }}
+        sx={{
+          fontSize: 14,
+          color: 'gray.dark1',
+          p: 1,
+        }}
       >
         <Grid
           item
-          xs={isEditingName ? 12 : 8}
+          xs={isEditingName ? 12 : 7}
           md={5}
           order={{ xs: 2, md: 2 }}
           component={StackRow}
@@ -233,7 +237,7 @@ const SharedDataEntryBase = props => {
 
         <Grid
           item
-          xs={4}
+          xs={5}
           md={2}
           order={{ xs: 3, md: 6 }}
           component={StackRow}

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -191,7 +191,7 @@ const SharedDataEntryBase = props => {
           <EntryTypeIcon
             resourceType={dataEntry.resourceType}
             styleProps={{
-              marginTop: { xs: '1em', md: 'inherit' },
+              marginTop: { xs: '0.8em', md: 'inherit' },
               marginLeft: { xs: '-5px', md: 'inherit' },
               paddingRight: { xs: '5px', md: 'inherit' },
             }}

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -182,18 +182,15 @@ const SharedDataEntryBase = props => {
           order={{ xs: 2, md: 2 }}
           component={StackRow}
           sx={{
-            alignItems: {
-              xs: 'flex-start',
-              md: 'inherit',
-            },
+            alignItems: 'flex-start',
           }}
         >
           <EntryTypeIcon
             resourceType={dataEntry.resourceType}
             styleProps={{
-              marginTop: { xs: '0.8em', md: 'inherit' },
-              marginLeft: { xs: '-5px', md: 'inherit' },
-              paddingRight: { xs: '5px', md: 'inherit' },
+              marginTop: '0.8em',
+              marginLeft: '-5px',
+              paddingRight: '5px',
             }}
           />
           <Restricted

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -185,14 +185,7 @@ const SharedDataEntryBase = props => {
             alignItems: 'flex-start',
           }}
         >
-          <EntryTypeIcon
-            resourceType={dataEntry.resourceType}
-            styleProps={{
-              marginTop: '0.8em',
-              marginLeft: '-5px',
-              paddingRight: '5px',
-            }}
-          />
+          <EntryTypeIcon resourceType={dataEntry.resourceType} />
           <Restricted
             permission="sharedData.edit"
             resource={permissionsResource}

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -356,12 +356,21 @@ const SharedDataEntryFile = props => {
   return (
     <SharedDataEntryBase
       sharedResource={sharedResource}
-      EntryTypeIcon={SharedFileIcon}
+      EntryTypeIcon={() => (
+        <SharedFileIcon
+          resourceType={sharedResource.dataEntry.resourceType}
+          styleProps={{
+            marginTop: '0.8em',
+            marginLeft: '-5px',
+            paddingRight: '5px',
+          }}
           fallbackStyleProps={{
             marginTop: '0.5em',
             marginLeft: '-5px',
             paddingRight: '5px',
           }}
+        />
+      )}
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
       fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -357,6 +357,11 @@ const SharedDataEntryFile = props => {
     <SharedDataEntryBase
       sharedResource={sharedResource}
       EntryTypeIcon={SharedFileIcon}
+          fallbackStyleProps={{
+            marginTop: '0.5em',
+            marginLeft: '-5px',
+            paddingRight: '5px',
+          }}
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
       fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -82,7 +82,15 @@ const SharedDataEntryLink = props => {
     <SharedDataEntryBase
       sharedResource={sharedResource}
       EntryTypeIcon={() => (
-        <LinkIcon alt={t('sharedData.link_label')} role="img" />
+        <LinkIcon
+          alt={t('sharedData.link_label')}
+          role="img"
+          sx={{
+            marginTop: { xs: '0.6em', md: 'inherit' },
+            marginLeft: { xs: '-5px', md: 'inherit' },
+            paddingRight: { xs: '5px', md: 'inherit' },
+          }}
+        />
       )}
       DownloadComponent={DownloadComponent}
       info={domain}

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -86,9 +86,9 @@ const SharedDataEntryLink = props => {
           alt={t('sharedData.link_label')}
           role="img"
           sx={{
-            marginTop: { xs: '0.6em', md: 'inherit' },
-            marginLeft: { xs: '-5px', md: 'inherit' },
-            paddingRight: { xs: '5px', md: 'inherit' },
+            marginTop: '0.6em',
+            marginLeft: '-3px',
+            paddingRight: '3px',
           }}
         />
       )}

--- a/src/sharedData/components/SharedFileIcon.js
+++ b/src/sharedData/components/SharedFileIcon.js
@@ -41,7 +41,7 @@ const ICON_FILES = {
 };
 
 const SharedFileIcon = props => {
-  const { resourceType, styleProps } = props;
+  const { resourceType, styleProps, fallbackStyleProps } = props;
 
   if (_.includes(resourceType, Object.keys(ICON_FILES))) {
     return (
@@ -64,6 +64,7 @@ const SharedFileIcon = props => {
       sx={{
         fontSize: ICON_SIZE,
         color: 'gray.dark1',
+        ...fallbackStyleProps,
       }}
     />
   );

--- a/src/sharedData/components/SharedFileIcon.js
+++ b/src/sharedData/components/SharedFileIcon.js
@@ -42,7 +42,7 @@ const ICON_FILES = {
 
 const SharedFileIcon = props => {
   const { resourceType, styleProps } = props;
-  console.log(styleProps);
+
   if (_.includes(resourceType, Object.keys(ICON_FILES))) {
     return (
       <Box

--- a/src/sharedData/components/SharedFileIcon.js
+++ b/src/sharedData/components/SharedFileIcon.js
@@ -17,6 +17,7 @@
 import React from 'react';
 import _ from 'lodash/fp';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import { Box } from '@mui/material';
 
 const ICON_SIZE = 24;
 const ICON_FILES = {
@@ -40,16 +41,18 @@ const ICON_FILES = {
 };
 
 const SharedFileIcon = props => {
-  const { resourceType, style } = props;
+  const { resourceType, styleProps } = props;
+  console.log(styleProps);
   if (_.includes(resourceType, Object.keys(ICON_FILES))) {
     return (
-      <img
-        style={{
+      <Box
+        component="img"
+        sx={{
           filter: 'opacity(50%)',
-          ...style,
+          width: 24,
+          height: 24,
+          ...styleProps,
         }}
-        width="24"
-        height="24"
         src={`/files/${ICON_FILES[resourceType]}`}
         alt={resourceType.toUpperCase()}
       />

--- a/src/sharedData/components/SharedFileIcon.js
+++ b/src/sharedData/components/SharedFileIcon.js
@@ -40,9 +40,7 @@ const ICON_FILES = {
   png: 'png.png',
 };
 
-const SharedFileIcon = props => {
-  const { resourceType, styleProps, fallbackStyleProps } = props;
-
+const SharedFileIcon = ({ resourceType, styleProps, fallbackStyleProps }) => {
   if (_.includes(resourceType, Object.keys(ICON_FILES))) {
     return (
       <Box

--- a/src/sharedData/components/SharedFileIcon.js
+++ b/src/sharedData/components/SharedFileIcon.js
@@ -39,11 +39,15 @@ const ICON_FILES = {
   png: 'png.png',
 };
 
-const SharedFileIcon = ({ resourceType }) => {
+const SharedFileIcon = props => {
+  const { resourceType, style } = props;
   if (_.includes(resourceType, Object.keys(ICON_FILES))) {
     return (
       <img
-        style={{ filter: 'opacity(50%)' }}
+        style={{
+          filter: 'opacity(50%)',
+          ...style,
+        }}
         width="24"
         height="24"
         src={`/files/${ICON_FILES[resourceType]}`}


### PR DESCRIPTION
## Description
* vertically align file type icon on mobile
* add space at top of full-screen confirmation dialog
* prevent share icon from overlapping file name on mobile

### Checklist
- [X] Corresponding issue has been opened
- [X] Verified on mobile
- [X] Verified on desktop

### Related Issues
Fixes #1659.