### PR TITLE
fix: story maps breadcrumbs

### DIFF
--- a/src/navigation/components/Breadcrumbs.test.jsx
+++ b/src/navigation/components/Breadcrumbs.test.jsx
@@ -29,7 +29,14 @@ jest.mock('react-router', () => ({
 
 const TestComponent = () => {
   useBreadcrumbsParams(
-    useMemo(() => ({ groupName: 'Group Name', loading: false }), [])
+    useMemo(
+      () => ({
+        groupName: 'Group Name',
+        loading: false,
+        title: 'Story Map Title',
+      }),
+      []
+    )
   );
   return <Breadcrumbs />;
 };
@@ -71,6 +78,35 @@ test('Breadcrumbs: Show items', async () => {
     '/groups/group-1/members'
   );
   expect(screen.getByRole('link', { name: 'Members' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  );
+});
+
+test('Breadcrumbs: Story map only displays once', async () => {
+  useLocation.mockReturnValue({
+    pathname: '/tools/story-maps/5e530dc3/story-map',
+  });
+  await setup();
+  expect(
+    screen.getByRole('navigation', { name: 'Breadcrumbs' })
+  ).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+    'href',
+    '/'
+  );
+  expect(screen.getByRole('link', { name: 'Tools' })).toHaveAttribute(
+    'href',
+    '/tools'
+  );
+  expect(
+    screen.getByRole('link', { name: 'Terraso Story Maps' })
+  ).toHaveAttribute('href', '/tools/story-maps');
+  expect(screen.getByRole('link', { name: 'Story Map Title' })).toHaveAttribute(
+    'href',
+    '/tools/story-maps/5e530dc3/story-map'
+  );
+  expect(screen.getByRole('link', { name: 'Story Map Title' })).toHaveAttribute(
     'aria-current',
     'page'
   );

--- a/src/navigation/components/Routes.jsx
+++ b/src/navigation/components/Routes.jsx
@@ -221,6 +221,7 @@ const paths = [
     path(`${basePath}/`, UserStoryMap, {
       showBreadcrumbs: true,
       breadcrumbsLabel: 'storyMap.breadcrumbs_view',
+      breadcrumbsOnlyIfCurrentPath: !basePath.endsWith(':slug'),
       breadcrumbsShareProps: {
         bgColor: 'white',
         marginTop: 0,
@@ -281,7 +282,11 @@ export const useBreadcrumbs = () => {
           };
         }
         const path = getPath(to);
-        if (!path || !path.breadcrumbsLabel) {
+        if (
+          !path ||
+          !path.breadcrumbsLabel ||
+          path.breadcrumbsOnlyIfCurrentPath
+        ) {
           return null;
         }
 


### PR DESCRIPTION
## Description
Fixes the duplicate story map breadcrumbs issue introduced in https://github.com/techmatters/terraso-web-client/pull/2788.

The issue was that both the story map ID and slug path components had a breadcrumbs label associated. 

The most obvious solution would've been to remove the breadcrumbs label from one of those path segments. We can't remove the breadcrumbs label from the ID segment, or it won't show for story maps with empty slugs (like in the previous bug which prompted the PR that introduced this bug).

We could remove the breadcrumb label it from the slug segment, but then the breadcrumb label from the ID segment wouldn't be recognized as "current". We could handle the "current" issue by doing away with "current" detection and just always consider the last breadcrumb segment "current".

But then there's still an issue where the last breadcrumb segment navigates doesn't navigate to the current path, it navigates to the path without the slug. 

So I introduced a new field for routes: `breadcrumbsOnlyIfCurrentPath`, to filter out the ID part's breadcrumb label only when it's not the current path. It's a bit janky but it works, and could be potentially useful in other scenarios as well. But let me know if there's something less janky I'm missing.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Fixes #2848.

### Verification steps
Navigate to story map view with slug, observe that only one breadcrumb is displayed.

Also confirmed with an automated test that fails before the fix is introduced, and passes afterwards.
