### PR TITLE
feat: no tilesets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "slate-hyperscript": "^0.100.0",
         "slate-react": "^0.124.0",
         "source-map-explorer": "^2.5.3",
-        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-08-07.0",
+        "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-08-17.0",
         "use-debounce": "^10.1.1",
         "uuid": "^14.0.0",
         "vite": "^7.3.6",
@@ -17897,18 +17897,18 @@
     },
     "node_modules/terraso-backend": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#2344d215ab31127c43392b00843a4a0192fae265"
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-backend.git#1281ebfc94c7ef1f2d07bc263bbd46dc19df823b"
     },
     "node_modules/terraso-client-shared": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#df3fc1160da116c36e04b284541c58e19e4c952f",
+      "resolved": "git+ssh://git@github.com/techmatters/terraso-client-shared.git#ce1191e1bff8e5abafa082432adb20579c3e9eaf",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.1",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^19.2.1",
         "react-redux": "^9.2.0",
-        "terraso-backend": "github:techmatters/terraso-backend#2026-07-16.0",
+        "terraso-backend": "github:techmatters/terraso-backend#2026-08-17.0",
         "uuid": "^10.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "slate-hyperscript": "^0.100.0",
     "slate-react": "^0.124.0",
     "source-map-explorer": "^2.5.3",
-    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-08-07.0",
+    "terraso-client-shared": "github:techmatters/terraso-client-shared#2026-08-17.0",
     "use-debounce": "^10.1.1",
     "uuid": "^14.0.0",
     "vite": "^7.3.6",

--- a/src/gis/components/GeoJsonSource.js
+++ b/src/gis/components/GeoJsonSource.js
@@ -15,24 +15,51 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useMap } from 'terraso-web-client/gis/components/Map';
 
 const GeoJsonSource = props => {
-  const { id, geoJson } = props;
+  const { id, geoJson, geoJsonUrl, onError } = props;
   const { map, addSource } = useMap();
+
+  const handleSourceError = useCallback(
+    event => {
+      if (onError && event.sourceId === id && event.error) {
+        onError(event.error);
+      }
+    },
+    [onError, id]
+  );
 
   useEffect(() => {
     if (!map) {
       return;
     }
 
+    const sourceData = geoJsonUrl
+      ? geoJsonUrl
+      : geoJson
+        ? geoJson
+        : { type: 'FeatureCollection', features: [] };
+
     addSource(id, {
       type: 'geojson',
-      data: geoJson ? geoJson : { type: 'FeatureCollection', features: [] },
+      data: sourceData,
     });
-  }, [id, map, addSource, geoJson]);
+  }, [id, map, addSource, geoJson, geoJsonUrl]);
+
+  // Listen for source errors
+  useEffect(() => {
+    if (!map || !onError) {
+      return;
+    }
+
+    map.on('error', handleSourceError);
+    return () => {
+      map.off('error', handleSourceError);
+    };
+  }, [map, onError, handleSourceError]);
 
   return null;
 };

--- a/src/localization/locales/en-US.json
+++ b/src/localization/locales/en-US.json
@@ -1165,6 +1165,7 @@
         "form_location_add_data_layer_dialog_cancel": "Cancel",
         "form_location_add_data_layer_dialog_processing": "Processing",
         "form_location_add_data_layer_confirm": "Next",
+        "form_location_add_data_layer_saving": "Saving…",
         "share_dialog_title": "Invite Editors",
         "share_dialog_description": "Invite people to edit your story map. <1>Learn more about collaborating on story maps</1>.",
         "share_dialog_help_url": "https://terraso.org/help/how-to-manage-editors-for-your-story-map/",

--- a/src/localization/locales/es-ES.json
+++ b/src/localization/locales/es-ES.json
@@ -1169,6 +1169,7 @@
         "form_location_add_data_layer_dialog_cancel": "Cancelar",
         "form_location_add_data_layer_dialog_processing": "Procesando",
         "form_location_add_data_layer_confirm": "Siguiente",
+        "form_location_add_data_layer_saving": "Guardando…",
         "share_dialog_title": "Invitar a editores",
         "share_dialog_description": "Invita a personas a editar tu story map. <1>Más información sobre cómo colaborar en story maps</1>.",
         "share_dialog_help_url": "https://terraso.org/help/how-to-manage-editors-for-your-story-map/",

