### PR TITLE
fix: Filter layers that used on the current transition

### DIFF
--- a/src/storyMap/components/StoryMap.js
+++ b/src/storyMap/components/StoryMap.js
@@ -207,14 +207,16 @@ const getTransition = ({ config, id, direction }) => {
     return {
       transition: config.titleTransition,
       index: -1,
+      nextTransition: _.get('chapters[0]', config),
     };
   }
   const chapterIndex = config.chapters.findIndex(chapter => chapter.id === id);
   const chapter = config.chapters[chapterIndex];
-  const next =
-    direction === 'up'
-      ? _.get(`chapters[${chapterIndex - 1}]`, config)
-      : _.get(`chapters[${chapterIndex + 1}]`, config);
+  const nextIndex = direction === 'up' ? chapterIndex - 1 : chapterIndex + 1;
+  const nextIsTitle = nextIndex === -1;
+  const next = nextIsTitle
+    ? config.titleTransition
+    : _.get(`chapters[${nextIndex}]`, config);
   return {
     transition: chapter,
     nextTransition: next,


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
On chapter exit transition filter layers that are used on the current transition

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/2371


