### PR TITLE
feat: area of interest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/lab": "^7.0.1-beta.20",
         "@mui/material": "^7.3.6",
         "@mui/x-data-grid": "^8.23.0",
+        "@placemarkio/geo-viewport": "^1.0.2",
         "@reduxjs/toolkit": "^2.11.2",
         "@sentry/cli": "^3.0.1",
         "@sentry/react": "^10.32.1",
@@ -6715,6 +6716,15 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@placemarkio/geo-viewport": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@placemarkio/geo-viewport/-/geo-viewport-1.0.2.tgz",
+      "integrity": "sha512-GbLO7fcSQvrcL+jBsP5yrphRxSrgVWArxL3OyfbU/S+Ghls7ty+94DYdV+AicZL/2VIalcinOIK8OGEGq37fiA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -7824,12 +7834,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
-      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
+      "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.13.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -17626,6 +17636,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -19995,22 +20021,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map-explorer/node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/source-map-explorer/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -21664,9 +21674,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/lab": "^7.0.1-beta.20",
     "@mui/material": "^7.3.6",
     "@mui/x-data-grid": "^8.23.0",
+    "@placemarkio/geo-viewport": "^1.0.2",
     "@reduxjs/toolkit": "^2.11.2",
     "@sentry/cli": "^3.0.1",
     "@sentry/react": "^10.32.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -208,7 +208,6 @@ export const MAPBOX_LANDSCAPE_DIRECTORY_STYLE =
   import.meta.env.REACT_APP_MAPBOX_LANDSCAPE_DIRECTORY_STYLE ||
   MAPBOX_STYLE_DEFAULT;
 
