### PR TITLE
fix: change LoadingButton to Button

### DIFF
--- a/src/collaboration/components/MemberJoin.js
+++ b/src/collaboration/components/MemberJoin.js
@@ -18,7 +18,7 @@
 import React from 'react';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { LoadingButton } from '@mui/lab';
+import { Button } from '@mui/material';
 
 import { useCollaborationContext } from 'collaboration/collaborationContext';
 
@@ -28,7 +28,7 @@ const MemberJoin = props => {
   const { ariaLabel, onJoin, buttonProps, loading } = props;
 
   return (
-    <LoadingButton
+    <Button
       variant="outlined"
       aria-label={t(ariaLabel, {
         name: _.get('name', owner),
@@ -39,7 +39,7 @@ const MemberJoin = props => {
       {...buttonProps}
     >
       {t(props.label)}
-    </LoadingButton>
+    </Button>
   );
 };
 

--- a/src/collaboration/components/MembersPage.js
+++ b/src/collaboration/components/MembersPage.js
@@ -19,8 +19,7 @@ import React, { useMemo } from 'react';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { LoadingButton } from '@mui/lab';
-import { ListItem, Stack, Typography } from '@mui/material';
+import { Button, ListItem, Stack, Typography } from '@mui/material';
 
 import { withProps } from 'react-hoc';
 
@@ -137,13 +136,13 @@ const PendingApprovals = props => {
             aria-label={t('user.full_name', { user: membership.user })}
             secondaryAction={
               <Stack spacing={2} direction="row">
-                <LoadingButton
+                <Button
                   variant="contained"
                   loading={membership.fetching}
                   onClick={() => onMemberApprove(membership)}
                 >
                   {t('collaboration.members_list_pending_approve')}
-                </LoadingButton>
+                </Button>
                 <ConfirmButton
                   onConfirm={() => onMemberRemove(membership)}
                   confirmTitle={t(

--- a/src/common/components/ConfirmButton.js
+++ b/src/common/components/ConfirmButton.js
@@ -16,8 +16,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { LoadingButton } from '@mui/lab';
-import { Tooltip } from '@mui/material';
+import { Button, Tooltip } from '@mui/material';
 
 import ConfirmationDialog from 'common/components/ConfirmationDialog';
 
@@ -65,7 +64,7 @@ const ConfirmButton = props => {
         loading={loading}
       />
       <TooltipWrapper>
-        <LoadingButton
+        <Button
           onClick={onClick}
           loading={loading}
           variant={variant || 'outlined'}
@@ -73,7 +72,7 @@ const ConfirmButton = props => {
           {...(buttonProps || {})}
         >
           {buttonLabel || props.children}
-        </LoadingButton>
+        </Button>
       </TooltipWrapper>
     </>
   );

--- a/src/common/components/ConfirmationDialog.js
+++ b/src/common/components/ConfirmationDialog.js
@@ -17,7 +17,6 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { LoadingButton } from '@mui/lab';
 import {
   Button,
   Dialog,
@@ -80,13 +79,9 @@ const ConfirmationDialog = props => {
           {t('common.dialog_cancel_label')}
         </Button>
 
-        <LoadingButton
-          variant="contained"
-          onClick={onConfirm}
-          loading={loading}
-        >
+        <Button variant="contained" onClick={onConfirm} loading={loading}>
           {confirmButtonLabel}
-        </LoadingButton>
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/common/components/EditableText.js
+++ b/src/common/components/EditableText.js
@@ -18,7 +18,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import EditIcon from '@mui/icons-material/Edit';
-import { LoadingButton } from '@mui/lab';
 import {
   Button,
   InputLabel,
@@ -123,13 +122,9 @@ const EditableText = props => {
           onKeyDown={onInputKeyDown}
           sx={{ flexGrow: 1 }}
         />
-        <LoadingButton
-          variant="contained"
-          loading={processing}
-          onClick={handleSave}
-        >
+        <Button variant="contained" loading={processing} onClick={handleSave}>
           {t('common.editable_text_save')}
-        </LoadingButton>
+        </Button>
         <Button disabled={processing} onClick={reset}>
           {t('common.editable_text_cancel')}
         </Button>

--- a/src/group/membership/components/GroupMemberJoin.js
+++ b/src/group/membership/components/GroupMemberJoin.js
@@ -18,7 +18,7 @@
 import React from 'react';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
-import { LoadingButton } from '@mui/lab';
+import { Button } from '@mui/material';
 
 import { useCollaborationContext } from 'collaboration/collaborationContext';
 
@@ -28,7 +28,7 @@ const GroupMemberJoin = props => {
   const { ariaLabel, onJoin, buttonProps, loading } = props;
 
   return (
-    <LoadingButton
+    <Button
       variant="outlined"
       aria-label={t(ariaLabel, {
         name: _.get('name', owner),
@@ -39,7 +39,7 @@ const GroupMemberJoin = props => {
       {...buttonProps}
     >
       {t(props.label)}
-    </LoadingButton>
+    </Button>
   );
 };
 

--- a/src/sharedData/components/SharedDataUpload/index.js
+++ b/src/sharedData/components/SharedDataUpload/index.js
@@ -20,7 +20,7 @@ import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import ErrorIcon from '@mui/icons-material/Report';
-import { LoadingButton, TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Button, Paper, Stack, Tab, Typography } from '@mui/material';
 
 import { useCollaborationContext } from 'collaboration/collaborationContext';
@@ -237,7 +237,7 @@ const SharedDataUpload = props => {
         </Typography>
       )}
       <Stack direction="row" spacing={2} sx={{ marginTop: 3 }}>
-        <LoadingButton
+        <Button
           variant="contained"
           disabled={isSaveDisabled}
           loading={isUploading}
@@ -245,7 +245,7 @@ const SharedDataUpload = props => {
           sx={{ paddingLeft: 5, paddingRight: 5 }}
         >
           {t('sharedData.upload_save')}
-        </LoadingButton>
+        </Button>
         <Button variant="text" onClick={onCancel}>
           {t('sharedData.upload_cancel')}
         </Button>

--- a/src/storyMap/components/StoryMapForm/ShareDialog.js
+++ b/src/storyMap/components/StoryMapForm/ShareDialog.js
@@ -21,7 +21,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { useDispatch, useSelector } from 'terrasoApi/store';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { LoadingButton } from '@mui/lab';
 import {
   Accordion,
   AccordionDetails,
@@ -309,14 +308,14 @@ const ShareDialog = props => {
           {t('storyMap.share_dialog_cancel_label')}
         </Button>
 
-        <LoadingButton
+        <Button
           variant="contained"
           onClick={onConfirm}
           loading={processing}
           disabled={_.isEmpty(newEditors)}
         >
           {t('storyMap.share_dialog_confirm_label')}
-        </LoadingButton>
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/storyMap/components/StoryMapsCard.js
+++ b/src/storyMap/components/StoryMapsCard.js
@@ -22,10 +22,10 @@ import { useNavigate } from 'react-router';
 import { useDispatch, useSelector } from 'terrasoApi/store';
 import DeleteIcon from '@mui/icons-material/Delete';
 import PeopleIcon from '@mui/icons-material/People';
-import { LoadingButton } from '@mui/lab';
 import {
   List as BaseList,
   Box,
+  Button,
   Chip,
   Divider,
   Grid,
@@ -210,7 +210,7 @@ const StoryMapListItem = props => {
       >
         <Grid size={{ xs: 6 }}>
           {isStoryMapMembershipPending ? (
-            <LoadingButton
+            <Button
               size="small"
               variant="outlined"
               sx={{ pr: 3, pl: 3 }}
@@ -218,7 +218,7 @@ const StoryMapListItem = props => {
               loading={processing}
             >
               {t('storyMap.home_accept')}
-            </LoadingButton>
+            </Button>
           ) : (
             <RouterButton
               to={generateStoryMapEditUrl(storyMap)}


### PR DESCRIPTION
## Description
Change MUI Lab LoadingButton to MUI Button

Fixes this warning:
      MUI: The LoadingButton component functionality is now part of the Button component from Material UI.

      You should use `import Button from '@mui/material/Button'`
      or `import { Button } from '@mui/material'`