### PR TITLE
fix: use the language "Sign in/out" consistently

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -8,7 +8,7 @@
     },
     "user": {
         "sign_out": "Sign Out",
-        "sign_in": "Log In",
+        "sign_in": "Sign In",
         "account_created_message": "Your Terraso account has been created successfully with the following information. You can edit them any time.",
         "edit_profile_button": "Edit Profile Info",
         "full_name": "{{user.firstName}} {{user.lastName}}"
@@ -212,8 +212,8 @@
         "apple_login": "Sign in with Apple",
         "google_login": "Sign in with Google",
         "microsoft_login": "Sign in with Microsoft",
-        "login_document_title": "Log in",
-        "login_document_description": "Log in to Terraso",
+        "login_document_title": "Sign in",
+        "login_document_description": "Sign in to Terraso",
         "profile_document_title": "Account",
         "profile_document_description": "View and edit your Terraso profile and preferences",
         "profile_form_label": "Manage profile",


### PR DESCRIPTION
## Description
Uses consistent language for "Sign in/out".

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues
Fixes #991 

### Verification steps
All text on site should say "Sign in" or "Sign out"
