### PR TITLE
feat: story maps loading performance

### DIFF
--- a/src/sharedData/visualization/components/VisualizationMapLayer.jsx
+++ b/src/sharedData/visualization/components/VisualizationMapLayer.jsx
@@ -70,9 +70,6 @@ const getSourceBounds = async (map, sourceId) => {
     return new mapboxgl.LngLatBounds(loadedSource.bounds);
   }
 
-  // When _data is a string (URL-based source), fetch the GeoJSON to compute
-  // bounds. The browser cache serves this instantly since Mapbox GL already
-  // fetched it. For inline GeoJSON objects, compute bounds directly.
   let sourceData = loadedSource._data;
 
   if (typeof sourceData === 'string') {
@@ -253,10 +250,13 @@ const MapboxLayer = props => {
   ]);
 
   useEffect(() => {
-    if (!map) {
+    if (!map || !changeBounds) {
       return;
     }
-    const visualizationConfigBounds = (async function () {
+
+    let cancelled = false;
+
+    const getConfigBounds = () => {
       const viewportBounds = visualizationConfig?.viewportConfig?.bounds;
       if (!viewportBounds) {
         return;
@@ -269,27 +269,36 @@ const MapboxLayer = props => {
       const sw = new mapboxgl.LngLat(southWest.lng, southWest.lat);
       const ne = new mapboxgl.LngLat(northEast.lng, northEast.lat);
       return new mapboxgl.LngLatBounds(sw, ne);
-    })();
+    };
 
-    const sourceBounds = getSourceBounds(map, sourceName);
-
-    Promise.all([visualizationConfigBounds, sourceBounds]).then(
-      ([visualizationConfigBounds, sourceBounds]) => {
-        if (!changeBounds) {
-          return;
-        }
-        const bounds =
-          useConfigBounds && visualizationConfigBounds
-            ? visualizationConfigBounds
-            : sourceBounds;
-
-        if (bounds && !bounds.isEmpty()) {
-          map.fitBounds(bounds, {
-            animate: false,
-          });
-        }
+    const applyBounds = bounds => {
+      if (!cancelled && bounds && !bounds.isEmpty()) {
+        map.fitBounds(bounds, {
+          animate: false,
+        });
       }
-    );
+    };
+
+    if (useConfigBounds) {
+      const configBounds = getConfigBounds();
+      if (configBounds) {
+        applyBounds(configBounds);
+        return;
+      }
+    }
+
+    // Bounds must come from the source. This fetch only runs when its result
+    // will actually be consumed, because it will re-parse the GeoJSON, and may
+    // even re-download it depending on browser.
+    getSourceBounds(map, sourceName)
+      .then(applyBounds)
+      .catch(() => {
+        // If fitBounds throws (e.g. on invalid bounds), just ignore it.
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     map,
     visualizationConfig?.viewportConfig?.bounds,

--- a/src/sharedData/visualization/components/VisualizationMapLayer.test.jsx
+++ b/src/sharedData/visualization/components/VisualizationMapLayer.test.jsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2026 Technology Matters
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
+
+import { render } from 'terraso-web-client/tests/utils';
+import { useEffect } from 'react';
+import { act } from '@testing-library/react';
+
+import { MapProvider, useMap } from 'terraso-web-client/gis/components/Map';
+import mapboxgl from 'terraso-web-client/gis/mapbox';
+import VisualizationMapLayer from 'terraso-web-client/sharedData/visualization/components/VisualizationMapLayer';
+
+jest.mock(
+  'terraso-web-client/sharedData/visualization/visualizationMarkers',
+  () => ({
+    getLayerImage: jest.fn(),
+  })
+);
+
+const SOURCE_URL = 'https://data.example.org/points.geojson';
+
+const GEOJSON = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [10, 20] },
+      properties: {},
+    },
+  ],
+};
+
+const CONFIG_BOUNDS = {
+  southWest: { lng: 1, lat: 2 },
+  northEast: { lng: 3, lat: 4 },
+};
+
+let mapMock;
+let sourceMock;
+let fetchMock;
+let loaded;
+
+const createSource = ({ data, bounds } = {}) => ({
+  loaded: () => loaded,
+  _data: data,
+  bounds,
+});
+
+const createMapMock = () => ({
+  on: jest.fn(),
+  off: jest.fn(),
+  getSource: jest.fn(() => sourceMock),
+  fitBounds: jest.fn(),
+  getStyle: jest.fn(() => ({})),
+  getLayer: jest.fn(() => undefined),
+  hasImage: jest.fn(() => false),
+  addImage: jest.fn(),
+  addLayer: jest.fn(),
+  removeLayer: jest.fn(),
+  removeSource: jest.fn(),
+  getCanvas: jest.fn(() => ({ style: {} })),
+});
+
+const MapHarness = ({ map }) => {
+  const { setMap } = useMap();
+  useEffect(() => {
+    setMap(map);
+  }, [map, setMap]);
+  return null;
+};
+
+const renderLayer = async props => {
+  const view = await render(
+    <MapProvider>
+      <MapHarness map={mapMock} />
+      <VisualizationMapLayer sourceName="visualization" {...props} />
+    </MapProvider>
+  );
+  await act(async () => {});
+  return view;
+};
+
+beforeEach(() => {
+  loaded = true;
+  sourceMock = undefined;
+  mapMock = createMapMock();
+  fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+    json: jest.fn().mockResolvedValue(GEOJSON),
+  });
+  mapboxgl.LngLat = jest.fn((lng, lat) => ({ lng, lat }));
+  mapboxgl.LngLatBounds = jest.fn((...args) => ({
+    args,
+    isEmpty: () => false,
+  }));
+  mapboxgl.Popup = jest.fn(() => ({
+    setDOMContent: jest.fn(),
+    setLngLat: jest.fn(),
+    addTo: jest.fn(),
+    isOpen: jest.fn(() => false),
+  }));
+});
+
+test('does not fetch or fit bounds when changeBounds is false (URL source)', async () => {
+  sourceMock = createSource({ data: SOURCE_URL });
+
+  await renderLayer({ changeBounds: false });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mapMock.fitBounds).not.toHaveBeenCalled();
+});
+
+test('uses config bounds and skips the source fetch when useConfigBounds is set', async () => {
+  sourceMock = createSource({ data: SOURCE_URL });
+
+  await renderLayer({
+    changeBounds: true,
+    useConfigBounds: true,
+    visualizationConfig: { viewportConfig: { bounds: CONFIG_BOUNDS } },
+  });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mapMock.fitBounds).toHaveBeenCalledTimes(1);
+  expect(mapMock.fitBounds).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: [
+        { lng: 1, lat: 2 },
+        { lng: 3, lat: 4 },
+      ],
+    }),
+    { animate: false }
+  );
+});
+
+test('fetches the URL source once and fits the computed bounds when bounds are needed', async () => {
+  sourceMock = createSource({ data: SOURCE_URL });
+
+  await renderLayer({ changeBounds: true });
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(fetchMock).toHaveBeenCalledWith(SOURCE_URL);
+  expect(mapMock.fitBounds).toHaveBeenCalledTimes(1);
+  expect(mapMock.fitBounds).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: [
+        [10, 20],
+        [10, 20],
+      ],
+    }),
+    { animate: false }
+  );
+});
+
+test('does not fetch when the source already exposes bounds', async () => {
+  const sourceBounds = [
+    [0, 0],
+    [5, 5],
+  ];
+  sourceMock = createSource({ data: SOURCE_URL, bounds: sourceBounds });
+
+  await renderLayer({ changeBounds: true });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mapMock.fitBounds).toHaveBeenCalledTimes(1);
+  expect(mapMock.fitBounds).toHaveBeenCalledWith(
+    expect.objectContaining({ args: [sourceBounds] }),
+    { animate: false }
+  );
+});
+
+test('computes bounds from inline geojson without fetching', async () => {
+  sourceMock = createSource({ data: GEOJSON });
+
+  await renderLayer({ changeBounds: true });
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mapMock.fitBounds).toHaveBeenCalledTimes(1);
+  expect(mapMock.fitBounds).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: [
+        [10, 20],
+        [10, 20],
+      ],
+    }),
+    { animate: false }
+  );
+});
+
+test('does not fit bounds from a stale effect run after unmount', async () => {
+  sourceMock = createSource({ data: SOURCE_URL });
+  let resolveFetch;
+  fetchMock.mockReturnValueOnce(
+    new Promise(resolve => {
+      resolveFetch = resolve;
+    })
+  );
+
+  const { unmount } = await renderLayer({ changeBounds: true });
+
+  await act(async () => {
+    unmount();
+    resolveFetch({ json: jest.fn().mockResolvedValue(GEOJSON) });
+  });
+  await act(async () => {});
+
+  expect(mapMock.fitBounds).not.toHaveBeenCalled();
+});
+
+test('does not leave an unhandled rejection when fitBounds throws', async () => {
+  sourceMock = createSource({ data: SOURCE_URL });
+  mapMock.fitBounds.mockImplementation(() => {
+    throw new Error('fitBounds exploded');
+  });
+
+  const onUnhandledRejection = jest.fn();
+  process.on('unhandledRejection', onUnhandledRejection);
+  try {
+    await renderLayer({ changeBounds: true });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    expect(onUnhandledRejection).not.toHaveBeenCalled();
+  } finally {
+    process.removeListener('unhandledRejection', onUnhandledRejection);
+  }
+});