--- a/src/sharedData/sharedDataFragments.ts
+++ b/src/sharedData/sharedDataFragments.ts
@@ -66,6 +66,7 @@ export const visualizationConfigWithConfiguration = /* GraphQL */ `
     ...visualizationConfig
     mapboxTilesetId
     mapboxTilesetStatus
+    geojsonSignedUrl
     configuration
   }
 `;

--- a/src/sharedData/visualization/components/Visualization.jsx
+++ b/src/sharedData/visualization/components/Visualization.jsx
@@ -70,7 +70,8 @@ const Visualization = props => {
   } = props;
 
   const visualizationContext = useVisualizationContext();
-  const { useTileset, isMapFile, loadingFile } = visualizationContext;
+  const { useTileset, isMapFile, loadingFile, geoJsonUrl } =
+    visualizationContext;
 
   const visualizationConfig = useMemo(
     () => ({
@@ -103,7 +104,9 @@ const Visualization = props => {
         <MapStyleSwitcher />
         {!visualizationContext.loadingFile && (
           <>
-            {useTileset ? (
+            {geoJsonUrl ? (
+              <GeoJsonSource id="visualization" geoJsonUrl={geoJsonUrl} />
+            ) : useTileset ? (
               <MapboxRemoteSource
                 sourceName="visualization"
                 visualizationConfig={visualizationConfig}

--- a/src/sharedData/visualization/components/VisualizationMapLayer.jsx
+++ b/src/sharedData/visualization/components/VisualizationMapLayer.jsx
@@ -70,11 +70,30 @@ const getSourceBounds = async (map, sourceId) => {
     return new mapboxgl.LngLatBounds(loadedSource.bounds);
   }
 
-  if (!loadedSource._data) {
+  // When _data is a string (URL-based source), fetch the GeoJSON to compute
+  // bounds. The browser cache serves this instantly since Mapbox GL already
+  // fetched it. For inline GeoJSON objects, compute bounds directly.
+  let sourceData = loadedSource._data;
+
+  if (typeof sourceData === 'string') {
+    try {
+      const response = await fetch(sourceData);
+      sourceData = await response.json();
+    } catch {
+      return;
+    }
+  }
+
+  if (!sourceData || typeof sourceData !== 'object') {
     return;
   }
 
-  const calculatedBbox = bbox(loadedSource._data);
+  let calculatedBbox;
+  try {
+    calculatedBbox = bbox(sourceData);
+  } catch {
+    return;
+  }
   if (
     calculatedBbox.some(
       value => !value || value === Infinity || value === -Infinity

--- a/src/sharedData/visualization/components/VisualizationWrapper.jsx
+++ b/src/sharedData/visualization/components/VisualizationWrapper.jsx
@@ -78,6 +78,7 @@ const VisualizationWrapper = props => {
             ...data.configuration,
             selectedFile: data.dataEntry,
             tilesetId: data.mapboxTilesetId,
+            geojsonSignedUrl: data.geojsonSignedUrl,
           },
     [data, fetching]
   );

--- a/src/sharedData/visualization/visualizationContext.jsx
+++ b/src/sharedData/visualization/visualizationContext.jsx
@@ -49,6 +49,7 @@ export const VisualizationContextProvider = props => {
   const [loadingFile, setLoadingFile] = useState(true);
   const [loadingFileError, setLoadingFileError] = useState();
   const [useTileset, setUseTileset] = useState(null);
+  const [geoJsonUrl, setGeoJsonUrl] = useState(null);
 
   const clear = useCallback(() => {
     setVisualizationConfig(INITIAL_CONFIG);
@@ -56,6 +57,7 @@ export const VisualizationContextProvider = props => {
     setLoadingFile(true);
     setLoadingFileError(null);
     setUseTileset(null);
+    setGeoJsonUrl(null);
   }, [setVisualizationConfig]);
 
   const isMapFile = useMemo(() => {
@@ -69,16 +71,30 @@ export const VisualizationContextProvider = props => {
   }, [visualizationConfig.selectedFile]);
 
   useEffect(() => {
-    if (!visualizationConfig.tilesetId) {
+    if (visualizationConfig.geojsonSignedUrl) {
+      setGeoJsonUrl(visualizationConfig.geojsonSignedUrl);
+      setUseTileset(false);
+      setLoadingFile(false);
       return;
     }
 
-    setUseTileset(true);
-    setLoadingFile(false);
-  }, [visualizationConfig.tilesetId]);
+    if (visualizationConfig.tilesetId) {
+      setGeoJsonUrl(null);
+      setUseTileset(true);
+      setLoadingFile(false);
+      return;
+    }
+
+    setGeoJsonUrl(null);
+    setUseTileset(false);
+  }, [visualizationConfig.geojsonSignedUrl, visualizationConfig.tilesetId]);
 
   useEffect(() => {
-    if (!visualizationConfig.selectedFile || visualizationConfig.tilesetId) {
+    if (
+      !visualizationConfig.selectedFile ||
+      visualizationConfig.tilesetId ||
+      visualizationConfig.geojsonSignedUrl
+    ) {
       return;
     }
     const newFileContext =
@@ -126,6 +142,7 @@ export const VisualizationContextProvider = props => {
   }, [
     visualizationConfig.selectedFile,
     visualizationConfig.tilesetId,
+    visualizationConfig.geojsonSignedUrl,
     fileContext,
     dispatch,
     isMapFile,
@@ -151,6 +168,7 @@ export const VisualizationContextProvider = props => {
         loadingFileError,
         getDataColumns,
         useTileset,
+        geoJsonUrl,
         isMapFile,
         clear,
       }}

--- a/src/storyMap/components/StoryMapForm/MapConfigurationDialog/CreateMapLayerDialog.tsx
+++ b/src/storyMap/components/StoryMapForm/MapConfigurationDialog/CreateMapLayerDialog.tsx
@@ -27,6 +27,7 @@ import { useDispatch, useSelector } from 'terraso-web-client/terrasoApi/store';
 import * as yup from 'yup';
 import {
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -225,9 +226,15 @@ const CreateMapLayerForm = () => {
     ? identifyLatLngColumns(headers)
     : {};
 
-  const { fetching, list: mapLayers } = useSelector(
-    state => state.storyMap.dataLayers
-  ) as { fetching: boolean; list: MapLayerConfig[] };
+  const {
+    fetching,
+    saving,
+    list: mapLayers,
+  } = useSelector(state => state.storyMap.dataLayers) as {
+    fetching: boolean;
+    saving: boolean;
+    list: MapLayerConfig[];
+  };
 
   const initialTitle = (() => {
     const fileName = selectedFile?.name;
@@ -303,6 +310,11 @@ const CreateMapLayerDialog = ({
   const { visualizationConfig, loadingFile, loadingFileError } =
     useVisualizationContext();
   const { selectedFile: dataEntry } = visualizationConfig;
+  const saving = useSelector(
+    state =>
+      (state.storyMap as { dataLayers?: { saving?: boolean } })?.dataLayers
+        ?.saving ?? false
+  );
 
   const formContext = useFormGetContext();
   const trigger = 'trigger' in formContext ? formContext.trigger : undefined;
@@ -382,12 +394,17 @@ const CreateMapLayerDialog = ({
       <DialogContent>{open && <CreateMapLayerForm />}</DialogContent>
       <DialogActions>
         <Button
-          disabled={!trigger}
+          disabled={!trigger || saving}
           size="small"
           onClick={onConfirm}
           variant="contained"
+          startIcon={
+            saving ? <CircularProgress size={16} color="inherit" /> : undefined
+          }
         >
-          {t('storyMap.form_location_add_data_layer_confirm')}
+          {saving
+            ? t('storyMap.form_location_add_data_layer_saving')
+            : t('storyMap.form_location_add_data_layer_confirm')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/storyMap/components/StoryMapLayer.tsx
+++ b/src/storyMap/components/StoryMapLayer.tsx
@@ -25,24 +25,46 @@ type Props = {
   changeBounds: boolean;
   useConfigBounds?: boolean;
   opacity?: number;
+  onSourceError?: (error: unknown) => void;
 };
+
+const getSourceType = (config: MapLayerConfig): 's3' | 'tileset' | 'inline' => {
+  if (config.geojsonSignedUrl) {
+    return 's3';
+  }
+  if (
+    config.mapboxTilesetStatus === 'READY' &&
+    Boolean(config.mapboxTilesetId)
+  ) {
+    return 'tileset';
+  }
+  return 'inline';
+};
+
 export const StoryMapLayer = ({
   config,
   changeBounds,
   opacity,
   useConfigBounds = false,
+  onSourceError,
 }: Props) => {
-  const useTileset =
-    config.mapboxTilesetStatus === 'READY' && Boolean(config.mapboxTilesetId);
+  const sourceType = getSourceType(config);
+  const useTileset = sourceType === 'tileset';
+
   return (
     <>
-      {useTileset ? (
+      {sourceType === 'tileset' ? (
         <VisualizationMapRemoteSource
           sourceName={config.id}
           visualizationConfig={config}
         />
       ) : (
-        <GeoJsonSource id={config.id} geoJson={config.geojson} />
+        <GeoJsonSource
+          id={config.id}
+          geoJsonUrl={sourceType === 's3' ? config.geojsonSignedUrl : undefined}
+          geoJson={sourceType === 'inline' ? config.geojson : undefined}
+          onError={onSourceError}
+        />
       )}
       <VisualizationMapLayer
         sourceName={config.id}

--- a/src/storyMap/storyMapService.js
+++ b/src/storyMap/storyMapService.js
@@ -371,11 +371,17 @@ export const addMapLayer = ({
       },
     })
     .then(_.get('addVisualizationConfig.visualizationConfig'))
-    .then(({ geojson, configuration, ...rest }) => ({
-      ...rest,
-      ...JSON.parse(configuration),
-      geojson: JSON.parse(geojson),
-    }));
+    .then(({ geojson, configuration, ...rest }) => {
+      const result = {
+        ...rest,
+        ...JSON.parse(configuration),
+      };
+      // Only include inline geojson for VCs without S3 URL (legacy path)
+      if (!rest.geojsonSignedUrl) {
+        result.geojson = JSON.parse(geojson);
+      }
+      return result;
+    });
 };
 
 export const fetchDataLayers = ({ ownerId }) => {
@@ -424,6 +430,7 @@ export const fetchDataLayers = ({ ownerId }) => {
       list.map(entry => ({
         ..._.omit(['configuration', 'geojson'], entry.node),
         tilesetId: entry.node.mapboxTilesetId,
+        geojsonSignedUrl: entry.node.geojsonSignedUrl,
         dataEntry: {
           ...entry.node.dataEntry,
           sharedResources: entry.node.dataEntry.sharedResources?.edges.map(
@@ -435,9 +442,7 @@ export const fetchDataLayers = ({ ownerId }) => {
             edge.node?.target?.membershipList?.membershipType ===
             MEMBERSHIP_TYPE_CLOSED
         ),
-        processing:
-          entry.node.mapboxTilesetStatus === TILESET_STATUS_PENDING ||
-          !entry.node.mapboxTilesetId,
+        processing: !entry.node.geojsonSignedUrl && !entry.node.mapboxTilesetId,
         ...JSON.parse(entry.node.configuration),
         geojson: JSON.parse(entry.node.geojson),
       }))

--- a/src/storyMap/storyMapSlice.js
+++ b/src/storyMap/storyMapSlice.js
@@ -49,6 +49,7 @@ const initialState = {
   },
   dataLayers: {
     fetching: true,
+    saving: false,
     list: [],
   },
 };
@@ -404,6 +405,27 @@ const storyMapSlice = createSlice({
       },
     }));
 
+    builder.addCase(addMapLayer.pending, state => ({
+      ...state,
+      dataLayers: {
+        ...state.dataLayers,
+        saving: true,
+      },
+    }));
+    builder.addCase(addMapLayer.fulfilled, state => ({
+      ...state,
+      dataLayers: {
+        ...state.dataLayers,
+        saving: false,
+      },
+    }));
+    builder.addCase(addMapLayer.rejected, state => ({
+      ...state,
+      dataLayers: {
+        ...state.dataLayers,
+        saving: false,
+      },
+    }));
     builder.addCase(fetchDataLayers.pending, state => ({
       ...state,
       dataLayers: initialState.dataLayers,


### PR DESCRIPTION
## Description
See the backend PR for more context: https://github.com/techmatters/terraso-backend/pull/2069.

This updates the frontend to accept the new geojsonSignedUrl field, and prefer it as the data source for map layers. Also adds a loading spinner to the map layer creation process since that's a synchronous file upload now (takes up to a couple seconds, rather than the tileset creation (several minutes) or inline geojson solutions (instant)).

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Related to #3010 

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
