### PR TITLE
feat: add TOS to footer and login screen

### DIFF
--- a/src/account/components/AccountLogin.js
+++ b/src/account/components/AccountLogin.js
@@ -143,6 +143,7 @@ const AccountForm = () => {
           <Trans i18nKey="account.disclaimer">
             prefix
             <ExternalLink href={t('account.disclaimer_url')}>text</ExternalLink>
+            <ExternalLink href={t('footer.links.tos.url')}>text</ExternalLink>
           </Trans>
         </Typography>
 

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -197,7 +197,7 @@
     },
     "account": {
         "profile": "Account Profile",
-        "disclaimer": "If you don’t already have a Terraso account, signing in will create one in accordance with our <1>privacy policy</1>.",
+        "disclaimer": "If you don’t already have a Terraso account, signing in will create one in accordance with our <1>privacy policy</1> and <2>terms of service</2>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",
         "unauthenticated_message": "Your Terraso session has expired. Please log in again.",
         "form_first_name_label_singular": "Given name",

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -241,6 +241,10 @@
                 "text": "Privacy Policy",
                 "url": "https://techmatters.org/privacy-policy/"
             },
+            "tos": {
+                "text": "Terms of Service",
+                "url": "https://terraso.org/terms-of-service/"
+            },
             "data": { "text": "Data Policy", "url": "#" },
             "about": { "text": "About Terraso", "url": "https://terraso.org/" }
         }

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -197,7 +197,7 @@
     },
     "account": {
         "profile": "Perfil de cuenta",
-        "disclaimer": "Si aún no tiene una cuenta de Terraso, al iniciar sesión se creará una de acuerdo con nuestros <1>política de privacidad</1>.",
+        "disclaimer": "Si aún no tiene una cuenta de Terraso, al iniciar sesión se creará una de acuerdo con nuestros <1>política de privacidad</1> y <2>termos de serviço</2>.",
         "disclaimer_url": "https://techmatters.org/privacy-policy/",
         "unauthenticated_message": "Su sesión de Terraso ha caducado. Vuelva a iniciar sesión.",
         "form_first_name_label_singular": "Nombre",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -241,6 +241,10 @@
                 "text": "Política de privacidad",
                 "url": "https://techmatters.org/privacy-policy/"
             },
+            "tos": {
+                "text": "Termos de Serviço",
+                "url": "https://terraso.org/terms-of-service/"
+            },
             "data": { "text": "Política de datos", "url": "#" },
             "about": {
                 "text": "Acerca de Terraso",


### PR DESCRIPTION
## Description
Add Terms of Service to the Terraso web app footer and login screen..

### Checklist
- [X] Corresponding issue has been opened
- [X] English strings reviewed and copyedited
- [X] Strings are localized
- [X] Verified on mobile
- [X] Verified on desktop


## Related issues
Fixes https://github.com/techmatters/terraso-web-client/issues/2518.