### PR TITLE
fix: persist token cookies for 30 days so sessions survive browser re…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,8 @@ export const GRAPHQL_ENDPOINT = 'graphql/';
 export const COOKIES_DOMAIN =
   import.meta.env.REACT_APP_COOKIES_DOMAIN || '127.0.0.1';
 
-const COOKIES_PARAMS = { path: '/' };
+// 30 days expiration for both access and refresh tokens, since refresh token rotation is implemented on the backend
+const COOKIES_PARAMS = { path: '/', expires: 30 };
 
 export const SENTRY_DSN = import.meta.env.REACT_APP_SENTRY_DSN || '';
 

--- a/src/layout/AppBar.test.jsx
+++ b/src/layout/AppBar.test.jsx
@@ -118,11 +118,13 @@ test('AppBar: Sign out', async () => {
   const saveCall = Cookies.remove.mock.calls[0];
   expect(saveCall[1]).toStrictEqual({
     path: '/',
+    expires: 30,
   });
   const saveCall2 = Cookies.remove.mock.calls[1];
   expect(saveCall2[1]).toStrictEqual({
     domain: '127.0.0.1',
     path: '/',
+    expires: 30,
   });
 });
 


### PR DESCRIPTION

Without an explicit expires, js-cookie wrote both atoken and rtoken as session cookies, dropping them when the browser quit. That forced a re-login on next launch even though the server-side refresh-token TTL is 30 days and a silent renewal would have worked. Match the cookie expiry to the refresh TTL so the silent refresh path can actually run. Refresh rotation on the backend continues to limit the practical lifetime of any single stored token.