--- a/src/storyMap/components/StoryMap.jsx
+++ b/src/storyMap/components/StoryMap.jsx
@@ -47,7 +47,7 @@ mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
 const Audio = ({ record }) => {
   return (
     <>
-      <audio style={{ width: '100%' }} controls>
+      <audio style={{ width: '100%' }} controls loading="lazy">
         <source src={record.media.signedUrl} type={record.media.type} />
       </audio>
     </>
@@ -57,7 +57,7 @@ const Audio = ({ record }) => {
 const Video = ({ record }) => {
   return (
     <>
-      <video style={{ width: '100%' }} controls>
+      <video style={{ width: '100%' }} controls loading="lazy">
         <source src={record.media.signedUrl} type={record.media.type} />
       </video>
     </>
@@ -71,6 +71,7 @@ const Image = ({ record }) => {
       src={record.media.signedUrl || record.media.url}
       alt={t('storyMap.view_chapter_media_label')}
       width="100%"
+      loading="lazy"
     ></img>
   );
 };
@@ -82,6 +83,7 @@ const Embedded = ({ record }) => {
       title={record.media.title}
       src={record.media.url}
       style={{ height: '300px', width: '100%' }}
+      loading="lazy"
     />
   );
 };


### PR DESCRIPTION
## Description
Two changes:
- loading="lazy" on story map media, so we don't download all of it right away
- updates `VisualizationMapLayer` so that it only downloads GeoJSON for a bounds check if it actually needs it. depending on browser, this can save both CPU and download time.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Related Issues
Related to https://github.com/techmatters/terraso-web-client/issues/3068

### Verification steps
Should see lower data transferred in the browser console on initial load (and overall if your browser was double-downloading).