-export const STORY_MAP_INSET_STYLE = 'mapbox://styles/mapbox/dark-v10';
 export const STORY_MAP_MEDIA_MAX_SIZE = 10000000; // 10 MB
 
 export const STORY_MAP_IMAGE_ACCEPTED_TYPES = {

--- a/src/gis/components/Map.jsx
+++ b/src/gis/components/Map.jsx
@@ -172,6 +172,7 @@ export const MapProvider = props => {
   const language = i18n.language.split('-')[0];
   const { children, onStyleChange } = props;
   const [map, setMap] = useState(null);
+  const [mapDimensions, setMapDimensions] = useState(undefined);
   const [images, setImages] = useState({});
   const [sources, setSources] = useState({});
   const [layers, setLayers] = useState({});
@@ -291,6 +292,8 @@ export const MapProvider = props => {
       value={{
         setMap,
         map,
+        setMapDimensions,
+        mapDimensions,
         changeStyle,
         addImage,
         removeImage,
@@ -328,7 +331,7 @@ const Map = forwardRef((props, ref) => {
     children,
   } = props;
   const { i18n } = useTranslation();
-  const { map, setMap } = useMap();
+  const { map, setMap, setMapDimensions } = useMap();
   const mapContainer = useRef(null);
   const [bounds] = useState(initialBounds);
   const [initialLocation] = useState(propsInitialLocation);
@@ -462,8 +465,14 @@ const Map = forwardRef((props, ref) => {
       return;
     }
 
-    const observer = new ResizeObserver(() => {
+    const observer = new ResizeObserver(([entry]) => {
       map.resize();
+      if (entry.contentBoxSize && entry.contentBoxSize[0]) {
+        setMapDimensions({
+          height: entry.contentBoxSize[0].blockSize,
+          width: entry.contentBoxSize[0].inlineSize,
+        });
+      }
     });
 
     observer.observe(map.getContainer());
@@ -471,7 +480,7 @@ const Map = forwardRef((props, ref) => {
     return () => {
       observer.disconnect();
     };
-  }, [map]);
+  }, [map, setMapDimensions]);
 
   useEffect(() => {
     if (!map) {

--- a/src/gis/components/Map.jsx
+++ b/src/gis/components/Map.jsx
@@ -426,6 +426,8 @@ const Map = forwardRef((props, ref) => {
     map.touchZoomRotate.enableRotation();
     map.dragPan.enable();
     map.dragRotate.enable();
+    map.doubleClickZoom.enable();
+    map.scrollZoom.enable();
 
     if (disableRotation) {
       // disable map rotation using right click + drag
@@ -456,11 +458,7 @@ const Map = forwardRef((props, ref) => {
   }, [map, onBoundsChange]);
 
   useEffect(() => {
-    if (
-      !map ||
-      !mapContainer.current ||
-      typeof ResizeObserver === 'undefined'
-    ) {
+    if (!map || typeof ResizeObserver === 'undefined') {
       return;
     }
 
@@ -468,7 +466,7 @@ const Map = forwardRef((props, ref) => {
       map.resize();
     });
 
-    observer.observe(mapContainer.current);
+    observer.observe(map.getContainer());
 
     return () => {
       observer.disconnect();

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -62,3 +62,10 @@ globalThis.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+globalThis.IntersectionObserver = class IntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/src/sharedData/visualization/components/VisualizationMapLayer.jsx
+++ b/src/sharedData/visualization/components/VisualizationMapLayer.jsx
@@ -28,7 +28,15 @@ import { getLayerImage } from 'terraso-web-client/sharedData/visualization/visua
 
 const DEFAULT_MARKER_OPACITY = 1;
 
-export const LAYER_TYPES = ['markers', 'polygons-outline', 'polygons-fill'];
+export const LAYER_TYPES = {
+  MARKERS: 'markers',
+  POLYGONS_OUTLINE: 'polygons-outline',
+  POLYGONS_FILL: 'polygons-fill',
+};
+
+export const generateLayerId = (layerId, layerType) => {
+  return `${layerId}-${layerType}`;
+};
 
 // Opacity range between 0 - 100
 export const getLayerOpacity = (type, visualizationConfig) => {
@@ -388,17 +396,20 @@ const MapboxLayer = props => {
     <>
       {layer && (
         <Layer
-          id={`${sourceName}-markers`}
+          id={generateLayerId(sourceName, LAYER_TYPES.MARKERS)}
           layer={layer}
           images={layerImages}
           events={layerEvents}
         />
       )}
       <Layer
-        id={`${sourceName}-polygons-outline`}
+        id={generateLayerId(sourceName, LAYER_TYPES.POLYGONS_OUTLINE)}
         layer={layerPolygonOutline}
       />
-      <Layer id={`${sourceName}-polygons-fill`} layer={layerPolygonFill} />
+      <Layer
+        id={generateLayerId(sourceName, LAYER_TYPES.POLYGONS_FILL)}
+        layer={layerPolygonFill}
+      />
       <Portal container={popupContainer}>
         {popupData?.data && <MarkerPopupContent data={popupData.data} />}
       </Portal>

--- a/src/storyMap/components/StoryMap.jsx
+++ b/src/storyMap/components/StoryMap.jsx
@@ -29,10 +29,7 @@ import {
 } from 'terraso-web-client/storyMap/storyMapConstants';
 import { chapterHasVisualMedia } from 'terraso-web-client/storyMap/storyMapUtils';
 
-import {
-  MAPBOX_ACCESS_TOKEN,
-  STORY_MAP_INSET_STYLE,
-} from 'terraso-web-client/config';
+import { MAPBOX_ACCESS_TOKEN } from 'terraso-web-client/config';
 
 import 'terraso-web-client/storyMap/components/StoryMap.css';
 
@@ -49,28 +46,6 @@ mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
 
 const CURRENT_LOCATION_CHECK_PRESSISION = 13; // 13 decimal places
 const ROTATION_DURATION = 30000; // 30 seconds
-
-const getBoundsJson = bounds => ({
-  type: 'FeatureCollection',
-  features: [
-    {
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: 'Polygon',
-        coordinates: [
-          [
-            [bounds._sw.lng, bounds._sw.lat],
-            [bounds._ne.lng, bounds._sw.lat],
-            [bounds._ne.lng, bounds._ne.lat],
-            [bounds._sw.lng, bounds._ne.lat],
-            [bounds._sw.lng, bounds._sw.lat],
-          ],
-        ],
-      },
-    },
-  ],
-});
 
 const Audio = ({ record }) => {
   return (
@@ -226,95 +201,8 @@ const getTransition = ({ config, id, direction }) => {
   };
 };
 
-const InsetConfig = props => {
-  const { map, insetContext } = props;
-  const { map: insetMap, addSource, addLayer } = insetContext;
-
-  useEffect(() => {
-    if (!map || !insetMap) {
-      return;
-    }
-
-    function addInsetLayer(bounds) {
-      addSource('boundsSource', {
-        type: 'geojson',
-        data: bounds,
-      });
-
-      addLayer({
-        id: 'boundsLayer',
-        type: 'fill',
-        source: 'boundsSource', // reference the data source
-        layout: {},
-        paint: {
-          'fill-color': theme.palette.white,
-          'fill-opacity': 0.2,
-        },
-      });
-      // Add a black outline around the polygon.
-      addLayer({
-        id: 'outlineLayer',
-        type: 'line',
-        source: 'boundsSource',
-        layout: {},
-        paint: {
-          'line-color': theme.palette.black,
-          'line-width': 1,
-        },
-      });
-    }
-    addInsetLayer(map.getBounds());
-
-    function updateInsetLayer(bounds) {
-      insetMap.getSource('boundsSource').setData(bounds);
-    }
-
-    function getInsetBounds() {
-      const bounds = map.getBounds();
-      updateInsetLayer(getBoundsJson(bounds));
-    }
-
-    // As the map moves, grab and update bounds in inset map.
-    map.on('move', getInsetBounds);
-    return () => {
-      map.off('move', getInsetBounds);
-    };
-  }, [map, insetMap, addSource, addLayer]);
-
-  return null;
-};
-
-const InsetMap = props => {
-  const { config, initialLocation, map, children } = props;
-
-  if (!config.inset) {
-    return props.children(null);
-  }
-
-  return (
-    <Map
-      id="map-inset"
-      projection="mercator"
-      mapStyle={STORY_MAP_INSET_STYLE}
-      center={initialLocation?.center}
-      zoom={3}
-      interactive={false}
-      attributionControl={false}
-    >
-      <MapContextConsumer>
-        {insetContext => (
-          <>
-            <InsetConfig insetContext={insetContext} map={map} />
-            {children(insetContext)}
-          </>
-        )}
-      </MapContextConsumer>
-    </Map>
-  );
-};
-
 const Scroller = props => {
-  const { config, map, insetMap, animation, onStepChange, onReady } = props;
+  const { config, map, animation, onStepChange, onReady } = props;
   const [marker, setMarker] = useState(null);
   const [isReady, setIsReady] = useState(false);
 
@@ -383,7 +271,7 @@ const Scroller = props => {
 
   const startTransition = useCallback(
     transition => {
-      if (!map || (config.inset && !insetMap) || !transition) {
+      if (!map || !transition) {
         return;
       }
 
@@ -404,16 +292,6 @@ const Scroller = props => {
             transition.location
           );
 
-          // If you do not want to have a dynamic inset map,
-          // rather want to keep it a static view but still change the
-          // bbox as main map move: comment out the below if section.
-          if (config.inset) {
-            if (transition.location.zoom < 5) {
-              insetMap.flyTo({ center: transition.location.center, zoom: 0 });
-            } else {
-              insetMap.flyTo({ center: transition.location.center, zoom: 3 });
-            }
-          }
           if (config.showMarkers) {
             if (!marker) {
               const newMarker = new mapboxgl.Marker({
@@ -442,11 +320,11 @@ const Scroller = props => {
         });
       }
     },
-    [map, config, insetMap, marker, setLayerOpacity, animation]
+    [map, config, marker, setLayerOpacity, animation]
   );
 
   useEffect(() => {
-    if (!map || (config.inset && !insetMap)) {
+    if (!map) {
       return;
     }
 
@@ -515,7 +393,6 @@ const Scroller = props => {
     };
   }, [
     map,
-    insetMap,
     marker,
     setLayerOpacity,
     startTransition,
@@ -523,7 +400,6 @@ const Scroller = props => {
     config.titleTransition,
     config.chapters,
     config.auto,
-    config.inset,
     config.showMarkers,
     onStepChange,
   ]);
@@ -606,22 +482,13 @@ const StoryMap = props => {
       >
         <MapContextConsumer>
           {({ map }) => (
-            <InsetMap
-              config={config}
+            <Scroller
               map={map}
-              initialLocation={initialLocation}
-            >
-              {insetMapContext => (
-                <Scroller
-                  map={map}
-                  insetMap={insetMapContext?.map}
-                  config={config}
-                  animation={animation}
-                  onStepChange={onStepChange}
-                  onReady={onReady}
-                />
-              )}
-            </InsetMap>
+              config={config}
+              animation={animation}
+              onStepChange={onStepChange}
+              onReady={onReady}
+            />
           )}
         </MapContextConsumer>
 

--- a/src/storyMap/components/StoryMap.jsx
+++ b/src/storyMap/components/StoryMap.jsx
@@ -19,13 +19,14 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import _ from 'lodash/fp';
 import { useTranslation } from 'react-i18next';
 import scrollama from 'scrollama';
-import { Box, GlobalStyles, useMediaQuery } from '@mui/material';
+import { Box, useMediaQuery } from '@mui/material';
 
 import RichTextEditor from 'terraso-web-client/common/components/RichTextEditor/index';
 import mapboxgl from 'terraso-web-client/gis/mapbox';
 import {
   ALIGNMENTS,
   LAYER_TYPES,
+  STORY_MAP_TITLE_ID,
 } from 'terraso-web-client/storyMap/storyMapConstants';
 import { chapterHasVisualMedia } from 'terraso-web-client/storyMap/storyMapUtils';
 
@@ -43,9 +44,6 @@ import StoryMapOutline from 'terraso-web-client/storyMap/components/StoryMapOutl
 import theme from 'terraso-web-client/theme';
 
 mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
-
-const CURRENT_LOCATION_CHECK_PRESSISION = 13; // 13 decimal places
-const ROTATION_DURATION = 30000; // 30 seconds
 
 const Audio = ({ record }) => {
   return (
@@ -160,7 +158,7 @@ const Title = props => {
 
   return (
     <Box
-      id="story-map-title"
+      id={STORY_MAP_TITLE_ID}
       component="section"
       aria-label={t('storyMap.view_title_label', { title: config.title })}
       className="step step-container fully title"
@@ -178,32 +176,8 @@ const Title = props => {
   );
 };
 
-const getTransition = ({ config, id, direction }) => {
-  const isTitle = id === 'story-map-title';
-  if (isTitle) {
-    return {
-      transition: config.titleTransition,
-      index: -1,
-      nextTransition: _.get('chapters[0]', config),
-    };
-  }
-  const chapterIndex = config.chapters.findIndex(chapter => chapter.id === id);
-  const chapter = config.chapters[chapterIndex];
-  const nextIndex = direction === 'up' ? chapterIndex - 1 : chapterIndex + 1;
-  const nextIsTitle = nextIndex === -1;
-  const next = nextIsTitle
-    ? config.titleTransition
-    : _.get(`chapters[${nextIndex}]`, config);
-  return {
-    transition: chapter,
-    nextTransition: next,
-    index: chapterIndex,
-  };
-};
-
 const Scroller = props => {
   const { config, map, animation, onStepChange, onReady } = props;
-  const [marker, setMarker] = useState(null);
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -212,28 +186,6 @@ const Scroller = props => {
     }
     onReady?.();
   }, [isReady, onReady]);
-
-  // this is needed to avoid the map breaking after toggling full screen on/off
-  useEffect(() => {
-    if (!map) {
-      return;
-    }
-
-    const mapContainer = map.getContainer();
-    if (!mapContainer) {
-      return;
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      map.resize();
-    });
-
-    resizeObserver.observe(mapContainer);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [map]);
 
   const getLayerPaintType = useCallback(
     layer => {
@@ -258,11 +210,6 @@ const Scroller = props => {
       }
       const paintProps = getLayerPaintType(layer.layer);
       paintProps?.forEach(function (prop) {
-        const options = layer.duration ? { duration: layer.duration } : {};
-        if (layer.duration) {
-          const transitionProp = prop + '-transition';
-          map.setPaintProperty(layer.layer, transitionProp, options);
-        }
         map.setPaintProperty(layer.layer, prop, layer.opacity, options);
       });
     },
@@ -276,48 +223,12 @@ const Scroller = props => {
       }
 
       if (transition.location && !_.isEmpty(transition.location)) {
-        const mapCenter = map.getCenter();
-        const transitionCenter = transition.location.center;
-
-        // Check if the map is already at the transition center
-        const decimalPlaces = CURRENT_LOCATION_CHECK_PRESSISION;
-        const isInLocation =
-          mapCenter.lng.toFixed(decimalPlaces) ===
-            transitionCenter.lng.toFixed(decimalPlaces) &&
-          mapCenter.lat.toFixed(decimalPlaces) ===
-            transitionCenter.lat.toFixed(decimalPlaces);
-
-        if (!isInLocation) {
           map[animation || transition.mapAnimation || 'flyTo'](
             transition.location
           );
-
-          if (config.showMarkers) {
-            if (!marker) {
-              const newMarker = new mapboxgl.Marker({
-                color: config.markerColor,
-              })
-                .setLngLat(transition.location.center)
-                .addTo(map);
-
-              setMarker(newMarker);
-            } else {
-              marker.setLngLat(transition.location.center);
-            }
-          }
-        }
       }
       if (transition.onChapterEnter && transition.onChapterEnter.length > 0) {
         transition.onChapterEnter.forEach(setLayerOpacity);
-      }
-      if (transition.rotateAnimation) {
-        map.once('moveend', () => {
-          const rotateNumber = map.getBearing();
-          map.rotateTo(rotateNumber + 180, {
-            duration: ROTATION_DURATION,
-            easing: t => t,
-          });
-        });
       }
     },
     [map, config, marker, setLayerOpacity, animation]

--- a/src/storyMap/components/StoryMap.jsx
+++ b/src/storyMap/components/StoryMap.jsx
@@ -23,9 +23,9 @@ import { Box, useMediaQuery } from '@mui/material';
 
 import RichTextEditor from 'terraso-web-client/common/components/RichTextEditor/index';
 import mapboxgl from 'terraso-web-client/gis/mapbox';
+import { startTransition } from 'terraso-web-client/storyMap/mapUtils';
 import {
   ALIGNMENTS,
-  LAYER_TYPES,
   STORY_MAP_TITLE_ID,
 } from 'terraso-web-client/storyMap/storyMapConstants';
 import { chapterHasVisualMedia } from 'terraso-web-client/storyMap/storyMapUtils';
@@ -34,10 +34,8 @@ import { MAPBOX_ACCESS_TOKEN } from 'terraso-web-client/config';
 
 import 'terraso-web-client/storyMap/components/StoryMap.css';
 
-import logger from 'terraso-client-shared/monitoring/logger';
-
 import { FullscreenButton } from 'terraso-web-client/gis/components/FullscreenControl';
-import Map, { MapContextConsumer } from 'terraso-web-client/gis/components/Map';
+import Map, { useMap } from 'terraso-web-client/gis/components/Map';
 import { StoryMapLayer } from 'terraso-web-client/storyMap/components/StoryMapLayer';
 import StoryMapOutline from 'terraso-web-client/storyMap/components/StoryMapOutline';
 
@@ -177,7 +175,7 @@ const Title = props => {
 };
 
 const Scroller = props => {
-  const { config, map, animation, onStepChange, onReady } = props;
+  const { onStepChange, onReady } = props;
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -187,58 +185,7 @@ const Scroller = props => {
     onReady?.();
   }, [isReady, onReady]);
 
-  const getLayerPaintType = useCallback(
-    layer => {
-      if (!map.getStyle()) {
-        return [];
-      }
-
-      const layerType = map.getLayer(layer)?.type;
-      if (!layerType) {
-        logger.warn(`Layer ${layer} not found`);
-        return null;
-      }
-      return LAYER_TYPES[layerType];
-    },
-    [map]
-  );
-
-  const setLayerOpacity = useCallback(
-    layer => {
-      if (!layer.layer) {
-        return;
-      }
-      const paintProps = getLayerPaintType(layer.layer);
-      paintProps?.forEach(function (prop) {
-        map.setPaintProperty(layer.layer, prop, layer.opacity, options);
-      });
-    },
-    [map, getLayerPaintType]
-  );
-
-  const startTransition = useCallback(
-    transition => {
-      if (!map || !transition) {
-        return;
-      }
-
-      if (transition.location && !_.isEmpty(transition.location)) {
-          map[animation || transition.mapAnimation || 'flyTo'](
-            transition.location
-          );
-      }
-      if (transition.onChapterEnter && transition.onChapterEnter.length > 0) {
-        transition.onChapterEnter.forEach(setLayerOpacity);
-      }
-    },
-    [map, config, marker, setLayerOpacity, animation]
-  );
-
   useEffect(() => {
-    if (!map) {
-      return;
-    }
-
     const scroller = scrollama();
     scroller
       .setup({
@@ -247,77 +194,50 @@ const Scroller = props => {
         offset: 0.5,
       })
       .onStepEnter(async response => {
-        const { index, transition } = getTransition({
-          config: {
-            titleTransition: config.titleTransition,
-            chapters: config.chapters,
-          },
-          id: response.element.id,
-          direction: response.direction,
-        });
+        onStepChange(response.element.id);
         response.element.classList.add('active');
-        startTransition(transition);
-        onStepChange?.(response.element.id);
-
-        if (config.auto) {
-          const nextChapterIndex = (index + 1) % config.chapters.length;
-          map.once('moveend', () => {
-            document
-              .querySelectorAll(
-                '[data-scrollama-index="' + nextChapterIndex.toString() + '"]'
-              )[0]
-              .scrollIntoView();
-          });
-        }
       })
       .onStepExit(response => {
-        const { transition, nextTransition } = getTransition({
-          config: {
-            titleTransition: config.titleTransition,
-            chapters: config.chapters,
-          },
-          id: response.element.id,
-          direction: response.direction,
-        });
         response.element.classList.remove('active');
-        if (transition?.onChapterExit && transition.onChapterExit.length > 0) {
-          const onEnterLayers = nextTransition?.onChapterEnter?.map(
-            _.get('layer')
-          );
-          const filtered = transition.onChapterExit.filter(
-            transition => !_.includes(transition.layer, onEnterLayers)
-          );
-          filtered.forEach(setLayerOpacity);
-        }
       });
-    // This is needed for development due to resize observer issue
-    // should not be here on production
-    if (import.meta.env.MODE === 'development') {
-      scroller.disable();
-    }
+
     setIsReady(true);
 
-    window.addEventListener('resize', scroller.resize);
     return () => {
       scroller.destroy();
-      window.removeEventListener('resize', scroller.resize);
     };
-  }, [
-    map,
-    marker,
-    setLayerOpacity,
-    startTransition,
-    config.title,
-    config.titleTransition,
-    config.chapters,
-    config.auto,
-    config.showMarkers,
-    onStepChange,
-  ]);
+  }, [onStepChange]);
 
   return null;
 };
 
+const MapTransitionController = ({ config, currentChapter }) => {
+  const isMobile = useMediaQuery(theme.breakpoints.only('xs'));
+  const { map, mapDimensions } = useMap();
+
+  useEffect(() => {
+    if (!mapDimensions) {
+      return;
+    }
+    startTransition(map, {
+      config,
+      chapterId: currentChapter,
+      mapDimensions,
+      isMobile,
+    });
+  }, [map, config, mapDimensions, currentChapter, isMobile]);
+
+  return null;
+};
+
+// the basic state machine here is:
+// MapTransitionController calls startTransition (which moves the map).
+// this is a cheap and idempotent operation, so we call it liberally.
+// it's called in a useEffect, which depends on:
+//   - the story map's config, to pick up chapter alignment changes
+//   - the current chapter, which is a piece of state updated by Scrollama
+//   - whether we're in a mobile viewport (which forces a centered chapter)
+//   - the map dimensions, so we readjust when the map's size changes
 const StoryMap = props => {
   const { t } = useTranslation();
   const {
@@ -325,14 +245,23 @@ const StoryMap = props => {
     onStepChange,
     ChapterComponent = Chapter,
     TitleComponent = Title,
-    animation,
     onReady,
     chaptersFilter,
     isContained = false,
   } = props;
 
   const [isMapFullscreen, setIsMapFullscreen] = useState(false);
+  const [currentChapter, setCurrentChapter] = useState(STORY_MAP_TITLE_ID);
   const isMobile = useMediaQuery(theme.breakpoints.only('xs'));
+
+  const onStepChangeWrapped = useCallback(
+    id => {
+      setCurrentChapter(id);
+      onStepChange?.(id);
+    },
+    [setCurrentChapter, onStepChange]
+  );
+
   const initialLocation = useMemo(() => {
     if (config.titleTransition?.location) {
       return config.titleTransition?.location;
@@ -391,18 +320,6 @@ const StoryMap = props => {
             : { top: 0, height: '33vh', zIndex: 4 },
         })}
       >
-        <MapContextConsumer>
-          {({ map }) => (
-            <Scroller
-              map={map}
-              config={config}
-              animation={animation}
-              onStepChange={onStepChange}
-              onReady={onReady}
-            />
-          )}
-        </MapContextConsumer>
-
         <FullscreenButton
           isFullscreen={isMapFullscreen}
           onToggle={() => setIsMapFullscreen(prev => !prev)}
@@ -417,6 +334,14 @@ const StoryMap = props => {
               opacity={0}
             />
           ))}
+
+        <MapTransitionController
+          // NOTE: the MapTransitionController unfortunately must come AFTER any map layers
+          // due to timing of the react render lifecycle and imperative mapbox events.
+          // hopefully this will be less janky in the future.
+          config={config}
+          currentChapter={currentChapter}
+        />
       </Map>
       <Box
         sx={({ breakpoints }) => ({
@@ -427,6 +352,7 @@ const StoryMap = props => {
         id="features"
         className={ALIGNMENTS[config.alignment]}
       >
+        <Scroller onStepChange={onStepChangeWrapped} onReady={onReady} />
         <TitleComponent config={config} />
         {filteredChapters.map(chapter => (
           <ChapterComponent

--- a/src/storyMap/components/StoryMapForm.test.jsx
+++ b/src/storyMap/components/StoryMapForm.test.jsx
@@ -36,6 +36,7 @@ import {
 } from 'terraso-web-client/sharedData/sharedDataConstants';
 import StoryMapForm from 'terraso-web-client/storyMap/components/StoryMapForm/index';
 import { StoryMapConfigContextProvider } from 'terraso-web-client/storyMap/components/StoryMapForm/storyMapConfigContext';
+import { STORY_MAP_TITLE_ID } from 'terraso-web-client/storyMap/storyMapConstants';
 
 // Mock mapboxgl
 jest.mock('terraso-web-client/gis/mapbox', () => ({}));
@@ -665,7 +666,7 @@ test('StoryMapForm: Sidebar navigation', async () => {
   // Trigger on title
   await act(async () => {
     scroller.stepEnter({
-      element: document.querySelector('#story-map-title'),
+      element: document.querySelector(`#${STORY_MAP_TITLE_ID}`),
     });
   });
   expect(title).toHaveAttribute('aria-current', 'step');

--- a/src/storyMap/components/StoryMapForm.test.jsx
+++ b/src/storyMap/components/StoryMapForm.test.jsx
@@ -249,6 +249,23 @@ const BASE_CONFIG = {
   ],
 };
 
+const OriginalResizeObserver = global.ResizeObserver;
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      this.cb([{ contentBoxSize: [{ blockSize: 600, inlineSize: 1200 }] }]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+});
+afterAll(() => {
+  global.ResizeObserver = OriginalResizeObserver;
+});
+
 beforeEach(() => {
   global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
   mapboxgl.LngLatBounds = jest.fn();
@@ -652,6 +669,9 @@ test('StoryMapForm: Sidebar navigation', async () => {
   expect(map.flyTo).toHaveBeenCalledTimes(0);
 
   // Trigger on chapter 2
+  await waitFor(() =>
+    expect(document.querySelector('#chapter-2')).toBeInTheDocument()
+  );
   await act(async () => {
     scroller.stepEnter({
       element: document.querySelector('#chapter-2'),
@@ -808,6 +828,12 @@ test('StoryMapForm: Change chapter location', async () => {
     getZoom: () => 10,
     getPitch: () => 64,
     getBearing: () => 45,
+    getBounds: jest.fn().mockReturnValue({
+      toArray: () => [
+        [-180, -90],
+        [180, 90],
+      ],
+    }),
   };
   mapboxgl.Map.mockReturnValue(map);
   const { onSaveDraft } = await setup({ config: BASE_CONFIG });
@@ -844,6 +870,7 @@ test('StoryMapForm: Change chapter location', async () => {
     expect.objectContaining({
       location: {
         bearing: 45,
+        bounds: [-180, -90, 180, 90],
         center: {
           lat: -0.2294635049867253,
           lng: -78.54414857836304,
@@ -862,6 +889,12 @@ test('StoryMapForm: Change chapter style', async () => {
     getZoom: () => 10,
     getPitch: () => 64,
     getBearing: () => 45,
+    getBounds: jest.fn().mockReturnValue({
+      toArray: () => [
+        [-180, -90],
+        [180, 90],
+      ],
+    }),
   };
   mapboxgl.Map.mockReturnValue(map);
   const { onSaveDraft } = await setup({ config: BASE_CONFIG });
@@ -910,6 +943,12 @@ test('StoryMapForm: Add map layer', async () => {
     getZoom: () => 10,
     getPitch: () => 64,
     getBearing: () => 45,
+    getBounds: jest.fn().mockReturnValue({
+      toArray: () => [
+        [-180, -90],
+        [180, 90],
+      ],
+    }),
   };
   mapboxgl.Map.mockReturnValue(map);
 
@@ -1287,6 +1326,9 @@ test('StoryMapForm: Keep map on chapter change', async () => {
   await waitFor(() => expect(scrollama).toHaveBeenCalled());
 
   // Go to chapter 1
+  await waitFor(() =>
+    expect(document.querySelector('#chapter-1')).toBeInTheDocument()
+  );
   await act(async () =>
     scroller.stepEnter({
       element: document.querySelector('#chapter-1'),
@@ -1294,6 +1336,9 @@ test('StoryMapForm: Keep map on chapter change', async () => {
   );
 
   // Go to chapter 2
+  await waitFor(() =>
+    expect(document.querySelector('#chapter-2')).toBeInTheDocument()
+  );
   await act(async () =>
     scroller.stepEnter({
       element: document.querySelector('#chapter-2'),
@@ -1309,14 +1354,12 @@ test('StoryMapForm: Keep map on chapter change', async () => {
   await expect(map.setPaintProperty).toHaveBeenCalledWith(
     'layer1',
     'fill-opacity',
-    1,
-    {}
+    1
   );
   await expect(map.setPaintProperty).not.toHaveBeenCalledWith(
     'layer1',
     'fill-opacity',
-    0,
-    {}
+    0
   );
 
   // Go to chapter 1
@@ -1335,14 +1378,12 @@ test('StoryMapForm: Keep map on chapter change', async () => {
   await expect(map.setPaintProperty).toHaveBeenCalledWith(
     'layer1',
     'fill-opacity',
-    1,
-    {}
+    1
   );
   await expect(map.setPaintProperty).not.toHaveBeenCalledWith(
     'layer1',
     'fill-opacity',
-    0,
-    {}
+    0
   );
 });
 

--- a/src/storyMap/components/StoryMapForm/ChapterForm.jsx
+++ b/src/storyMap/components/StoryMapForm/ChapterForm.jsx
@@ -34,6 +34,7 @@ import {
 import { withProps } from 'terraso-web-client/react-hoc';
 
 import {
+  generateLayerId,
   getLayerOpacity,
   LAYER_TYPES,
 } from 'terraso-web-client/sharedData/visualization/components/VisualizationMapLayer';
@@ -200,8 +201,8 @@ const ChapterForm = ({ theme, record }) => {
   const onDataLayerChange = useCallback(
     dataLayerConfig => {
       const baseEvents = dataLayerConfig
-        ? LAYER_TYPES.map(name => ({
-            layer: `${dataLayerConfig.id}-${name}`,
+        ? Object.values(LAYER_TYPES).map(name => ({
+            layer: generateLayerId(dataLayerConfig.id, name),
             opacity: getLayerOpacity(name, dataLayerConfig),
             duration: 0,
           }))

--- a/src/storyMap/components/StoryMapForm/ChaptersSideBar.jsx
+++ b/src/storyMap/components/StoryMapForm/ChaptersSideBar.jsx
@@ -39,6 +39,7 @@ import { withProps } from 'terraso-web-client/react-hoc';
 
 import ConfirmMenuItem from 'terraso-web-client/common/components/ConfirmMenuItem';
 import StrictModeDroppable from 'terraso-web-client/common/components/StrictModeDroppable';
+import { STORY_MAP_TITLE_ID } from 'terraso-web-client/storyMap/storyMapConstants';
 
 import dragIcon from 'terraso-web-client/assets/drag-icon.svg';
 
@@ -286,8 +287,8 @@ const ChaptersSidebar = props => {
   const titleItem = useMemo(
     () => ({
       label: `${t('storyMap.form_title_chapter_label')}`,
-      id: 'story-map-title',
-      active: currentStepId === 'story-map-title',
+      id: STORY_MAP_TITLE_ID,
+      active: currentStepId === STORY_MAP_TITLE_ID,
       index: 'T',
     }),
     [currentStepId, t]

--- a/src/storyMap/components/StoryMapForm/MapConfigurationDialog/MapConfigurationDialog.tsx
+++ b/src/storyMap/components/StoryMapForm/MapConfigurationDialog/MapConfigurationDialog.tsx
@@ -338,11 +338,12 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
   return (
     <CollaborationContextProvider owner={storyMap} entityType="story_map">
       <Dialog
-        fullScreen
         open={open}
         onClose={handleCancel}
         aria-labelledby="map-location-dialog-title"
         aria-describedby="map-location-dialog-content-text"
+        maxWidth="sm"
+        fullWidth
       >
         <Stack direction="row" justifyContent="space-between">
           <Stack>
@@ -394,7 +395,6 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
           <Map
             ref={mapRef}
             use3dTerrain
-            height="100%"
             initialLocation={initialLocation}
             projection={config.projection}
             mapStyle={config.style}

--- a/src/storyMap/components/StoryMapForm/MapConfigurationDialog/MapConfigurationDialog.tsx
+++ b/src/storyMap/components/StoryMapForm/MapConfigurationDialog/MapConfigurationDialog.tsx
@@ -47,6 +47,7 @@ import { MapLayerDialog } from 'terraso-web-client/storyMap/components/StoryMapF
 import { useStoryMapConfigContext } from 'terraso-web-client/storyMap/components/StoryMapForm/storyMapConfigContext';
 import { StoryMapLayer } from 'terraso-web-client/storyMap/components/StoryMapLayer';
 import {
+  MapBounds,
   MapLayerConfig,
   MapPosition,
   StoryMapConfig,
@@ -215,7 +216,7 @@ const MapLocationChange = ({ onPositionChange }: MapLocationChangeProps) => {
         zoom: map.getZoom(),
         pitch: map.getPitch(),
         bearing: map.getBearing(),
-        bounds: map.getBounds(),
+        bounds: _.flatten(map.getBounds().toArray()) as MapBounds,
       });
     };
     map.on('load', updatePosition);
@@ -251,6 +252,7 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
   const [mapZoom, setMapZoom] = useState(location?.zoom);
   const [mapPitch, setMapPitch] = useState(location?.pitch);
   const [mapBearing, setMapBearing] = useState(location?.bearing);
+  const [mapBounds, setMapBounds] = useState(location?.bounds);
   const [mapStyle, setMapStyle] = useState<string | undefined>();
   const [changeBounds, setChangeBounds] = useState(false);
   const [mapLayerConfig, setMapLayerConfig] = useState(props.mapLayerConfig);
@@ -290,6 +292,7 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
       zoom: mapZoom,
       pitch: mapPitch,
       bearing: mapBearing,
+      bounds: mapBounds,
     });
     onConfirm({
       location,
@@ -302,6 +305,7 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
     mapZoom,
     mapPitch,
     mapBearing,
+    mapBounds,
     mapStyle,
     config.style,
     mapLayerConfig,
@@ -316,6 +320,7 @@ export const MapConfigurationDialog = (props: MapConfigurationDialogProps) => {
     setMapZoom(position.zoom);
     setMapPitch(position.pitch);
     setMapBearing(position.bearing);
+    setMapBounds(position.bounds);
   }, []);
 
   const onStyleChange = useCallback(

--- a/src/storyMap/components/StoryMapForm/TitleForm.jsx
+++ b/src/storyMap/components/StoryMapForm/TitleForm.jsx
@@ -29,6 +29,7 @@ import EditableText from 'terraso-web-client/storyMap/components/StoryMapForm/Ed
 import { MapConfigurationDialog } from 'terraso-web-client/storyMap/components/StoryMapForm/MapConfigurationDialog/MapConfigurationDialog';
 import { useStoryMapConfigContext } from 'terraso-web-client/storyMap/components/StoryMapForm/storyMapConfigContext';
 import StoryMapOutline from 'terraso-web-client/storyMap/components/StoryMapOutline';
+import { STORY_MAP_TITLE_ID } from 'terraso-web-client/storyMap/storyMapConstants';
 
 const TitleForm = props => {
   const { t } = useTranslation();
@@ -66,8 +67,8 @@ const TitleForm = props => {
   const onDataLayerChange = useCallback(
     dataLayerConfig => {
       const baseEvents = dataLayerConfig
-        ? LAYER_TYPES.map(name => ({
-            layer: `${dataLayerConfig.id}-${name}`,
+        ? Object.values(LAYER_TYPES).map(name => ({
+            layer: generateLayerId(dataLayerConfig.id, name),
             opacity: getLayerOpacity(name, dataLayerConfig),
             duration: 0,
           }))
@@ -118,7 +119,7 @@ const TitleForm = props => {
 
   return (
     <Box
-      id="story-map-title"
+      id={STORY_MAP_TITLE_ID}
       className="step active title"
       component="section"
       aria-label={t('storyMap.view_title_label', {

--- a/src/storyMap/components/StoryMapForm/index.jsx
+++ b/src/storyMap/components/StoryMapForm/index.jsx
@@ -35,6 +35,7 @@ import { useStoryMapConfigContext } from 'terraso-web-client/storyMap/components
 import TitleForm from 'terraso-web-client/storyMap/components/StoryMapForm/TitleForm';
 import TopBar from 'terraso-web-client/storyMap/components/StoryMapForm/TopBar';
 import TopBarPreview from 'terraso-web-client/storyMap/components/StoryMapForm/TopBarPreview';
+import { STORY_MAP_TITLE_ID } from 'terraso-web-client/storyMap/storyMapConstants';
 import { isChapterEmpty } from 'terraso-web-client/storyMap/storyMapUtils';
 
 import { STORY_MAP_AUTO_SAVE_DEBOUNCE } from 'terraso-web-client/config';
@@ -45,10 +46,7 @@ const BASE_CHAPTER = {
   alignment: 'left',
   title: '',
   description: '',
-  mapAnimation: 'flyTo',
-  rotateAnimation: false,
   onChapterEnter: [],
-  onChapterExit: [],
 };
 
 const Preview = props => {
@@ -151,7 +149,7 @@ const StoryMapForm = props => {
   // Focus on the title when the map is ready
   const onMapReady = useCallback(() => {
     const input = document
-      .getElementById('story-map-title')
+      .getElementById(STORY_MAP_TITLE_ID)
       .querySelector('input');
     input?.focus();
     init.current = true;

--- a/src/storyMap/components/StoryMapNew.jsx
+++ b/src/storyMap/components/StoryMapNew.jsx
@@ -43,44 +43,6 @@ import { MAPBOX_STYLE_DEFAULT } from 'terraso-web-client/config';
 
 import theme from 'terraso-web-client/theme';
 
-/*
- * Chapter schema
- * {
- *   id: string,
- *   title: string,
- *   description: RichText,
- *   alignment: string (left|right|center),
- *   rotateAnimation: boolean,
- *   mapAnimation: string (flyTo|jumpTo),
- *   media: {
- *     type: string (image|video|embedded),
- *     url: string,
- *     signedUrl: string,
- *   },
- *   location: {
- *     center: {
- *       lat: number,
- *       lng: number,
- *     },
- *     zoom: number,
- *     pitch: number,
- *     bearing: number,
- *   },
- *   onChapterEnter: [
- *    {
- *      layer: string,
- *      opacity: number,
- *    },
- *   ],
- *   onChapterExit: [
- *    {
- *      layer: string,
- *      opacity: number,
- *    },
- *  ],
- * }
- */
-
 const BASE_CONFIG = {
   style: MAPBOX_STYLE_DEFAULT,
   theme: 'dark',

--- a/src/storyMap/mapUtils.ts
+++ b/src/storyMap/mapUtils.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2026 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import * as geoViewport from '@placemarkio/geo-viewport';
+import _ from 'lodash/fp';
+import type { LngLat } from 'mapbox-gl';
+import logger from 'terraso-client-shared/monitoring/logger';
+
+import { isValidBounds } from 'terraso-web-client/gis/gisUtils';
+import {
+  generateLayerId,
+  LAYER_TYPES,
+} from 'terraso-web-client/sharedData/visualization/components/VisualizationMapLayer';
+import {
+  LAYER_PAINT_TYPES,
+  LayerPaintType,
+} from 'terraso-web-client/storyMap/storyMapConstants';
+import {
+  ChapterAlignment,
+  LayerConfig,
+  MapBounds,
+  MapPosition,
+  StoryMapConfig,
+} from 'terraso-web-client/storyMap/storyMapTypes';
+import { getTransition } from 'terraso-web-client/storyMap/storyMapUtils';
+
+// Assumed viewport size when center/zoom were originally set in the editor
+const DEFAULT_ASSUMED_CLIENT_WIDTH = 1200;
+const DEFAULT_ASSUMED_CLIENT_HEIGHT = 600;
+
+const getLayerPaintType = (map: mapboxgl.Map, layer: string) => {
+  if (!map.getStyle()) {
+    return [];
+  }
+
+  const layerType = map.getLayer(layer)?.type;
+  if (!layerType) {
+    logger.warn(`Layer ${layer} not found`);
+    return null;
+  }
+  return LAYER_PAINT_TYPES[layerType as LayerPaintType];
+};
+
+const setLayerOpacity = (map: mapboxgl.Map, layer: LayerConfig) => {
+  if (!layer.layer) {
+    return;
+  }
+  const paintProps = getLayerPaintType(map, layer.layer);
+  paintProps?.forEach(function (prop) {
+    map.setPaintProperty(layer.layer, prop, layer.opacity);
+  });
+};
+
+/**
+ * Calculate bounds from center/zoom for legacy chapters without bounds
+ */
+const calculateLegacyBounds = (center: LngLat, zoom: number): MapBounds => {
+  return geoViewport.bounds(
+    [center.lng, center.lat],
+    zoom,
+    [DEFAULT_ASSUMED_CLIENT_WIDTH, DEFAULT_ASSUMED_CLIENT_HEIGHT],
+    512
+  );
+};
+
+/**
+ * Adjust bounds for legacy chapters based on alignment
+ * Crops out the area that would be covered by the chapter panel
+ */
+const adjustBoundsForAlignment = (
+  bounds: MapBounds,
+  alignment: ChapterAlignment
+): MapBounds => {
+  if (!alignment || alignment === 'center') {
+    return bounds;
+  }
+
+  const [swLng, swLat, neLng, neLat] = bounds;
+  const lngRange = neLng - swLng;
+
+  if (alignment === 'left') {
+    // Crop out lefthand 40% - shift west bound eastward
+    return [swLng + lngRange * 0.4, swLat, neLng, neLat];
+  } else if (alignment === 'right') {
+    // Crop out righthand 40% - shift east bound westward
+    return [swLng, swLat, neLng - lngRange * 0.4, neLat];
+  }
+
+  return bounds;
+};
+
+/**
+ * Add padding area to bounds for display based on alignment
+ * Expands the bounds to account for the chapter panel
+ */
+const expandBoundsForDisplay = (
+  bounds: MapBounds,
+  alignment: ChapterAlignment
+): MapBounds => {
+  if (!alignment || alignment === 'center') {
+    return bounds;
+  }
+
+  const [swLng, swLat, neLng, neLat] = bounds;
+  const lngRange = neLng - swLng;
+  const expansion = lngRange * (2 / 3); // Add area that's 2/3 the original size
+
+  if (alignment === 'left') {
+    // Add area to the left - expand west bound westward
+    return [swLng - expansion, swLat, neLng, neLat];
+  } else if (alignment === 'right') {
+    // Add area to the right - expand east bound eastward
+    return [swLng, swLat, neLng + expansion, neLat];
+  }
+
+  return bounds;
+};
+
+/**
+ * Backfill bounds for legacy chapters from center/zoom
+ * Applies alignment adjustment when calculating
+ */
+const backfillBounds = (location: MapPosition, alignment: ChapterAlignment) => {
+  // Calculate bounds assuming default editor viewport size
+  const bounds = calculateLegacyBounds(location.center, location.zoom);
+
+  // Adjust for alignment (crop out covered area)
+  return adjustBoundsForAlignment(bounds, alignment);
+};
+
+const fitBoundsAnimated = (
+  map: mapboxgl.Map,
+  bounds: MapBounds,
+  mapDimensions: { height: number; width: number }
+) => {
+  const viewport = geoViewport.viewport(
+    bounds,
+    [mapDimensions.width, mapDimensions.height],
+    { allowAntiMeridian: true, allowFloat: true, tileSize: 512 }
+  );
+  map.flyTo({
+    center: viewport.center,
+    zoom: viewport.zoom,
+    linear: false,
+    pitch: 0,
+    bearing: 0,
+    essential: true,
+  });
+};
+
+export type StartTransitionOptions = {
+  config: StoryMapConfig;
+  chapterId: string;
+  mapDimensions: { height: number; width: number };
+  isMobile: boolean;
+};
+export const startTransition = (
+  map: mapboxgl.Map,
+  { config, chapterId, isMobile, mapDimensions }: StartTransitionOptions
+) => {
+  const transition = getTransition({ config, id: chapterId });
+
+  if (!map || !transition) {
+    return;
+  }
+
+  if (transition.location && !_.isEmpty(transition.location)) {
+    const alignment =
+      isMobile || !('alignment' in transition)
+        ? 'center'
+        : transition.alignment;
+
+    let boundsToUse = transition.location.bounds;
+
+    // If no bounds, backfill from center/zoom for legacy chapters
+    if (!boundsToUse || !isValidBounds(boundsToUse)) {
+      const legacyAlignment =
+        'alignment' in transition ? transition.alignment : 'center';
+      boundsToUse = backfillBounds(transition.location, legacyAlignment);
+    }
+
+    const displayBounds = expandBoundsForDisplay(boundsToUse, alignment);
+
+    fitBoundsAnimated(map, displayBounds, mapDimensions);
+  }
+  transition.onChapterEnter?.forEach(layerConfig =>
+    setLayerOpacity(map, layerConfig)
+  );
+
+  Object.values(config.dataLayers ?? {})
+    .flatMap(({ id: layerId }) =>
+      Object.values(LAYER_TYPES).map(layerType =>
+        generateLayerId(layerId, layerType)
+      )
+    )
+    .filter(id => transition.onChapterEnter?.every(({ layer }) => layer !== id))
+    .forEach(id => {
+      setLayerOpacity(map, { layer: id, opacity: 0 });
+    });
+};

--- a/src/storyMap/storyMapConstants.ts
+++ b/src/storyMap/storyMapConstants.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
-export const LAYER_TYPES = {
+export const LAYER_PAINT_TYPES = {
   fill: ['fill-opacity'],
   line: ['line-opacity'],
   circle: ['circle-opacity', 'circle-stroke-opacity'],
@@ -22,7 +22,9 @@ export const LAYER_TYPES = {
   raster: ['raster-opacity'],
   'fill-extrusion': ['fill-extrusion-opacity'],
   heatmap: ['heatmap-opacity'],
-};
+} as const;
+
+export type LayerPaintType = keyof typeof LAYER_PAINT_TYPES;
 
 export const ALIGNMENTS = {
   left: 'lefty',
@@ -33,3 +35,5 @@ export const ALIGNMENTS = {
 
 export const MEMBERSHIP_ROLE_EDITOR = 'editor';
 export const MEMBERSHIP_ROLE_OWNER = 'owner';
+
+export const STORY_MAP_TITLE_ID = 'story-map-title';

--- a/src/storyMap/storyMapTypes.ts
+++ b/src/storyMap/storyMapTypes.ts
@@ -82,7 +82,7 @@ export type StoryMapConfig = {
   chapters: ChapterConfig[];
   titleTransition?: Transition;
   projection?: string;
-  dataLayers: Record<string, MapLayerConfig>;
+  dataLayers?: Record<string, MapLayerConfig>;
 };
 
 export type VisualizationConfigForm = {

--- a/src/storyMap/storyMapTypes.ts
+++ b/src/storyMap/storyMapTypes.ts
@@ -16,7 +16,7 @@
  */
 
 import type { GeoJSON } from 'geojson';
-import { LngLat, LngLatBounds } from 'mapbox-gl';
+import { LngLat } from 'mapbox-gl';
 import { Descendant } from 'slate';
 import type {
   DataEntryNode,
@@ -39,35 +39,37 @@ export type MapPosition = {
   bearing: number;
   pitch: number;
   zoom: number;
-  bounds: LngLatBounds;
+  bounds: MapBounds;
 };
+
+export type LayerConfig = {
+  layer: string;
+  opacity: number;
+};
+
+export type Transition = {
+  location: MapPosition;
+  onChapterEnter?: LayerConfig[];
+};
+
+export type ChapterAlignment = 'left' | 'right' | 'center';
+
+/**
+ * swLng, swLat, neLng, neLat
+ */
+export type MapBounds = [number, number, number, number];
 
 export type ChapterConfig = {
   id: string;
   title: string;
   description: Descendant;
-  alignment: 'left' | 'right' | 'center';
-  rotateAnimation: boolean;
-  mapAnimation: 'flyTo' | 'jumpTo';
+  alignment: ChapterAlignment;
   media: {
     type: 'image' | 'video' | 'embedded';
     url: string;
     signedUrl: string;
   };
-  location: MapPosition;
-  onChapterEnter: [
-    {
-      layer: string;
-      opacity: number;
-    },
-  ];
-  onChapterExit: [
-    {
-      layer: string;
-      opacity: number;
-    },
-  ];
-};
+} & Transition;
 
 export type StoryMapConfig = {
   style: string;
@@ -78,10 +80,9 @@ export type StoryMapConfig = {
   subtitle: string;
   byline: string;
   chapters: ChapterConfig[];
-  titleTransition?: {
-    location: MapPosition;
-  };
+  titleTransition?: Transition;
   projection?: string;
+  dataLayers: Record<string, MapLayerConfig>;
 };
 
 export type VisualizationConfigForm = {

--- a/src/storyMap/storyMapUtils.js
+++ b/src/storyMap/storyMapUtils.js
@@ -15,11 +15,15 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
+/** @import { ChapterConfig, StoryMapConfig, Transition } from 'terraso-web-client/storyMap/storyMapTypes' */
+
 import _ from 'lodash/fp';
 import {
   extractAccountMembership,
   extractMembershipInfo,
 } from 'terraso-client-shared/collaboration/membershipsUtils';
+
+import { STORY_MAP_TITLE_ID } from 'terraso-web-client/storyMap/storyMapConstants';
 
 import { REACT_APP_BASE_URL } from 'terraso-web-client/config';
 
@@ -58,3 +62,17 @@ export const extractStoryMap = storyMap => ({
   accountMembership: extractAccountMembership(storyMap.membershipList),
   membershipInfo: extractMembershipInfo(storyMap.membershipList),
 });
+
+/**
+ * @param {{ config: StoryMapConfig, id: string }} options
+ * @returns {ChapterConfig | Transition | undefined}
+ */
+export const getTransition = ({ config, id }) => {
+  const isTitle = id === STORY_MAP_TITLE_ID;
+  if (isTitle) {
+    return config.titleTransition;
+  }
+  const chapterIndex = config.chapters.findIndex(chapter => chapter.id === id);
+  const chapter = config.chapters[chapterIndex];
+  return chapter;
+};

--- a/src/tests/data/storyMap.ts
+++ b/src/tests/data/storyMap.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { LngLat, LngLatBounds } from 'mapbox-gl';
+import { LngLat } from 'mapbox-gl';
 import {
   DataEntryNode,
   StoryMapNode,
@@ -34,7 +34,7 @@ export const createTestPosition = (): MapPosition => ({
   zoom: 10,
   pitch: 0,
   bearing: 0,
-  bounds: new LngLatBounds([-1, -1], [1, 1]),
+  bounds: [-1, -1, 1, 1],
 });
 
 export const createTestStoryMapConfig = (): StoryMapConfig => ({

--- a/src/tests/mapboxMock.js
+++ b/src/tests/mapboxMock.js
@@ -57,6 +57,7 @@ export const createMapMock = (overrides = {}) => ({
     disableRotation: jest.fn(),
   },
   touchPitch: { enable: jest.fn(), disable: jest.fn() },
+  resize: jest.fn(),
   ...overrides,
 });
 


### PR DESCRIPTION
## Description
### Remaining work
- [x] change "edit map" to windowed dialog
- [x] issue: swapping chapter alignment on pre-existing story map without editing the map location will cause incorrect area of interest calculations
- [x] issue: map layers aren't getting disabled when chapter is exited anymore
- [x] i haven't checked how this works where longitude wraps around in the pacific :shrug:
- [x] fix tests 
- [x] see about if there's any way to test this ( :grimacing: )

### Changes
i was having a lot of trouble getting this working without a significant code restructuring, since before the map would only move because of scroll events and so the map move was triggered directly in the Scroller component. but now many different events can trigger a map adjustment. while i was making these changes, i was running into issues with other pieces of code which were for features we don't actually expose to the user. 

rather than try to keep those features functional without testing them properly, i've opted to remove them from the codebase, with the idea we can add them back in later if we decide to prioritize them on our roadmap and test them properly at that point. none of the features i removed are on our roadmap currently. here's the list:
- inset map (small minimap in the corner which shows where you are looking on a globe)
- setting a duration for map layer opacity changes
- including a rotation in the animation
- moving the map instantaneously instead of with an animation
- automatically paging through the map on a timer

i also made the following simplifications:
- almost all the logic in Scroller got moved to stateless functions in a new `storyMap/mapUtils.ts` file, which also contains the new GIS code for adjusting map bounds
- there's no more calculating previous and next chapter in order to figure out which layers to disable. instead we just track next chapter, and disable all layers besides the ones in that chapter
- no longer tries to avoid calling mapbox animation by checking the current location. the old code didn't account for zoom, and it was hard to update it to work with bounds. my thinking is that there's no harm in calling it again if you happen to be in the same location, it'll just be a no-op, but let me know if there's any concerns with this.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes #2934 

### Verification steps
- Mess around in existing maps on mobile and see that the view alignment is better.
- Edit a story map by changing map location and swapping chapter alignment, resizing browser window, opening/closing sidebar, etc, and see that area of interest remains visible.