### PR TITLE
feat: allow hostname to be dynamic for dev workflows

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -23,15 +23,17 @@ import type { Severity } from 'terraso-client-shared/monitoring/logger';
 export const TERRASO_ENV = import.meta.env.ENV || 'development';
 
 export const TERRASO_API_URL =
-  import.meta.env.REACT_APP_TERRASO_API_URL || 'http://127.0.0.1:8000';
+  import.meta.env.REACT_APP_TERRASO_API_URL ||
+  `http://${window.location.hostname}:8000`;
 
 export const REACT_APP_BASE_URL =
-  import.meta.env.REACT_APP_BASE_URL || 'http://127.0.0.1:3000';
+  import.meta.env.REACT_APP_BASE_URL ||
+  `http://${window.location.hostname}:3000`;
 
 export const GRAPHQL_ENDPOINT = 'graphql/';
 
 export const COOKIES_DOMAIN =
-  import.meta.env.REACT_APP_COOKIES_DOMAIN || '127.0.0.1';
+  import.meta.env.REACT_APP_COOKIES_DOMAIN || window.location.hostname;
 
 // 30 days expiration for both access and refresh tokens, since refresh token rotation is implemented on the backend
 const COOKIES_PARAMS = { path: '/', expires: 30 };

--- a/src/layout/AppBar.test.jsx
+++ b/src/layout/AppBar.test.jsx
@@ -122,7 +122,7 @@ test('AppBar: Sign out', async () => {
   });
   const saveCall2 = Cookies.remove.mock.calls[1];
   expect(saveCall2[1]).toStrictEqual({
-    domain: '127.0.0.1',
+    domain: 'localhost',
     path: '/',
     expires: 30,
   });


### PR DESCRIPTION
## Description
When no backend address is configured, instead of hardcoding the fallback, allows it to be dynamic based on the hostname the app was invoked from. This is useful to me because if I'm running the app server in a VM, then from a browser outside the VM the backend will be at a different address than a browser inside the VM, so there is no single hardcoded correct value. Prod is unaffected, and other dev envs would only be affected if they were navigating to the dev server from an address which doesn't resolve to the backend properly. You can always manually set the env vars back to the old fallback values if needed!