### PR TITLE
feat: full screen storymaps editor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import { Box } from '@mui/material';
 import AppBar from 'layout/AppBar';
 import Footer from 'layout/Footer';
 import Navigation from 'navigation/components/Navigation';
-import Routes, { useOptionalAuth } from 'navigation/components/Routes';
+import Routes, { usePathParams } from 'navigation/components/Routes';
 
 import 'index.css';
 
@@ -32,9 +32,9 @@ import OptionalAuthTopMessage from 'account/components/OptionalAuthTopMessage';
 const App = () => {
   const contentRef = useRef();
   const navigationRef = useRef();
-  const { isEmbedded } = useOptionalAuth();
+  const { isEmbedded, optionalAuth } = usePathParams();
 
-  if (isEmbedded) {
+  if (isEmbedded || optionalAuth.isEmbedded) {
     return <Routes />;
   }
 

--- a/src/navigation/components/Routes.js
+++ b/src/navigation/components/Routes.js
@@ -205,13 +205,17 @@ const paths = [
     showBreadcrumbs: true,
     breadcrumbsLabel: 'storyMap.breadcrumbs_tool_home',
   }),
-  path('/tools/story-maps/new', StoryMapNew),
+  path('/tools/story-maps/new', StoryMapNew, {
+    isEmbedded: true,
+  }),
   ...[
     '/tools/story-maps/:storyMapId',
     '/tools/story-maps/:storyMapId/',
     '/tools/story-maps/:storyMapId/:slug',
   ].flatMap(basePath => [
-    path(`${basePath}/edit`, StoryMapUpdate),
+    path(`${basePath}/edit`, StoryMapUpdate, {
+      isEmbedded: true,
+    }),
     path(`${basePath}/`, UserStoryMap, {
       showBreadcrumbs: true,
       breadcrumbsLabel: 'storyMap.breadcrumbs_view',

--- a/src/storyMap/components/StoryMapForm/index.js
+++ b/src/storyMap/components/StoryMapForm/index.js
@@ -157,11 +157,11 @@ const StoryMapForm = props => {
       return;
     }
     const headerHeight =
-      document.getElementById('header-container')?.clientHeight;
+      document.getElementById('header-container')?.clientHeight ?? 0;
     const footerHeight =
-      document.getElementsByClassName('footer')?.[0]?.clientHeight;
+      document.getElementsByClassName('footer')?.[0]?.clientHeight ?? 0;
     const formHeaderHeight =
-      document.getElementById('form-header')?.clientHeight + 1;
+      (document.getElementById('form-header')?.clientHeight ?? 0) + 1;
 
     setMapHeight(
       `calc(100vh - (${headerHeight}px + ${footerHeight}px + ${formHeaderHeight}px))`


### PR DESCRIPTION
## Description
Disables the header and footer inside the story maps editor.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [x] English strings reviewed and copyedited
- [x] Strings are localized
- [x] Images are compressed (TinyPNG or svgo)
- [x] Sample environment file updated (when environment variables changed)
- [x] Verified on mobile
- [x] Verified on desktop
- [x] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues


### Verification steps
No header or footer should be visible inside the story maps editor.
