### PR TITLE
fix: wrap rich text toolbar controls

### DIFF
--- a/src/common/components/RichTextEditor/Toolbar.jsx
+++ b/src/common/components/RichTextEditor/Toolbar.jsx
@@ -47,6 +47,7 @@ const Toolbar = props => {
           disableElevation
           variant="text"
           sx={{
+            // Let individual controls wrap while retaining logical toolbar groups.
             display: 'contents',
             '& .MuiButton-root': {
               color: 'black',

--- a/src/common/components/RichTextEditor/Toolbar.jsx
+++ b/src/common/components/RichTextEditor/Toolbar.jsx
@@ -37,6 +37,7 @@ const Toolbar = props => {
       direction="row"
       sx={{
         bgcolor: 'gray.lite2',
+        flexWrap: 'wrap',
       }}
     >
       {groups.map((group, index) => (
@@ -46,6 +47,7 @@ const Toolbar = props => {
           disableElevation
           variant="text"
           sx={{
+            display: 'contents',
             '& .MuiButton-root': {
               color: 'black',
             },

--- a/src/common/components/RichTextEditor/Toolbar.jsx
+++ b/src/common/components/RichTextEditor/Toolbar.jsx
@@ -50,6 +50,12 @@ const Toolbar = props => {
             display: 'contents',
             '& .MuiButton-root': {
               color: 'black',
+              minHeight: 32,
+              minWidth: 32,
+              px: 0,
+            },
+            '& .MuiButton-root > svg': {
+              fontSize: '1.125rem',
             },
             '& .MuiButton-root.Mui-disabled': {
               color: 'gray.mid',

--- a/src/common/components/RichTextEditor/index.test.jsx
+++ b/src/common/components/RichTextEditor/index.test.jsx
@@ -317,6 +317,11 @@ test('RichTextEditor: shows new highlight, list, and style controls', async () =
     'Numbered list',
     'Bulleted list',
   ]);
+
+  expect(toolbar).toHaveStyle({ flexWrap: 'wrap' });
+  toolbar
+    .querySelectorAll('.MuiButtonGroup-root')
+    .forEach(group => expect(group).toHaveStyle({ display: 'contents' }));
 });
 
 test('RichTextEditor: style select does not trigger blur when opened', async () => {


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Wrap the toolbar items on smaller screens
- Made the icon buttons smaller

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added


### Related Issues
- https://github.com/techmatters/terraso-web-client/issues/3016

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
<img width="483" height="383" alt="image" src="https://github.com/user-attachments/assets/bad81db7-58c3-4701-b62f-50657654f4df" />
