### PR TITLE
fix: Set has token to false if failed to fetch user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "slate-hyperscript": "^0.100.0",
         "slate-react": "^0.117.4",
         "source-map-explorer": "^2.5.3",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#2d4b7c8a08ef8fa96e09d2a8a3ef38ec404be58f",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#829d421",
         "use-debounce": "^10.0.5",
         "uuid": "^11.1.0",
         "web-vitals": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "slate-hyperscript": "^0.100.0",
     "slate-react": "^0.117.4",
     "source-map-explorer": "^2.5.3",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#2d4b7c8a08ef8fa96e09d2a8a3ef38ec404be58f",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#829d421",
     "use-debounce": "^10.0.5",
     "uuid": "^11.1.0",
     "web-vitals": "^5.1.0",

--- a/src/account/components/RequireAuth.js
+++ b/src/account/components/RequireAuth.js
@@ -15,17 +15,22 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, useLocation } from 'react-router';
-import { fetchUser } from 'terraso-client-shared/account/accountSlice';
+import {
+  fetchUser,
+  setHasToken,
+} from 'terraso-client-shared/account/accountSlice';
 import { useFetchData } from 'terraso-client-shared/store/utils';
+import { useDispatch } from 'terrasoApi/store';
 
 import PageLoader from 'layout/PageLoader';
 import { generateReferrerUrl } from 'navigation/navigationUtils';
 import { useCompleteProfile } from 'account/accountProfileUtils';
 
 const RequireAuth = ({ children }) => {
+  const dispatch = useDispatch();
   const location = useLocation();
   const { data: user, fetching } = useSelector(
     state => state.account.currentUser
@@ -40,6 +45,12 @@ const RequireAuth = ({ children }) => {
       [hasToken, user]
     )
   );
+
+  useEffect(() => {
+    if (fetching === false && !user) {
+      dispatch(setHasToken(false));
+    }
+  }, [fetching, user, dispatch]);
 
   if (hasToken && fetching) {
     return <PageLoader />;

--- a/src/account/components/RequireAuth.test.js
+++ b/src/account/components/RequireAuth.test.js
@@ -282,3 +282,22 @@ test('Auth: Avoid redirect if profile complete already displayed for user', asyn
 
   expect(navigate).not.toHaveBeenCalled();
 });
+
+test('Auth: Test redirect when fetching is false and no user', async () => {
+  await render(
+    <RequireAuth>
+      <div />
+    </RequireAuth>,
+    {
+      account: {
+        hasToken: true,
+        currentUser: {
+          fetching: false,
+          data: null,
+        },
+      },
+    }
+  );
+
+  expect(screen.getByText('To: /account')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Set hasToken to false if failed to fetch user to avoid re fetching infinite loop

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
