### PR TITLE
fix: Allow empty slug if not supported characters

### DIFF
--- a/src/navigation/components/Routes.js
+++ b/src/navigation/components/Routes.js
@@ -206,26 +206,32 @@ const paths = [
     breadcrumbsLabel: 'storyMap.breadcrumbs_tool_home',
   }),
   path('/tools/story-maps/new', StoryMapNew),
-  path('/tools/story-maps/:storyMapId/:slug/edit', StoryMapUpdate),
-  path('/tools/story-maps/:storyMapId/:slug', UserStoryMap, {
-    showBreadcrumbs: true,
-    breadcrumbsLabel: 'storyMap.breadcrumbs_view',
-    breadcrumbsShareProps: {
-      bgColor: 'white',
-      marginTop: 0,
-    },
-    optionalAuth: {
-      enabled: true,
-      topMessage: 'storyMap.optional_auth_top_message',
-      bottomMessage: 'storyMap.optional_auth_bottom_message',
-    },
-  }),
-  path('/tools/story-maps/:storyMapId/:slug/embed', UserStoryMapEmbed, {
-    optionalAuth: {
-      enabled: true,
-      isEmbedded: true,
-    },
-  }),
+  ...[
+    '/tools/story-maps/:storyMapId/:slug',
+    '/tools/story-maps/:storyMapId/',
+    '/tools/story-maps/:storyMapId',
+  ].flatMap(basePath => [
+    path(`${basePath}/edit`, StoryMapUpdate),
+    path(`${basePath}/`, UserStoryMap, {
+      showBreadcrumbs: true,
+      breadcrumbsLabel: 'storyMap.breadcrumbs_view',
+      breadcrumbsShareProps: {
+        bgColor: 'white',
+        marginTop: 0,
+      },
+      optionalAuth: {
+        enabled: true,
+        topMessage: 'storyMap.optional_auth_top_message',
+        bottomMessage: 'storyMap.optional_auth_bottom_message',
+      },
+    }),
+    path(`${basePath}/embed`, UserStoryMapEmbed, {
+      optionalAuth: {
+        enabled: true,
+        isEmbedded: true,
+      },
+    }),
+  ]),
   path('/tools/story-maps/accept', StoryMapInvite),
   path('*', NotFound),
 ];

--- a/src/storyMap/storyMapService.js
+++ b/src/storyMap/storyMapService.js
@@ -67,7 +67,7 @@ export const fetchSamples = (params, currentUser) => {
 
 export const fetchStoryMap = ({ slug, storyMapId }) => {
   const query = graphql(`
-    query fetchStoryMap($slug: String!, $storyMapId: String!) {
+    query fetchStoryMap($slug: String, $storyMapId: String!) {
       storyMaps(slug: $slug, storyMapId: $storyMapId) {
         edges {
           node {
@@ -97,7 +97,7 @@ export const fetchStoryMap = ({ slug, storyMapId }) => {
 
 export const fetchStoryMapForm = ({ slug, storyMapId }) => {
   const query = graphql(`
-    query fetchStoryMapForm($slug: String!, $storyMapId: String!) {
+    query fetchStoryMapForm($slug: String, $storyMapId: String!) {
       storyMaps(slug: $slug, storyMapId: $storyMapId) {
         edges {
           node {


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
For special character title to unblock the user we can use an empty slug

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added


### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/2783

