### PR TITLE
fix: Fix order of shared file info from incorrect merge

### DIFF
--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -226,7 +226,7 @@ const SharedDataEntryBase = props => {
         </Grid>
         <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
-        <Grid item xs={11} md={3} order={{ xs: 8, md: 4 }}>
+        <Grid item xs={11} md={3} order={{ xs: 8, md: 6 }}>
           {t('sharedData.file_date_and_author', {
             date: formatDate(i18n.resolvedLanguage, dataEntry.createdAt),
             user: dataEntry.createdBy,


### PR DESCRIPTION
I incorrectly resolved a merge conflict in https://github.com/techmatters/terraso-web-client/pull/1665.
For a minute the order of shared file info was (incorrectly): file type, then date and user, then file size. 
This change returns the order to: file type, then file size, then date and user. 

- [x] Verified on desktop


