### PR TITLE
fix: blur any active elements when changing chapter focus

### DIFF
--- a/src/storyMap/components/StoryMapForm/ChaptersSideBar.js
+++ b/src/storyMap/components/StoryMapForm/ChaptersSideBar.js
@@ -69,6 +69,7 @@ const SideBarItem = props => {
   const scrollTo = id => {
     const element = document.getElementById(id);
     element?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    document.activeElement?.blur();
   };
 
   const handleOpenMenuClick = useCallback(event => {


### PR DESCRIPTION
## Description
Fixes bug where chapters couldn't be changed while a text field had focus.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [x] English strings reviewed and copyedited
- [x] Strings are localized
- [x] Images are compressed (TinyPNG or svgo)
- [x] Sample environment file updated (when environment variables changed)
- [x] Verified on mobile
- [x] Verified on desktop
- [x] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues
Fixes #1266
