### PR TITLE
fix: prevent Slate empty node reuse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "notistack": "^3.0.2",
         "path-browserify": "^1.0.1",
         "query-string": "^9.3.1",
-        "react": "^19.2.5",
+        "react": "19.2.5",
         "react-avatar-editor": "^15.1.0",
         "react-dom": "19.2.5",
         "react-dropzone": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "notistack": "^3.0.2",
     "path-browserify": "^1.0.1",
     "query-string": "^9.3.1",
-    "react": "^19.2.5",
+    "react": "19.2.5",
     "react-avatar-editor": "^15.1.0",
     "react-dom": "19.2.5",
     "react-dropzone": "^15.0.0",

--- a/src/common/components/RichTextEditor/index.jsx
+++ b/src/common/components/RichTextEditor/index.jsx
@@ -86,7 +86,7 @@ const BLOCK_OPTIONS = [
 ];
 const LIST_TYPES = ['bulleted-list', 'numbered-list'];
 
-const EMPTY_VALUE = [
+const createEmptyValue = () => [
   {
     type: 'paragraph',
     children: [{ text: '' }],
@@ -95,7 +95,7 @@ const EMPTY_VALUE = [
 
 const normalizeValue = value => {
   if (!value) {
-    return EMPTY_VALUE;
+    return createEmptyValue();
   }
 
   if (typeof value === 'string') {

--- a/src/common/components/RichTextEditor/index.test.jsx
+++ b/src/common/components/RichTextEditor/index.test.jsx
@@ -386,6 +386,24 @@ test('RichTextEditor: rerendered value replaces the live editor contents', async
   expect(screen.getByText('Updated value')).toBeInTheDocument();
 });
 
+test('RichTextEditor: renders independent documents for empty editors', async () => {
+  Editor.nodes.mockImplementation(actualSlateEditor.nodes);
+
+  await render(
+    <>
+      <RichTextEditor label="First empty editor" />
+      <RichTextEditor label="Second empty editor" />
+    </>
+  );
+
+  expect(
+    screen.getByRole('textbox', { name: 'First empty editor' })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('textbox', { name: 'Second empty editor' })
+  ).toBeInTheDocument();
+});
+
 test('RichTextEditor: rerendered value waits until blur when editor is focused', async () => {
   Editor.nodes.mockImplementation(actualSlateEditor.nodes);
 


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
React and Slate dependencies fixes

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

