### PR TITLE
fix: correct UUID processing state

### DIFF
--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -285,7 +285,7 @@ test('LandscapeView: Update Shared Data', async () => {
         input: {
           id: 'de-3',
           name: 'Data Entry 3 revised',
-          description: 'Description 3'
+          description: 'Description 3',
         },
       })
     )
@@ -376,7 +376,13 @@ test('LandscapeView: Update Shared Data', async () => {
   );
   expect(terrasoApi.requestGraphQL).toHaveBeenCalledWith(
     expect.stringContaining('mutation updateSharedData'),
-    { input: { id: 'de-3', name: 'Data Entry 3 revised', description: 'Description 3' } }
+    {
+      input: {
+        id: 'de-3',
+        name: 'Data Entry 3 revised',
+        description: 'Description 3',
+      },
+    }
   );
 });
 

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -270,6 +270,7 @@ test('LandscapeView: Update Shared Data', async () => {
           id: `de-3`,
           createdAt: '2022-05-20T16:25:21.536679+00:00',
           name: `Data Entry 3 updated`,
+          description: 'Description 3',
           createdBy: { id: 'user-id', firstName: 'First', lastName: 'Last' },
           size: 3456,
           entryType: 'FILE',
@@ -284,6 +285,7 @@ test('LandscapeView: Update Shared Data', async () => {
         input: {
           id: 'de-3',
           name: 'Data Entry 3 revised',
+          description: 'Description 3'
         },
       })
     )
@@ -294,6 +296,7 @@ test('LandscapeView: Update Shared Data', async () => {
           id: `de-3`,
           createdAt: '2022-05-20T16:25:21.536679+00:00',
           name: `Data Entry 3 revised`,
+          description: 'Description 3',
           createdBy: { id: 'user-id', firstName: 'First', lastName: 'Last' },
           size: 3456,
           entryType: 'FILE',
@@ -373,7 +376,7 @@ test('LandscapeView: Update Shared Data', async () => {
   );
   expect(terrasoApi.requestGraphQL).toHaveBeenCalledWith(
     expect.stringContaining('mutation updateSharedData'),
-    { input: { id: 'de-3', name: 'Data Entry 3 revised' } }
+    { input: { id: 'de-3', name: 'Data Entry 3 revised', description: 'Description 3' } }
   );
 });
 

--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -289,7 +289,7 @@ test('LandscapeView: Update Shared Data', async () => {
   const entriesList = within(sharedDataRegion.getByRole('list'));
   const items = entriesList.getAllByRole('listitem');
 
-  const nameField = within(items[3]).getByRole('button', {
+  let nameField = within(items[3]).getByRole('button', {
     name: 'Data Entry 3',
   });
   expect(nameField).toBeInTheDocument();
@@ -303,7 +303,7 @@ test('LandscapeView: Update Shared Data', async () => {
     ).toBeInTheDocument()
   );
 
-  const name = within(items[3]).getByRole('textbox', {
+  let name = within(items[3]).getByRole('textbox', {
     name: 'Update name',
   });
   fireEvent.change(name, { target: { value: 'Data Entry 3 updated' } });
@@ -314,11 +314,45 @@ test('LandscapeView: Update Shared Data', async () => {
       })
     )
   );
-  const saveCall = terrasoApi.requestGraphQL.mock.calls[2];
+  let saveCall = terrasoApi.requestGraphQL.mock.calls[2];
 
   expect(saveCall[1].input).toEqual({
     id: 'de-3',
     name: 'Data Entry 3 updated',
+    description: 'Description 3',
+  });
+
+  // Rename a second time to ensure state is reset
+  nameField = within(items[3]).getByRole('button', {
+    name: 'Data Entry 3 updated',
+  });
+  expect(nameField).toBeInTheDocument();
+  await act(async () => fireEvent.click(nameField));
+
+  await waitFor(() =>
+    expect(
+      within(items[3]).getByRole('textbox', {
+        name: 'Update name',
+      })
+    ).toBeInTheDocument()
+  );
+
+  name = within(items[3]).getByRole('textbox', {
+    name: 'Update name',
+  });
+  fireEvent.change(name, { target: { value: 'Data Entry 3 revised' } });
+  await act(async () =>
+    fireEvent.click(
+      within(items[3]).getByRole('button', {
+        name: 'Save',
+      })
+    )
+  );
+  saveCall = terrasoApi.requestGraphQL.mock.calls[2];
+
+  expect(saveCall[1].input).toEqual({
+    id: 'de-3',
+    name: 'Data Entry 3 revised',
     description: 'Description 3',
   });
 });

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -82,7 +82,7 @@ const SharedDataEntryBase = props => {
           },
         });
       }
-      dispatch(resetProcessing(dataEntry.id));
+      dispatch(resetProcessing(sharedResource.id));
     });
   }, [
     dataEntry,
@@ -112,7 +112,7 @@ const SharedDataEntryBase = props => {
             props: { [entityType]: owner.slug },
           });
         }
-        dispatch(resetProcessing(dataEntry.id));
+        dispatch(resetProcessing(sharedResource.id));
       });
     },
     [
@@ -146,7 +146,7 @@ const SharedDataEntryBase = props => {
             props: { [entityType]: owner.slug },
           });
         }
-        dispatch(resetProcessing(dataEntry.id));
+        dispatch(resetProcessing(sharedResource.id));
         return data;
       });
     },

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -150,7 +150,7 @@ const SharedDataEntryBase = props => {
         return data;
       });
     },
-    [dataEntry, dispatch, owner.slug, trackEvent, updateOwner, entityType]
+    [dispatch, owner.slug, trackEvent, updateOwner, entityType]
   );
 
   const description = useMemo(


### PR DESCRIPTION
## Description
Corrects the UUID used in resetProcessing to match the UUID used to set processing. Allows a file to be renamed twice.

### Checklist
- [X] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #1661.