### PR TITLE
fix: Display the domain url for links that was previously missing

### DIFF
--- a/src/landscape/components/LandscapeView.test.js
+++ b/src/landscape/components/LandscapeView.test.js
@@ -109,6 +109,7 @@ const baseViewTest = async (
       })),
   };
 
+  // Add files to the shared resources
   const sharedResources = {
     edges: Array(6)
       .fill(0)
@@ -129,6 +130,25 @@ const baseViewTest = async (
         },
       })),
   };
+  // Add a link to the shared resources
+  let index = 6;
+  sharedResources.edges.push({
+    node: {
+      id: `sr-${index}`,
+      source: {
+        id: `de-${index}`,
+        createdAt: '2023-05-20T16:25:21.536679+00:00',
+        name: `Data Entry ${index}`,
+        createdBy: { id: 'user-id', firstName: 'First', lastName: 'Last' },
+        description: `Description ${index}`,
+        size: null,
+        entryType: 'LINK',
+        resourceType: 'link',
+        url: `https://www.link-${index}.com`,
+        visualizations: { edges: [] },
+      },
+    },
+  });
 
   when(terrasoApi.requestGraphQL)
     .calledWith(
@@ -218,10 +238,22 @@ test('LandscapeView: Display data', async () => {
   ).toBeInTheDocument();
   const entriesList = within(sharedDataRegion.getByRole('list'));
   const items = entriesList.getAllByRole('listitem');
-  expect(items.length).toBe(6);
-  const firstEntry = within(items[0]);
-  expect(firstEntry.getByText('Data Entry 0')).toBeInTheDocument();
-  expect(firstEntry.getByText('txt')).toBeInTheDocument();
+  expect(items.length).toBe(7);
+  const fileEntry = within(items[0]);
+  expect(fileEntry.getByText('Data Entry 0')).toBeInTheDocument();
+  expect(fileEntry.getByText('txt')).toBeInTheDocument();
+  expect(fileEntry.getByText('3 kB')).toBeInTheDocument();
+  expect(
+    fileEntry.getByText('May 20, 2022, by First Last')
+  ).toBeInTheDocument();
+  expect(fileEntry.getByText('Description 0')).toBeInTheDocument();
+  const linkEntry = within(items[6]);
+  expect(linkEntry.getByText('Data Entry 6')).toBeInTheDocument();
+  expect(linkEntry.getByText('www.link-6.com')).toBeInTheDocument();
+  expect(
+    linkEntry.getByText('May 20, 2023, by First Last')
+  ).toBeInTheDocument();
+  expect(linkEntry.getByText('Description 6')).toBeInTheDocument();
 
   // Boundary
   expect(

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -54,9 +54,10 @@ const SharedDataEntryBase = props => {
     EntryTypeIcon,
     DownloadComponent,
     ShareComponent,
-    fileSize,
-    resourceType,
-    domain,
+    InfoComponent,
+    //fileSize, //TODO-cknipe: REMOVE
+    //fileType,
+    //linkDomain,
   } = props;
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -163,44 +164,45 @@ const SharedDataEntryBase = props => {
     [dataEntry, owner]
   );
 
-  const LinkInfo = ({ domain }) => {
-    return (
-      <Grid
-        item
-        xs={4}
-        md={2}
-        order={{ xs: 5, md: 4 }}
-        sx={{ wordWrap: 'break-word' }}
-      >
-        {domain}
-      </Grid>
-    );
-  };
+  // const LinkInfo = ({ linkDomain }) => {
+  //   return (
+  //     <Grid
+  //       item
+  //       xs={4}
+  //       md={2}
+  //       order={{ xs: 5, md: 4 }}
+  //       sx={{ wordWrap: 'break-word' }}
+  //     >
+  //       {linkDomain}
+  //     </Grid>
+  //   );
+  // };
 
-  const FileInfo = ({ fileSize, resourceType }) => {
-    return (
-      <>
-        <Grid
-          item
-          xs={2}
-          md={1}
-          order={{ xs: 5, md: 4 }}
-          sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
-        >
-          {resourceType}
-        </Grid>
-        <Grid
-          item
-          xs={2}
-          md={1}
-          order={{ xs: 6, md: 5 }}
-          sx={{ wordWrap: 'break-word' }}
-        >
-          {fileSize}
-        </Grid>
-      </>
-    );
-  };
+  // TODO-cknipe: Remove
+  // const FileInfo = ({ fileSize, fileType }) => {
+  //   return (
+  //     <>
+  //       <Grid
+  //         item
+  //         xs={2}
+  //         md={1}
+  //         order={{ xs: 5, md: 4 }}
+  //         sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
+  //       >
+  //         {fileType}
+  //       </Grid>
+  //       <Grid
+  //         item
+  //         xs={2}
+  //         md={1}
+  //         order={{ xs: 6, md: 5 }}
+  //         sx={{ wordWrap: 'break-word' }}
+  //       >
+  //         {fileSize}
+  //       </Grid>
+  //     </>
+  //   );
+  // };
 
   return (
     <ListItem sx={{ p: 0, flexDirection: 'column' }}>
@@ -252,11 +254,7 @@ const SharedDataEntryBase = props => {
         </Grid>
 
         <Grid item xs={1} order={{ xs: 4 }} display={{ md: 'none' }} />
-        {dataEntry.entryType === 'LINK' ? (
-          <LinkInfo domain={domain} />
-        ) : (
-          <FileInfo fileSize={fileSize} resourceType={resourceType} />
-        )}
+        {InfoComponent && <InfoComponent sharedResource={sharedResource} />}
 
         <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -55,9 +55,6 @@ const SharedDataEntryBase = props => {
     DownloadComponent,
     ShareComponent,
     InfoComponent,
-    //fileSize, //TODO-cknipe: REMOVE
-    //fileType,
-    //linkDomain,
   } = props;
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -163,46 +160,6 @@ const SharedDataEntryBase = props => {
     () => ({ owner, dataEntry }),
     [dataEntry, owner]
   );
-
-  // const LinkInfo = ({ linkDomain }) => {
-  //   return (
-  //     <Grid
-  //       item
-  //       xs={4}
-  //       md={2}
-  //       order={{ xs: 5, md: 4 }}
-  //       sx={{ wordWrap: 'break-word' }}
-  //     >
-  //       {linkDomain}
-  //     </Grid>
-  //   );
-  // };
-
-  // TODO-cknipe: Remove
-  // const FileInfo = ({ fileSize, fileType }) => {
-  //   return (
-  //     <>
-  //       <Grid
-  //         item
-  //         xs={2}
-  //         md={1}
-  //         order={{ xs: 5, md: 4 }}
-  //         sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
-  //       >
-  //         {fileType}
-  //       </Grid>
-  //       <Grid
-  //         item
-  //         xs={2}
-  //         md={1}
-  //         order={{ xs: 6, md: 5 }}
-  //         sx={{ wordWrap: 'break-word' }}
-  //       >
-  //         {fileSize}
-  //       </Grid>
-  //     </>
-  //   );
-  // };
 
   return (
     <ListItem sx={{ p: 0, flexDirection: 'column' }}>

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -56,6 +56,7 @@ const SharedDataEntryBase = props => {
     ShareComponent,
     fileSize,
     resourceType,
+    domain,
   } = props;
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -162,6 +163,45 @@ const SharedDataEntryBase = props => {
     [dataEntry, owner]
   );
 
+  const LinkInfo = ({ domain }) => {
+    return (
+      <Grid
+        item
+        xs={4}
+        md={2}
+        order={{ xs: 5, md: 4 }}
+        sx={{ wordWrap: 'break-word' }}
+      >
+        {domain}
+      </Grid>
+    );
+  };
+
+  const FileInfo = ({ fileSize, resourceType }) => {
+    return (
+      <>
+        <Grid
+          item
+          xs={2}
+          md={1}
+          order={{ xs: 5, md: 4 }}
+          sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
+        >
+          {resourceType}
+        </Grid>
+        <Grid
+          item
+          xs={2}
+          md={1}
+          order={{ xs: 6, md: 5 }}
+          sx={{ wordWrap: 'break-word' }}
+        >
+          {fileSize}
+        </Grid>
+      </>
+    );
+  };
+
   return (
     <ListItem sx={{ p: 0, flexDirection: 'column' }}>
       <Grid
@@ -212,24 +252,12 @@ const SharedDataEntryBase = props => {
         </Grid>
 
         <Grid item xs={1} order={{ xs: 4 }} display={{ md: 'none' }} />
-        <Grid
-          item
-          xs={2}
-          md={1}
-          order={{ xs: 5, md: 4 }}
-          sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
-        >
-          {resourceType}
-        </Grid>
-        <Grid
-          item
-          xs={2}
-          md={1}
-          order={{ xs: 6, md: 5 }}
-          sx={{ wordWrap: 'break-word' }}
-        >
-          {fileSize}
-        </Grid>
+        {dataEntry.entryType === 'LINK' ? (
+          <LinkInfo domain={domain} />
+        ) : (
+          <FileInfo fileSize={fileSize} resourceType={resourceType} />
+        )}
+
         <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={11} md={3} order={{ xs: 8, md: 6 }}>

--- a/src/sharedData/components/SharedDataEntryBase.js
+++ b/src/sharedData/components/SharedDataEntryBase.js
@@ -254,9 +254,18 @@ const SharedDataEntryBase = props => {
         </Grid>
 
         <Grid item xs={1} order={{ xs: 4 }} display={{ md: 'none' }} />
-        {InfoComponent && <InfoComponent sharedResource={sharedResource} />}
+        <Grid
+          item
+          xs={9}
+          md={2}
+          order={{ xs: 5, md: 4 }}
+          component={StackRow}
+          justifyContent="space-between"
+        >
+          {InfoComponent && <InfoComponent sharedResource={sharedResource} />}
+        </Grid>
+        <Grid item xs={2} order={{ xs: 6 }} display={{ md: 'none' }} />
 
-        <Grid item xs={7} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={1} order={{ xs: 7 }} display={{ md: 'none' }} />
         <Grid item xs={11} md={3} order={{ xs: 8, md: 6 }}>
           {t('sharedData.file_date_and_author', {

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -66,7 +66,7 @@ const InfoComponent = ({ sharedResource }) => {
   const fileSize = filesize(sharedResource.dataEntry.size, { round: 0 });
   const fileType = sharedResource.dataEntry.resourceType;
   return (
-    <Grid container>
+    <>
       <Grid
         item
         xs={3}
@@ -79,7 +79,7 @@ const InfoComponent = ({ sharedResource }) => {
         {fileSize}
       </Grid>
       <Grid item xs={1} display={{ md: 'none' }} />
-    </Grid>
+    </>
   );
 };
 

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -395,10 +395,6 @@ const SharedDataEntryFile = props => {
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
       InfoComponent={InfoComponent}
-      // TODO-cknipe: Remove
-      //fileSize: filesize(sharedResource.dataEntry.size, { round: 0 }),
-      //fileType: sharedResource.dataEntry.fileType,
-      //}}
     >
       <Visualizations file={sharedResource.dataEntry} />
     </SharedDataEntryBase>

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -66,26 +66,20 @@ const InfoComponent = ({ sharedResource }) => {
   const fileSize = filesize(sharedResource.dataEntry.size, { round: 0 });
   const fileType = sharedResource.dataEntry.resourceType;
   return (
-    <>
+    <Grid container>
       <Grid
         item
-        xs={2}
-        md={1}
-        order={{ xs: 5, md: 4 }}
+        xs={3}
+        md={6}
         sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
       >
         {fileType}
       </Grid>
-      <Grid
-        item
-        xs={2}
-        md={1}
-        order={{ xs: 6, md: 5 }}
-        sx={{ wordWrap: 'break-word' }}
-      >
+      <Grid item xs={8} md={6} sx={{ wordWrap: 'break-word' }}>
         {fileSize}
       </Grid>
-    </>
+      <Grid item xs={1} display={{ md: 'none' }} />
+    </Grid>
   );
 };
 

--- a/src/sharedData/components/SharedDataEntryFile.js
+++ b/src/sharedData/components/SharedDataEntryFile.js
@@ -62,6 +62,33 @@ const StackRow = props => (
   <Stack direction="row" alignItems="center" spacing={1} {...props} />
 );
 
+const InfoComponent = ({ sharedResource }) => {
+  const fileSize = filesize(sharedResource.dataEntry.size, { round: 0 });
+  const fileType = sharedResource.dataEntry.resourceType;
+  return (
+    <>
+      <Grid
+        item
+        xs={2}
+        md={1}
+        order={{ xs: 5, md: 4 }}
+        sx={{ wordWrap: 'break-word', textTransform: 'uppercase' }}
+      >
+        {fileType}
+      </Grid>
+      <Grid
+        item
+        xs={2}
+        md={1}
+        order={{ xs: 6, md: 5 }}
+        sx={{ wordWrap: 'break-word' }}
+      >
+        {fileSize}
+      </Grid>
+    </>
+  );
+};
+
 const Visualizations = props => {
   const { baseOwnerUrl } = useCollaborationContext();
   const { i18n, t } = useTranslation();
@@ -373,8 +400,11 @@ const SharedDataEntryFile = props => {
       )}
       DownloadComponent={DownloadComponent}
       ShareComponent={ShareComponent}
-      fileSize={filesize(sharedResource.dataEntry.size, { round: 0 })}
-      resourceType={sharedResource.dataEntry.resourceType}
+      InfoComponent={InfoComponent}
+      // TODO-cknipe: Remove
+      //fileSize: filesize(sharedResource.dataEntry.size, { round: 0 }),
+      //fileType: sharedResource.dataEntry.fileType,
+      //}}
     >
       <Visualizations file={sharedResource.dataEntry} />
     </SharedDataEntryBase>

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -17,7 +17,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { IconButton } from '@mui/material';
+import { Grid, IconButton } from '@mui/material';
 
 import { useCollaborationContext } from 'collaboration/collaborationContext';
 import ExternalLink from 'common/components/ExternalLink';
@@ -60,9 +60,8 @@ const DownloadComponent = props => {
   );
 };
 
-const SharedDataEntryLink = props => {
-  const { t } = useTranslation();
-  const { sharedResource } = props;
+// TODO-cknipe: Move this and finsih
+const InfoComponent = ({ sharedResource }) => {
   const dataEntry = useMemo(
     () => sharedResource.dataEntry,
     [sharedResource.dataEntry]
@@ -72,6 +71,33 @@ const SharedDataEntryLink = props => {
     const url = new URL(dataEntry.url);
     return url.hostname;
   }, [dataEntry.url]);
+
+  return (
+    <Grid
+      item
+      xs={4}
+      md={2}
+      order={{ xs: 5, md: 4 }}
+      sx={{ wordWrap: 'break-word' }}
+    >
+      {domain}
+    </Grid>
+  );
+};
+
+const SharedDataEntryLink = props => {
+  const { t } = useTranslation();
+  const { sharedResource } = props;
+  // TODO-cknipe: Think move this up to InfoComponent?
+  // const dataEntry = useMemo(
+  //   () => sharedResource.dataEntry,
+  //   [sharedResource.dataEntry]
+  // );
+
+  // const domain = useMemo(() => {
+  //   const url = new URL(dataEntry.url);
+  //   return url.hostname;
+  // }, [dataEntry.url]);
 
   return (
     <SharedDataEntryBase
@@ -87,8 +113,8 @@ const SharedDataEntryLink = props => {
           }}
         />
       )}
+      InfoComponent={InfoComponent}
       DownloadComponent={DownloadComponent}
-      domain={domain}
     />
   );
 };

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -73,13 +73,7 @@ const InfoComponent = ({ sharedResource }) => {
   }, [dataEntry.url]);
 
   return (
-    <Grid
-      item
-      xs={4}
-      md={2}
-      order={{ xs: 5, md: 4 }}
-      sx={{ wordWrap: 'break-word' }}
-    >
+    <Grid item xs={12} md={12} sx={{ wordWrap: 'break-word' }}>
       {domain}
     </Grid>
   );

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -60,7 +60,6 @@ const DownloadComponent = props => {
   );
 };
 
-// TODO-cknipe: Move this and finsih
 const InfoComponent = ({ sharedResource }) => {
   const dataEntry = useMemo(
     () => sharedResource.dataEntry,
@@ -82,16 +81,6 @@ const InfoComponent = ({ sharedResource }) => {
 const SharedDataEntryLink = props => {
   const { t } = useTranslation();
   const { sharedResource } = props;
-  // TODO-cknipe: Think move this up to InfoComponent?
-  // const dataEntry = useMemo(
-  //   () => sharedResource.dataEntry,
-  //   [sharedResource.dataEntry]
-  // );
-
-  // const domain = useMemo(() => {
-  //   const url = new URL(dataEntry.url);
-  //   return url.hostname;
-  // }, [dataEntry.url]);
 
   return (
     <SharedDataEntryBase

--- a/src/sharedData/components/SharedDataEntryLink.js
+++ b/src/sharedData/components/SharedDataEntryLink.js
@@ -88,7 +88,7 @@ const SharedDataEntryLink = props => {
         />
       )}
       DownloadComponent={DownloadComponent}
-      info={domain}
+      domain={domain}
     />
   );
 };


### PR DESCRIPTION
## Description
Displaying the domain was tied to the `info` prop. The bug was caused when I removed/renamed `info`, such that it then only applied to files, and failed to pass the domain info through for links. 
The `info` concept is now replaced by `InfoComponent` -- whose implementation will differ for files and links, as they will show different info with different layouts.

### Checklist
- [x] New tests added
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes #1690 
(which was caused by #1660)

### Verification steps
See #1690 
