### PR TITLE
fix: show files on join group

### DIFF
--- a/src/group/groupSlice.ts
+++ b/src/group/groupSlice.ts
@@ -95,7 +95,11 @@ export const leaveGroup = createAsyncThunk(
 );
 export const joinGroup = createAsyncThunk(
   'group/joinGroup',
-  groupService.joinGroup
+  async ({ groupSlug }: any, user, { dispatch }) => {
+    const group = await groupService.joinGroup({ groupSlug }, user);
+    dispatch(setSharedResourcesList(group.sharedResources));
+    return group;
+  }
 );
 export const leaveGroupFromList = createAsyncThunk(
   'group/leaveGroupFromList',

--- a/src/group/groupSlice.ts
+++ b/src/group/groupSlice.ts
@@ -95,7 +95,7 @@ export const leaveGroup = createAsyncThunk(
 );
 export const joinGroup = createAsyncThunk(
   'group/joinGroup',
-  async ({ groupSlug }: any, user, { dispatch }) => {
+  async ({ groupSlug }: { groupSlug: string }, user, { dispatch }) => {
     const group = await groupService.joinGroup({ groupSlug }, user);
     dispatch(setSharedResourcesList(group.sharedResources));
     return group;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Show shared data after join group

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/1599

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

https://github.com/user-attachments/assets/4dfd6461-9171-46b6-97f3-509407af1720


