### PR TITLE
fix: Fixed data grid sort model changes tracking

### DIFF
--- a/src/common/components/Table.js
+++ b/src/common/components/Table.js
@@ -148,9 +148,15 @@ const Table = props => {
   } = props;
 
   useEffect(() => {
-    const sort = searchParams?.sort;
-    setSortModel(sort ? parseSortQuery(sort) : props.initialSort);
-  }, [props.initialSort, searchParams]);
+    const sort = searchParams?.sort
+      ? parseSortQuery(searchParams?.sort)
+      : props.initialSort;
+
+    if (_.isEqual(sortModel, sort)) {
+      return;
+    }
+    setSortModel(sort);
+  }, [props.initialSort, searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const pageValue = searchParams?.page;
@@ -173,6 +179,10 @@ const Table = props => {
       const sort = model
         .map(column => `${SORT_DIRECTION_BY_WORD[column.sort]}${column.field}`)
         .join(',');
+
+      if (_.isEqual(sort, searchParams?.sort)) {
+        return;
+      }
       onSearchParamsChange?.({
         ...searchParams,
         sort,

--- a/src/group/components/GroupList.test.js
+++ b/src/group/components/GroupList.test.js
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { act, fireEvent, render, screen, within } from 'tests/utils';
+import { act, fireEvent, render, screen, waitFor, within } from 'tests/utils';
 import React from 'react';
 import { useSearchParams } from 'react-router';
 import * as terrasoApi from 'terraso-client-shared/terrasoApi/api';
@@ -150,12 +150,12 @@ test('GroupList: Display list', async () => {
   expect(
     within(rows[2])
       .getByRole('button', { name: 'Join: Group name 1' })
-      .closest('[role="gridcell"]')
+      .closest('[role="gridcell"]') // eslint-disable-line testing-library/no-node-access
   ).toHaveAttribute('data-field', 'actions');
   expect(
     screen
       .getByRole('button', { name: 'Leave: Group name 3' })
-      .closest('[role="gridcell"]')
+      .closest('[role="gridcell"]') // eslint-disable-line testing-library/no-node-access
   ).toHaveAttribute('data-field', 'actions');
 });
 test('GroupList: List sort', async () => {
@@ -335,11 +335,13 @@ test('GroupList: URL params', async () => {
       within(rows[0]).getByRole('columnheader', { name: 'Group' })
     )
   );
-  expect(setParamsMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      page: '1',
-      sort: '-name',
-    })
+  await waitFor(() =>
+    expect(setParamsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: '1',
+        sort: '-name',
+      })
+    )
   );
 
   // Page


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
With a data grid upgrade it seems that the logic to identify sort model changes changed creating a sorting update when the page changes

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added


### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/2786

