### PR TITLE
fix(story-map): add pixels to featured image dimensions copy

### DIFF
--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -1015,7 +1015,7 @@
         "form_featured_image_remove": "Remove",
         "form_featured_image_preview_alt": "Featured image preview",
         "form_featured_image_invalid": "Upload images with one of the following extensions: {{extensions}}",
-        "form_featured_image_recommended_dimensions": "Recommended dimensions: {{width}} x {{height}}",
+        "form_featured_image_recommended_dimensions": "Recommended dimensions: {{width}} x {{height}} pixels",
         "form_featured_image_read_error": "Unable to read the image file. Please try a different file.",
         "form_short_description_button": "Add short description",
         "form_published_url_label": "Published URL",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -1022,7 +1022,7 @@
         "form_featured_image_remove": "Eliminar",
         "form_featured_image_preview_alt": "Vista previa de imagen destacada",
         "form_featured_image_invalid": "Sube imágenes con una de las siguientes extensiones: {{extensions}}",
-        "form_featured_image_recommended_dimensions": "Dimensiones recomendadas: {{width}} x {{height}}",
+        "form_featured_image_recommended_dimensions": "Dimensiones recomendadas: {{width}} x {{height}} píxeles",
         "form_featured_image_read_error": "No se puede leer el archivo de imagen. Por favor, intente con un archivo diferente.",
         "form_short_description_button": "Agregar descripción corta",
         "form_published_url_label": "URL publicada",

--- a/src/storyMap/components/StoryMapForm.test.jsx
+++ b/src/storyMap/components/StoryMapForm.test.jsx
@@ -1404,7 +1404,7 @@ test('StoryMapForm: Add featured image', async () => {
   });
 
   expect(
-    within(dialog).getByText('Recommended dimensions: 1200 x 630')
+    within(dialog).getByText('Recommended dimensions: 1200 x 630 pixels')
   ).toBeInTheDocument();
 
   const dropZone = within(dialog).getByRole('button', {

--- a/src/storyMap/components/StoryMapForm/FeaturedImageDialog.test.jsx
+++ b/src/storyMap/components/StoryMapForm/FeaturedImageDialog.test.jsx
@@ -52,6 +52,6 @@ test('FeaturedImageDialog: Uses configured recommended dimensions', () => {
   );
 
   expect(
-    screen.getByText('Recommended dimensions: 1024 x 512')
+    screen.getByText('Recommended dimensions: 1024 x 512 pixels')
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Added "pixels" to message

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added


### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/2951

