### PR TITLE
experiment: add `/embed` to the end of a story map edit URL to get a cleaner view [render preview]

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import { Box } from '@mui/material';
 import AppBar from 'layout/AppBar';
 import Footer from 'layout/Footer';
 import Navigation from 'navigation/components/Navigation';
-import Routes, { useOptionalAuth } from 'navigation/components/Routes';
+import Routes, { usePathParams } from 'navigation/components/Routes';
 
 import 'index.css';
 
@@ -32,9 +32,9 @@ import OptionalAuthTopMessage from 'account/components/OptionalAuthTopMessage';
 const App = () => {
   const contentRef = useRef();
   const navigationRef = useRef();
-  const { isEmbedded } = useOptionalAuth();
+  const { isEmbedded, optionalAuth } = usePathParams();
 
-  if (isEmbedded) {
+  if (isEmbedded || optionalAuth.isEmbedded) {
     return <Routes />;
   }
 

--- a/src/navigation/components/Routes.js
+++ b/src/navigation/components/Routes.js
@@ -205,6 +205,9 @@ const paths = [
   }),
   path('/tools/story-maps/new', StoryMapNew),
   path('/tools/story-maps/:storyMapId/:slug/edit', StoryMapUpdate),
+  path('/tools/story-maps/:storyMapId/:slug/edit/embed', StoryMapUpdate, {
+    isEmbedded: true,
+  }),
   path('/tools/story-maps/:storyMapId/:slug', UserStoryMap, {
     showBreadcrumbs: true,
     breadcrumbsLabel: 'storyMap.breadcrumbs_view',

--- a/src/storyMap/components/StoryMapForm/index.js
+++ b/src/storyMap/components/StoryMapForm/index.js
@@ -157,11 +157,11 @@ const StoryMapForm = props => {
       return;
     }
     const headerHeight =
-      document.getElementById('header-container')?.clientHeight;
+      document.getElementById('header-container')?.clientHeight ?? 0;
     const footerHeight =
-      document.getElementsByClassName('footer')?.[0]?.clientHeight;
+      document.getElementsByClassName('footer')?.[0]?.clientHeight ?? 0;
     const formHeaderHeight =
-      document.getElementById('form-header')?.clientHeight + 1;
+      (document.getElementById('form-header')?.clientHeight ?? 0) + 1;
 
     setMapHeight(
       `calc(100vh - (${headerHeight}px + ${footerHeight}px + ${formHeaderHeight}px))`


### PR DESCRIPTION
## Description
Creates a view for the storymap editor without the rest of the Terraso header/footer.